### PR TITLE
ci: fail on deprecated Flux API versions

### DIFF
--- a/hack/validate-manifests.sh
+++ b/hack/validate-manifests.sh
@@ -40,6 +40,31 @@ validate() {
     "$@"
 }
 
+# Flux APIs that are deprecated upstream and removed in newer Flux versions.
+# Everything is on helm.toolkit.fluxcd.io/v2 and source.toolkit.fluxcd.io/v1;
+# this stops an old one creeping back in via a copied-and-pasted manifest.
+#
+# This is a source-level grep rather than kubeconform's -reject because -reject
+# matches on kind only, not group/version -- `-reject HelmRelease` would reject
+# every HelmRelease regardless of apiVersion, which is not what we want.
+#
+# image.toolkit.fluxcd.io/v1beta2 is deliberately not listed: that is still the
+# current storage version for ImagePolicy and ImageRepository.
+DEPRECATED_APIS='^apiVersion: (helm\.toolkit\.fluxcd\.io/v2beta[12]|source\.toolkit\.fluxcd\.io/v1beta[12]|kustomize\.toolkit\.fluxcd\.io/v1beta[12]|notification\.toolkit\.fluxcd\.io/v1beta[12])$'
+
+check_deprecated_apis() {
+  local hits
+  hits=$(git ls-files '*.yaml' '*.yml' | xargs grep -nE "$DEPRECATED_APIS" 2>/dev/null)
+  if [ -n "$hits" ]; then
+    echo "Deprecated Flux API versions found -- migrate to the GA versions:"
+    echo "$hits" | while IFS=: read -r f l rest; do
+      echo "::error file=$f,line=$l::deprecated Flux API: ${rest# }"
+    done
+    return 1
+  fi
+  echo "No deprecated Flux API versions."
+}
+
 flux_paths() {
   local query='select(.kind == "Kustomization" and (.apiVersion | test("^kustomize.toolkit.fluxcd.io/"))) | .spec.path'
   while IFS= read -r f; do
@@ -68,6 +93,12 @@ fi
 if [ -z "$targets" ]; then
   echo "Nothing to validate" >&2
   exit 1
+fi
+
+# Repo-wide policy check; only meaningful on a full run.
+api_check=0
+if [ "$#" -eq 0 ]; then
+  check_deprecated_apis || api_check=1
 fi
 
 total=0
@@ -108,5 +139,7 @@ if [ -n "$failed" ]; then
   for d in $failed; do echo "  - $d"; done
   exit 1
 fi
+
+[ "$api_check" -ne 0 ] && exit 1
 
 echo "All $total targets render and validate cleanly."


### PR DESCRIPTION
Locks in the migration from #942 so an old `apiVersion` can't creep back via a copied-and-pasted manifest.

## Not done with `-reject`, and why

The plan assumed kubeconform's `-reject` would express this. It doesn't — **`-reject` matches on kind only, not group/version.** `-reject HelmRelease` rejects *every* HelmRelease whatever its apiVersion, and passing a GVK is silently ignored. I tried all three plausible spellings against an injected `v2beta1`:

| form | result |
|---|---|
| `helm.toolkit.fluxcd.io/v2beta1/HelmRelease` | not rejected |
| `HelmRelease.helm.toolkit.fluxcd.io/v2beta1` | not rejected |
| `helm.toolkit.fluxcd.io/v2beta1` | not rejected |
| `HelmRelease` (bare kind) | rejected — but rejects all versions, useless here |

So this is a source-level grep over git-tracked YAML instead. That's also a better error — file and line, as a GitHub annotation:

```
::error file=base/cloudflared/release.yaml,line=2::deprecated Flux API: apiVersion: helm.toolkit.fluxcd.io/v2beta1
```

## Coverage

Rejects `helm` v2beta1/v2beta2, `source` v1beta1/v1beta2, `kustomize` v1beta1/v1beta2, `notification` v1beta1/v1beta2.

Deliberately **not** rejected, because they're still current storage versions — verified against `kubectl get crd`:
- `image.toolkit.fluxcd.io/v1beta2` — ImagePolicy, ImageRepository
- `notification.toolkit.fluxcd.io/v1beta3` — Alert, Provider

## Verification

| case | exit |
|---|---|
| clean tree | 0 — "No deprecated Flux API versions", all 73 targets valid |
| `v2beta1` injected into a HelmRelease | **1**, correct annotation |
| `v1beta2` injected into a HelmRepository | **1**, correct annotation |
| restored | 0 |

Runs only on a full validation pass, not when a single path is passed as an argument.

One caveat, shared with `validate-flux-paths.sh`: the check reads git-tracked files, so a brand-new *untracked* manifest isn't seen until staged. Harmless in CI where everything is committed, but worth knowing when testing locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)