### PR TITLE
Move Flux resources to GA APIs (groundwork for the Flux upgrade)

### DIFF
--- a/apps/ai-gateway/manifests/app/release.yaml
+++ b/apps/ai-gateway/manifests/app/release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: litellm

--- a/apps/ai-gateway/manifests/app/repository.yaml
+++ b/apps/ai-gateway/manifests/app/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: litellm

--- a/apps/atuin/manifests/atuin-server/release.yaml
+++ b/apps/atuin/manifests/atuin-server/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: atuin

--- a/apps/atuin/manifests/atuin-server/repository.yaml
+++ b/apps/atuin/manifests/atuin-server/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: atuin

--- a/apps/changedetection/release.yaml
+++ b/apps/changedetection/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: changedetection

--- a/apps/changedetection/repository.yaml
+++ b/apps/changedetection/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: alekc-charts

--- a/apps/crowdsec/release.yaml
+++ b/apps/crowdsec/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: crowdsec

--- a/apps/crowdsec/repository.yaml
+++ b/apps/crowdsec/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: crowdsecurity

--- a/apps/datalake-logs/release.yaml
+++ b/apps/datalake-logs/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: loki

--- a/apps/datalake-logs/repository.yaml
+++ b/apps/datalake-logs/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: grafana

--- a/apps/datalake-metrics/release.yaml
+++ b/apps/datalake-metrics/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: thanos

--- a/apps/datalake-metrics/repository.yaml
+++ b/apps/datalake-metrics/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: bitnami

--- a/apps/descheduler/release.yaml
+++ b/apps/descheduler/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: descheduler

--- a/apps/descheduler/repository.yaml
+++ b/apps/descheduler/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: descheduler

--- a/apps/external-dns/release.yaml
+++ b/apps/external-dns/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: external-dns

--- a/apps/external-dns/repository.yaml
+++ b/apps/external-dns/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: k8s-sigs-external-dns

--- a/apps/grafana/manifests/grafana/release.yaml
+++ b/apps/grafana/manifests/grafana/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: grafana

--- a/apps/grafana/manifests/grafana/repository.yaml
+++ b/apps/grafana/manifests/grafana/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: grafana

--- a/apps/jellyfin/manifests/release.yaml
+++ b/apps/jellyfin/manifests/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: jellyfin

--- a/apps/jellyfin/manifests/repository.yaml
+++ b/apps/jellyfin/manifests/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: jellyfin

--- a/apps/opencost/release.yaml
+++ b/apps/opencost/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: opencost

--- a/apps/opencost/repository.yaml
+++ b/apps/opencost/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: opencost

--- a/apps/photos/release.yaml
+++ b/apps/photos/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: immich

--- a/apps/photos/repository.yaml
+++ b/apps/photos/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: immich

--- a/apps/pocket-id/manifests/app/release.yaml
+++ b/apps/pocket-id/manifests/app/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: pocket-id

--- a/apps/pocket-id/manifests/app/repository.yaml
+++ b/apps/pocket-id/manifests/app/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: anza-labs

--- a/apps/promtail/release.yaml
+++ b/apps/promtail/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: promtail

--- a/apps/promtail/repository.yaml
+++ b/apps/promtail/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: grafana

--- a/apps/scripts-mon/manifests/release.yaml
+++ b/apps/scripts-mon/manifests/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: script-exporter

--- a/apps/scripts-mon/manifests/repository.yaml
+++ b/apps/scripts-mon/manifests/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: ricoberger

--- a/apps/stirling-pdf/release.yaml
+++ b/apps/stirling-pdf/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: stirling-pdf

--- a/apps/stirling-pdf/repository.yaml
+++ b/apps/stirling-pdf/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: stirling-pdf

--- a/apps/system-kured/release.yaml
+++ b/apps/system-kured/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: kured

--- a/apps/system-kured/repository.yaml
+++ b/apps/system-kured/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: kured

--- a/apps/vector/release.yaml
+++ b/apps/vector/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: vector

--- a/apps/vector/repository.yaml
+++ b/apps/vector/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: vector

--- a/base/cloudflared/release.yaml
+++ b/base/cloudflared/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: cloudflared

--- a/base/cloudflared/repository.yaml
+++ b/base/cloudflared/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: strrl

--- a/base/cnpg-system/barman/release.yaml
+++ b/base/cnpg-system/barman/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: barman

--- a/base/cnpg-system/operator/release.yaml
+++ b/base/cnpg-system/operator/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: cnpg

--- a/base/cnpg-system/operator/repository.yaml
+++ b/base/cnpg-system/operator/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: cnpg

--- a/base/csi-nfs/release.yaml
+++ b/base/csi-nfs/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: csi-nfs

--- a/base/csi-nfs/repository.yaml
+++ b/base/csi-nfs/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: csi-driver-nfs

--- a/base/longhorn-system/release.yaml
+++ b/base/longhorn-system/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: longhorn

--- a/base/longhorn-system/repository.yaml
+++ b/base/longhorn-system/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: longhorn

--- a/base/node-feature-discovery/release.yaml
+++ b/base/node-feature-discovery/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: nfd

--- a/base/node-feature-discovery/repository.yaml
+++ b/base/node-feature-discovery/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: node-feature-discovery

--- a/base/node-problem-detector/release.yaml
+++ b/base/node-problem-detector/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: node-problem-detector

--- a/base/node-problem-detector/repository.yaml
+++ b/base/node-problem-detector/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: deliveryhero

--- a/base/topolvm-system/diskprep/release.yaml
+++ b/base/topolvm-system/diskprep/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: diskprep

--- a/base/topolvm-system/diskprep/repository.yaml
+++ b/base/topolvm-system/diskprep/repository.yaml
@@ -1,8 +1,9 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: thaum-charts
   namespace: topolvm-system
 spec:
+  type: oci
   interval: 5m
   url: oci://ghcr.io/thaum-xyz/helm-charts

--- a/base/topolvm-system/topolvm/release.yaml
+++ b/base/topolvm-system/topolvm/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: topolvm

--- a/base/topolvm-system/topolvm/repository.yaml
+++ b/base/topolvm-system/topolvm/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: topolvm

--- a/base/traefik/private/release.yaml
+++ b/base/traefik/private/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: private

--- a/base/traefik/public/release.yaml
+++ b/base/traefik/public/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: public

--- a/base/traefik/repository.yaml
+++ b/base/traefik/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: traefik

--- a/base/velero/release.yaml
+++ b/base/velero/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: velero

--- a/base/velero/repository.yaml
+++ b/base/velero/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: tanzu

--- a/core/flux-system/additional/receiver.yaml
+++ b/core/flux-system/additional/receiver.yaml
@@ -11,7 +11,7 @@ spec:
     - ping
     - push
   resources:
-    - apiVersion: source.toolkit.fluxcd.io/v1beta1
+    - apiVersion: source.toolkit.fluxcd.io/v1
       kind: GitRepository
       name: ankhmorpork
   secretRef:

--- a/core/flux-system/controllers/release.yaml
+++ b/core/flux-system/controllers/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: flux2

--- a/core/flux-system/controllers/repository.yaml
+++ b/core/flux-system/controllers/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: fluxcd-community


### PR DESCRIPTION
Bumps **60 objects** onto GA Flux APIs: 27 HelmRelease `v2beta1` + 4 `v2beta2` → `helm.toolkit.fluxcd.io/v2`, and 29 HelmRepository `v1beta2` → `source.toolkit.fluxcd.io/v1`.

Every Flux file in the repo is single-kind, so this is a per-file `apiVersion` swap. I audited the diff for anything else and it contains only the two deliberate fixes below:

```
+    - apiVersion: source.toolkit.fluxcd.io/v1
+  type: oci
-    - apiVersion: source.toolkit.fluxcd.io/v1beta1
```

## Why this has to land before the Flux upgrade

The controllers are on **Flux 2.4.x** (`helm-controller v1.1.0`, `source-controller v1.4.1`, `kustomize-controller v1.4.0`), which still serves `v2beta1`. **Flux 2.6 removed it.** Upgrading first would break 27 HelmReleases simultaneously — so this is groundwork, and the upgrade follows in its own PR once this has reconciled.

## Why it's safe today

The storage versions are already GA — `kubectl get crd` reports `storage=[v2]` for HelmRelease and `storage=[v1]` for HelmRepository, so the API server has been converting on write all along. The declared version in git was the only thing lagging.

`flux -n flux-apps diff kustomization cloudflared --path ./base/cloudflared` reports **no drift**.

## Verification

`make validate` passes all **73 targets** with `-strict` against the real `v2`/`v1` schemas from the CRD catalog — that's the check that would have caught a field invalid in the GA version. None were. The fields in use across all 34 HelmReleases are `chart`, `install`, `upgrade`, `interval`, `timeout`, `valuesFrom`, `driftDetection`, `postRenderers`, `suspend`; all still valid. I confirmed all four target schemas resolve in the catalog before starting, since `hack/validate-manifests.sh` runs without `-ignore-missing-schemas` and a missing schema is a hard CI failure.

## Two fixes carried along

- **`base/topolvm-system/diskprep/repository.yaml`** was missing `spec.type: oci` on an `oci://` URL. The three OCI HelmRepositories that *are* deployed — `ai-gateway/litellm`, `datalake-metrics/bitnami`, `node-problem-detector/deliveryhero` — all set it, so this aligns diskprep with the working pattern.

  Correcting something I said earlier: I'd claimed diskprep's HelmRelease was Ready and therefore Flux tolerated the missing field. It isn't — `base/topolvm-system/kustomization.yaml` has `#- diskprep/ # TODO: uncomment when moving to talos`, so it has never been deployed. The fix follows Flux's documented requirement rather than observed behaviour.

- **`core/flux-system/additional/receiver.yaml`** referenced `GitRepository` at `source.toolkit.fluxcd.io/v1beta1` while the object is `v1`. `v1beta1` is still served so the GitHub webhook works today, but that reference would break on the very upgrade this PR prepares for.

`ImagePolicy`/`ImageRepository` stay at `image.toolkit.fluxcd.io/v1beta2` — that's still their storage version, not a deprecation.

## Follow-up

Once this reconciles: upgrade the flux2 chart, then add `-reject` for the deprecated GVKs to `hack/validate-manifests.sh` so they can't come back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)