### PR TITLE
Declare traefik and loki suspends in git

### DIFF
--- a/apps/datalake-logs/release.yaml
+++ b/apps/datalake-logs/release.yaml
@@ -29,3 +29,4 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: values
+  suspend: true

--- a/base/flux-apps/datalake-logs.yaml
+++ b/base/flux-apps/datalake-logs.yaml
@@ -8,7 +8,7 @@ spec:
   path: ./apps/datalake-logs
   prune: true
   force: true
-  suspend: false
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: ankhmorpork

--- a/base/flux-apps/traefik.yaml
+++ b/base/flux-apps/traefik.yaml
@@ -11,3 +11,4 @@ spec:
   sourceRef:
     kind: GitRepository
     name: ankhmorpork
+  suspend: true

--- a/base/traefik/private/release.yaml
+++ b/base/traefik/private/release.yaml
@@ -35,3 +35,4 @@ spec:
       name: values-common
     - kind: ConfigMap
       name: values-private
+  suspend: true

--- a/base/traefik/public/release.yaml
+++ b/base/traefik/public/release.yaml
@@ -34,3 +34,4 @@ spec:
       name: values-common
     - kind: ConfigMap
       name: values-public
+  suspend: true


### PR DESCRIPTION
Both components are already suspended in-cluster (since 2025-12-24) but git didn't say so — and `base/flux-apps/datalake-logs.yaml` actively claimed the opposite with `suspend: false`. This makes git tell the truth for the two we're deliberately leaving frozen. **Nothing changes in the cluster; both applications keep running.**

Suspending the **Kustomization *and* the HelmRelease**, not just the Kustomization — the HelmRelease is what helm-controller acts on, so suspending only the parent would still leave helm-controller free to reconcile the release and revert what's running.

## Why these two

**traefik** — git pins chart `41.0.0` while the cluster runs `37.4.0`, and the values in `base/traefik/{public,private}/values.yaml` aren't valid for `41.0.0`:

```
traefik:
- (root): Additional property logs is not allowed
- ports.web: Additional property redirections is not allowed
```

So resuming wouldn't upgrade traefik — it would **fail the Helm upgrade**. Ingress currently arrives via the cloudflared tunnels rather than traefik, so this isn't urgent; parking it explicitly beats leaving a broken upgrade armed.

**datalake-logs** — `loki-backend` runs 1 replica against git's 2, and `ConfigMap/loki` was hand-edited. Keeping the cluster as-is by request.

## Why `flux diff` missed this

`flux diff` only compares what a Kustomization applies — the HelmRelease — so everything Helm *renders* from it (Deployments, StatefulSets, ConfigMaps) is invisible to it. It reported traefik as merely "chart version drifted" and datalake-logs' replica change not at all.

[`flux-build`](https://github.com/DoodleScheduling/flux-build) renders the full chain. Running it over all 41 components: **37 build cleanly, 1 genuinely fails** (traefik, above). The other 3 failures are tool artifacts — `core` needs `--api-versions monitoring.coreos.com/v1` for cilium's chart guard (185 objects once given it), and `cloudflared`/`pocket-id` take values from a Secret that ExternalSecret creates at runtime.

Diffing the rendered chain against the cluster for the 24 suspended components: **11 clean, 13 differ.** Most of the differences are simply unapplied upgrades (longhorn's chart bump alone accounts for 43 objects), not manual state — so this PR only parks the two where the cluster genuinely holds something git doesn't.

## Follow-up noted while doing this

`base/cloudflared/credentials.yaml` carries the comment *"when modifying values, modify also the Secret in testdata"* — **there is no testdata directory, and there never has been** in git history. Committing that placeholder Secret would let `flux-build` (and CI) render the cloudflared and pocket-id chains instead of failing on them. `esoctl template` produces it, though it also needs `engineVersion: v2` on the ExternalSecret's target template, which is currently unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)