### PR TITLE
apps/monitoring/manifests/alertmanager: remove ConfigMapSecret

### DIFF
--- a/apps/monitoring/README.md
+++ b/apps/monitoring/README.md
@@ -13,8 +13,8 @@ Customized kube-prometheus stack for @paulfantom personal homelab. This is also 
 ### Long version
 
 `kube-prometheus` is used as a library and installed with `jb`. Next customization stored in `jsonnet/main.jsonnet` is
-applied. After this `jsonnet` is used to generate `manifests/` directory and ConfigMapSecrets are copied into `manifests/`
-from `configmapsecrets/` directory.
+applied. After this `jsonnet` is used to generate `manifests/` directory and raw manifests are copied into `manifests/`
+from `raw/` directory
 
 ## Dependencies
 

--- a/apps/monitoring/manifests/alertmanager/secret.yaml
+++ b/apps/monitoring/manifests/alertmanager/secret.yaml
@@ -1,23 +1,30 @@
-apiVersion: secrets.mz.com/v1alpha1
-kind: ConfigMapSecret
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
 metadata:
-  name: alertmanager-main
+  creationTimestamp: null
+  name: alertmanager-main-new
   namespace: monitoring
-  labels:
-    app: alertmanager
 spec:
+  encryptedData:
+    healthchecks_url: AgCArikwd75zXwwwzmZ/kT2P2yehOBfnuDx7EMFznquBaVzXT/+c40DSvn81Jo3Q2Xtu2pEkpZSILWr+ekvQZngdYJCrGobWAS3m7xc19CkmfPYj256yirv7MJteDY/ONUAbt6WV9RAVtMztm5Z4RP8jeqtU9Hvfv2ZAapt/slQvNpyip/rpgDMcE+9EC1bZerHFMUZ6ADASCL4Xg4BW8vbjwS7GqqWGZMqg4v5EerGn4N5vYViZBl0Ho5ubotczgNK/sOzrUMNpT5FDlIm+KenbOOiIUecBgWJZ+4vbnV0deoskskbyypE/G2zvXHvmOw6cjvzH8LR5D4kJZHyBY3tRgx1resG3DN0SHFpfeQiBprRH8E0H9KAgP5nu3bksUhJO9iwvH1bP9/GJ9kFv0E9K6m714xIgTZhjfvI5TTN0rZPNsYZcDkU0qiV8XzzMr1VB4WtIAZ8G/XP7pwWihNGk5HLgwNGZ+fXh/45DEXEi5QrYUajMXaD8vuvf8F7yuARd68EigpXBLZsCF6BtS9cclx70LSA/eKlPXJ8Rd1eWjtMo1deoDr/8oTnM+etXkeUlVdgPvo4gqxKzRjRis3ZmZOt8eJvGmHY7i44lMh7BzHC7L7QcrJpUMgZXSSGaugxaqnWkt1bBEUb3deRKiWcqTmIAf7KrryUfSCAkg+yuujQrhbRyoutgLb55zgdP/8sopw==
+    opsgenie_api_key: AgCArikwd75zXwwwzmZ/kT2P2yehOBfnuDx7EMFznquBaVzXT/+c40DSvn81Jo3Q2Xtu2pEkpZSILWr+ekvQZngdYJCrGobWAS3m7xc19CkmfPYj256yirv7MJteDY/ONUAbt6WV9RAVtMztm5Z4RP8jeqtU9Hvfv2ZAapt/slQvNpyip/rpgDMcE+9EC1bZerHFMUZ6ADASCL4Xg4BW8vbjwS7GqqWGZMqg4v5EerGn4N5vYViZBl0Ho5ubotczgNK/sOzrUMNpT5FDlIm+KenbOOiIUecBgWJZ+4vbnV0deoskskbyypE/G2zvXHvmOw6cjvzH8LR5D4kJZHyBY3tRgx1resG3DN0SHFpfeQiBprRH8E0H9KAgP5nu3bksUhJO9iwvH1bP9/GJ9kFv0E9K6m714xIgTZhjfvI5TTN0rZPNsYZcDkU0qiV8XzzMr1VB4WtIAZ8G/XP7pwWihNGk5HLgwNGZ+fXh/45DEXEi5QrYUajMXaD8vuvf8F7yuARd68EigpXBLZsCF6BtS9cclx70LSA/eKlPXJ8Rd1eWjtMo1deoDr/8oTnM+etXkeUlVdgPvo4gqxKzRjRis3ZmZOt8eJvGmHY7i44lMh7BzHC7L7QcrJpUMgZXSSGaugxaqnWkt1bBEUb3deRKiWcqTmIAf7KrryUfSCAkg+yuujQrhbRyoutgLb55zgdP/8sopw==
+    slack_api_url: AgCArikwd75zXwwwzmZ/kT2P2yehOBfnuDx7EMFznquBaVzXT/+c40DSvn81Jo3Q2Xtu2pEkpZSILWr+ekvQZngdYJCrGobWAS3m7xc19CkmfPYj256yirv7MJteDY/ONUAbt6WV9RAVtMztm5Z4RP8jeqtU9Hvfv2ZAapt/slQvNpyip/rpgDMcE+9EC1bZerHFMUZ6ADASCL4Xg4BW8vbjwS7GqqWGZMqg4v5EerGn4N5vYViZBl0Ho5ubotczgNK/sOzrUMNpT5FDlIm+KenbOOiIUecBgWJZ+4vbnV0deoskskbyypE/G2zvXHvmOw6cjvzH8LR5D4kJZHyBY3tRgx1resG3DN0SHFpfeQiBprRH8E0H9KAgP5nu3bksUhJO9iwvH1bP9/GJ9kFv0E9K6m714xIgTZhjfvI5TTN0rZPNsYZcDkU0qiV8XzzMr1VB4WtIAZ8G/XP7pwWihNGk5HLgwNGZ+fXh/45DEXEi5QrYUajMXaD8vuvf8F7yuARd68EigpXBLZsCF6BtS9cclx70LSA/eKlPXJ8Rd1eWjtMo1deoDr/8oTnM+etXkeUlVdgPvo4gqxKzRjRis3ZmZOt8eJvGmHY7i44lMh7BzHC7L7QcrJpUMgZXSSGaugxaqnWkt1bBEUb3deRKiWcqTmIAf7KrryUfSCAkg+yuujQrhbRyoutgLb55zgdP/8sopw==
   template:
     metadata:
-      name: alertmanager-main
-      labels:
-        app: alertmanager
+      annotations:
+        sealedsecrets.bitnami.com/managed: "true"
+      creationTimestamp: null
+      name: alertmanager-main-new
+      namespace: monitoring
+    type: Opaque
     data:
       alertmanager.yaml: |
         global:
           resolve_timeout: 5m
-          slack_api_url: $(SLACK_API_URL)
+          slack_api_url: "{{ index . "slack_api_url" }}"
           opsgenie_api_url: 'https://api.eu.opsgenie.com'
-          opsgenie_api_key: $(OPSGENIE_API_KEY)
+          opsgenie_api_key: "{{ index . "opsgenie_api_key" }}"
         receivers:
 
         - name: 'slack'
@@ -93,7 +100,7 @@ spec:
         - name: 'healthchecks.io'
           webhook_configs:
             - send_resolved: false
-              url: $(HEALTHCHECKS_URL)
+              url: "{{ index . "healthchecks_url" }}"
         route:
           group_by: ['alertname', 'instance', 'job']
           #group_by: ['instance', 'job']
@@ -145,36 +152,3 @@ spec:
               alertname: 'KubeNodeUnreachable'
             target_match:
               alertname: "KubeNodeNotReady"
-  vars:
-    - name: OPSGENIE_API_KEY
-      secretValue:
-        name: alertmanager-keys
-        key: opsgenie_api_key
-    - name: SLACK_API_URL
-      secretValue:
-        name: alertmanager-keys
-        key: slack_api_url
-    - name: HEALTHCHECKS_URL
-      secretValue:
-        name: alertmanager-keys
-        key: healthchecks_url
----
-apiVersion: bitnami.com/v1alpha1
-kind: SealedSecret
-metadata:
-  creationTimestamp: null
-  name: alertmanager-keys
-  namespace: monitoring
-spec:
-  encryptedData:
-    healthchecks_url: AgBm6muAr5Upz3bGEu3ykXy2IRWM8sh0n22vy91T9HX1mBpG0NsREaXejjlWmovwariUf8LtCsKU3fPozPpOKudUFoqDWJxGlHhlrJlUZZY+oLR+oX56aJOYlWnCw6aIgH9zZv8NoZzDrsJb7MssSb/JKgVmh37gyYNGceKCV3YeozQeLvP2ANyPPqSJJICL9kk+aMy5os0wSQdWFvYY0t7zXc9WDO1SlQatA6J6zUfV5kl/5Wfkk39PSj72sQlkqwPPY/xwcH3OVfuEbHH0ajkQAk72KvkhNhSsdD8p9BHlR8/aJdgBVK6jR8tLNZqsYHhsD0+X7FL1Lxq90z78e+g6/CGtfFrb59qMExJ/ZcA9f1JHooQNjvsxN3xUyIj4Tzk2nEchEmdehzdcKSmwNvLgUgboTk7n7rbulzcuTDU0BYJkjbpe8W/V+92zaJF7+iwmDxpwO61tRkO0N4ONVEN5jlnuRS2SVOTN0zvtiIn3ImQH4Oy9mX9t6xo9XdmIYsta6rMIIA0PJr1ws2Tj/kCg/ClNdHYU6EN46O0v+jsQDNkaRVrgie1wyqOKYsO1+0jg7QQxGm7lU0dK0dkQ3tuFcW9zE6wpcoaRFFAWQxgTzJ8hByWn/t2ElvWNCGw1D/lKf75hG1QLXZ5oziEnksT3IV/kzgJ0SsWfnzkxL8emQ/vLBpf4jooUa2FT8rjZltVi4eb3DY/Nj0cDkfrDVFgEYho34VFhqCaQktDIGbrJuHTqau/zXHsdL+wHn/8Nuyi2Mkk/THeCJQ==
-    opsgenie_api_key: AgCS2LpCTZpWfVM4S/4cJflYVwSHZSBSkQSqjIQhZMIuEp9flvkKmx9rmDRz2pdG/ph598M4SBtAM24H8vDGF3ffZuspUIx0NRMIrsp0mBi4mfizW4A5mavz9GicgrEjkQaR90qzGhMXWKhdlZ/lO8F720uoTohx+Ox5MfEKlJKVlZqxcPUzHN+S2ZEqLKYXXt5U91uI7jjkIHxOhg0EgAHUGH3nl9c37W7ipkfAVFC9M8PSBuR27YSQ1z98sq8/O9IPNNbMSWrQtj7kANzbU8K2lVhzxxWKU+u9P+XwJzWGkB5t2seQFxz55afpMoY+rRjpNYFANIGZWjMxVfmgZWJcq1YqnCnmGJLI3BKk1jkqC7FynVQH6MCnxMchUReL0u7W98V7UBUnHEFxTSyhy6peSlW7sX/7Ckh1Z01bKfWwHJrugmNBiWGIWr12s2ay7ER/jN18vy3gQauhCeas07Psld1aQe+pQMxMenUbSD8Tu6xb0jVXrih/U8+rEyXjkQPgcJsxfYl6SJo7pn38J/N8DyQY8qS/nla81ZKD/5CqZyoXqYIMgnvfHw05zuXlch3KawFl0BLVwCAru9JxBoDB5RnPoGc2qpjVRiU+LhFaCC5OjwMzeNVN6fPkC0tKin0Dfn40lg+PizWoLARgsThsjAs5/A2f5fp65xe0Zr8COh/VEKDWSsxmQ53es1lknOvYKg12nKWJpc9bl8UgosykYDxSg8eXnO4txNrqlBrRNqM8+QY=
-    slack_api_url: AgAaaOZ8BhPOqKeQFQ8bX6Wqr1c+vGTf8R0Bl8KuA60MHHBvSBA5HPqiedXWaRIU7WxYztkHvMsrtZDJVZgdhGbpeuIZsxhGGw2AAz/oJcvsnZvIq47YewQgvuRD6rze9Dxf5VvVP9zydXLwMgXjGEFW97X0UWsmSHyFc3eORuo3ZE01yJSLezpJ0i1COMbz/lo6AyKJwrqkOGH9s9Pk6oh5s6Cc3amPCupEKU7tP8duWTUZp7SnIk58R0dqa6d5pF5HYUIhODEl1HZA7EltUicYQKnG82LT6CkmpRmpXK8PtmUhvAjq1SuqNgsN2z61jR06611G7rah6LN6t1NvCnrQu1yPuyNNd4fjWq+9uTI0CXyHl8jCnx8mk6kO2swJnwjw4gZy9kOWwFpDfkR+rpPISpmamTAY4WbO9YrTMVN0qosNOuAQ9U2nhOhN8lgUFx/Yw2i4kfFYvACHTTK2XjJGfTRlrDy34MVYjTTWQ3ZwsXa7afVU3gzxvEqIgkzOVdwyBwMk2Wns7khWVQcxvK9TkAKsTOmPhnX12niLjnftWfGWzBq3D0Ruv4Yr+kboHDRtJg9GmoxeKCOplBVs69s5d6sqxAyRwVTIGwCp29syJCFZ+NAhMQyUbT2bCjGoKNCn8/wDF/CaXHYfKnU3fDYwiC6sxXlrUrFloXu7FgXc2c3zPaHXE6Yq/JAj7OfSblGEL0SbREDyzuoUAV2xLJfhi8Xjs8Inm10g9BgHzNo1QZKMIagYh+GUfxOgfUhQt1VOXjcVyOcBi8GoHMHRfFonDlgkaNw3LRc7q48u7A==
-  template:
-    metadata:
-      annotations:
-        sealedsecrets.bitnami.com/managed: "true"
-      creationTimestamp: null
-      name: alertmanager-keys
-      namespace: monitoring
-    type: Opaque


### PR DESCRIPTION
This won't work now as SealedSecrets templating engine uses the same templating as alertmanager. 

More in https://github.com/bitnami-labs/sealed-secrets/issues/584