### PR TITLE
Re-attach two components that were running outside GitOps

### DIFF
--- a/base/flux-apps/kube-system.yaml
+++ b/base/flux-apps/kube-system.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kube-system
+  namespace: flux-apps
+spec:
+  interval: 15m0s
+  path: ./base/kube-system/manifests
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: ankhmorpork

--- a/core/kustomization.yaml
+++ b/core/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  #- crds/
+  - cert-manager/
   - external-secrets/
   - flux-system/
   - kube-system/


### PR DESCRIPTION
Both were orphaned by the same `2025-12-20` reorg and have been running unmanaged since — invisible to CI because nothing referenced them, and invisible to Flux because nothing owned them. Verified against the live cluster; **both changes are adoptions of already-correct state, not installs.**

## cert-manager (`9c61d754`)

`13d129ee` deleted `base/flux-apps/cert-manager.yaml` and the component moved into `core/`, but it was never added to `core/kustomization.yaml`. The `HelmRelease` object survived because `core` is `prune: false`, so helm-controller kept reconciling it on its own while git had no say — and Renovate has been bumping a chart version nothing applied.

Live: namespace 5y50d, all three deployments 1/1, HelmRelease reporting *"Helm upgrade succeeded … cert-manager@v1.16.2"*, `ClusterIssuer/letsencrypt-prod` (4y170d) and `letsencrypt-dns01` both Ready. **16 apps** depend on this via `cert-manager.io/cluster-issuer`.

Adoption is a no-op — `flux diff kustomization core --path ./core` reports 8 objects drifted and *every* change is the ownership label moving from the deleted `cert-manager/flux-apps` to `core/flux-system`:

```
► HelmRelease/cert-manager/cert-manager drifted
metadata.labels.kustomize.toolkit.fluxcd.io/name
- cert-manager
+ core
```

Zero spec changes, because git and cluster both sit at v1.16.2. I checked explicitly: filtering the diff for anything that isn't a `kustomize.toolkit.fluxcd.io/` label returns nothing, and there are 0 lines touching `spec`.

**Not bumping the chart here.** v1.16.2 is well behind current, but that belongs in its own change once ownership has settled.

Also drops the empty `core/crds/` (a lone `.gitkeep`) and its commented-out reference.

## Intel GPU plugin (`cdd276ec`)

`f4a41851` moved the Cilium half of `base/kube-system` into `core/kube-system` and left `base/kube-system/manifests` behind with no Kustomization.

This one has a live consumer: `apps/jellyfin` requests `gpu.intel.com/i915`, which only this DaemonSet provides. Live state — 4/4 ready, 291d old, advertising `i915: 4` on all four nodes, both `NodeFeatureRule`s present, jellyfin running 111d against it.

Pure adoption: `kustomize build base/kube-system/manifests | kubectl diff -f -` is **empty**, so the committed manifests already match the cluster exactly.

## Verification

- `make validate` → 73 targets render and validate cleanly
- `make validate-flux` → **42** live Flux Kustomization paths (was 41)
- `kubectl diff` on the GPU manifests → exit 0, identical
- `flux diff kustomization core` → label-only drift, no spec changes

## Follow-up, deliberately not in this PR

`PriorityClass/production-high` is unused — nothing in the repo references it, and in-cluster there are 0 pods and 0 workloads using it. Removing it needs to come *after* this merges: it has never been in a Flux inventory, so deleting it from git while unmanaged would orphan the object in-cluster permanently. Once this PR is reconciled and the Kustomization owns it, a follow-up removal gets pruned properly. Branch `chore/drop-unused-priorityclass` is ready for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)