### PR TITLE
apps/monitoring: use better description in alert template

### DIFF
--- a/apps/monitoring/manifests/alertmanager/secret.yaml
+++ b/apps/monitoring/manifests/alertmanager/secret.yaml
@@ -76,8 +76,14 @@ spec:
                 alertname%3D%22{{ reReplaceAll " +" "%20" .CommonLabels.alertname }}%22%7D
         - name: 'opsgenie'
           opsgenie_configs:
-            - message: "{{ .GroupLabels.alertname }}"
-              description: "{{ .CommonAnnotations.summary }}"
+            - message: "{{ .GroupLabels.alertname }} - {{ .CommonAnnotations.summary }}"
+              description: |
+                {{ if gt (len .Alerts.Firing) 0 -}}
+                {{ template "__text_alert_list" .Alerts.Firing }}
+                {{- end }}
+                {{ if gt (len .Alerts.Resolved) 0 -}}
+                {{ template "__text_alert_list" .Alerts.Resolved }}
+                {{- end }}
               details:
                 runbookUrl: "{{ .CommonAnnotations.runbook_url }}"
                 dashboardUrl: "{{ .CommonAnnotations.dashboard_url }}"
@@ -89,7 +95,6 @@ spec:
                       {{- end -}}
                   {{- end -}}
                   alertname%3D%22{{ reReplaceAll " +" "%20" .CommonLabels.alertname }}%22%7D
-              note: "{{ (index .Alerts 0).Annotations.description }}{{ (index .Alerts 0).Annotations.message }}"
               priority: >-
                 {{- if ne .CommonLabels.priority "" -}}
                   {{- .CommonLabels.priority }}
@@ -100,7 +105,6 @@ spec:
                   P4
                   {{- end -}}
                 {{- end -}}
-              tags: "test"
               responders:
               - name: 'Main'
                 type: team

--- a/apps/monitoring/raw/alertmanager-secret.yaml
+++ b/apps/monitoring/raw/alertmanager-secret.yaml
@@ -76,8 +76,14 @@ spec:
                 alertname%3D%22{{ reReplaceAll " +" "%20" .CommonLabels.alertname }}%22%7D
         - name: 'opsgenie'
           opsgenie_configs:
-            - message: "{{ .GroupLabels.alertname }}"
-              description: "{{ .CommonAnnotations.summary }}"
+            - message: "{{ .GroupLabels.alertname }} - {{ .CommonAnnotations.summary }}"
+              description: |
+                {{ if gt (len .Alerts.Firing) 0 -}}
+                {{ template "__text_alert_list" .Alerts.Firing }}
+                {{- end }}
+                {{ if gt (len .Alerts.Resolved) 0 -}}
+                {{ template "__text_alert_list" .Alerts.Resolved }}
+                {{- end }}
               details:
                 runbookUrl: "{{ .CommonAnnotations.runbook_url }}"
                 dashboardUrl: "{{ .CommonAnnotations.dashboard_url }}"
@@ -89,7 +95,6 @@ spec:
                       {{- end -}}
                   {{- end -}}
                   alertname%3D%22{{ reReplaceAll " +" "%20" .CommonLabels.alertname }}%22%7D
-              note: "{{ (index .Alerts 0).Annotations.description }}{{ (index .Alerts 0).Annotations.message }}"
               priority: >-
                 {{- if ne .CommonLabels.priority "" -}}
                   {{- .CommonLabels.priority }}
@@ -100,7 +105,6 @@ spec:
                   P4
                   {{- end -}}
                 {{- end -}}
-              tags: "test"
               responders:
               - name: 'Main'
                 type: team


### PR DESCRIPTION
- `tags` seem to be useless
- `note` is not important
- `description` is passed down to slack so should contain all relevant information.