### PR TITLE
apps/monitoring/prometheus-operator: upgrade to v0.41

### DIFF
--- a/apps/monitoring/prometheus-operator/04_deployment.yaml
+++ b/apps/monitoring/prometheus-operator/04_deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.40.0
+    app.kubernetes.io/version: v0.41.0
   name: prometheus-operator
   namespace: monitoring
 spec:
@@ -18,16 +18,16 @@ spec:
       labels:
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: prometheus-operator
-        app.kubernetes.io/version: v0.40.0
+        app.kubernetes.io/version: v0.41.0
     spec:
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
         - --logtostderr=true
         - --config-reloader-image=jimmidyson/configmap-reload:v0.3.0
-        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.40.0
+        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.41.0
         - --log-level=debug
-        image: quay.io/coreos/prometheus-operator:v0.40.0
+        image: quay.io/coreos/prometheus-operator:v0.41.0
         name: prometheus-operator
         ports:
         - containerPort: 8080


### PR DESCRIPTION
Upgrade as soon as https://github.com/coreos/prometheus-operator/pull/3376 is ready.

Note: retrigger CI pipeline to check images availability.