### PR TITLE
Declare the cluster's suspend state in git

### DIFF
--- a/apps/changedetection/release.yaml
+++ b/apps/changedetection/release.yaml
@@ -4,6 +4,7 @@ kind: HelmRelease
 metadata:
   name: changedetection
 spec:
+  suspend: true
   chart:
     spec:
       chart: changedetection

--- a/apps/datalake-metrics/release.yaml
+++ b/apps/datalake-metrics/release.yaml
@@ -29,3 +29,4 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: values
+  suspend: true

--- a/apps/descheduler/release.yaml
+++ b/apps/descheduler/release.yaml
@@ -29,3 +29,4 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: values
+  suspend: true

--- a/apps/external-dns/release.yaml
+++ b/apps/external-dns/release.yaml
@@ -29,3 +29,4 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: values
+  suspend: true

--- a/apps/jellyfin/manifests/release.yaml
+++ b/apps/jellyfin/manifests/release.yaml
@@ -44,3 +44,4 @@ spec:
               - op: add
                 path: /spec/template/spec/securityContext/supplementalGroups/0
                 value: 109
+  suspend: true

--- a/apps/opencost/release.yaml
+++ b/apps/opencost/release.yaml
@@ -29,3 +29,4 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: values
+  suspend: true

--- a/apps/photos/release.yaml
+++ b/apps/photos/release.yaml
@@ -29,3 +29,4 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: values
+  suspend: true

--- a/apps/promtail/release.yaml
+++ b/apps/promtail/release.yaml
@@ -29,3 +29,4 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: values
+  suspend: true

--- a/apps/scripts-mon/manifests/release.yaml
+++ b/apps/scripts-mon/manifests/release.yaml
@@ -29,3 +29,4 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: values
+  suspend: true

--- a/apps/system-kured/release.yaml
+++ b/apps/system-kured/release.yaml
@@ -29,3 +29,4 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: values
+  suspend: true

--- a/apps/vector/release.yaml
+++ b/apps/vector/release.yaml
@@ -29,3 +29,4 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: values
+  suspend: true

--- a/base/cloudflared/release.yaml
+++ b/base/cloudflared/release.yaml
@@ -32,3 +32,4 @@ spec:
       name: values
     - kind: Secret
       name: credentials
+  suspend: true

--- a/base/cnpg-system/barman/release.yaml
+++ b/base/cnpg-system/barman/release.yaml
@@ -27,3 +27,4 @@ spec:
     timeout: 20m
     disableWait: false
     crds: CreateReplace
+  suspend: true

--- a/base/cnpg-system/operator/release.yaml
+++ b/base/cnpg-system/operator/release.yaml
@@ -30,3 +30,4 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: values
+  suspend: true

--- a/base/flux-apps/changedetection.yaml
+++ b/base/flux-apps/changedetection.yaml
@@ -10,3 +10,4 @@ spec:
   sourceRef:
     kind: GitRepository
     name: ankhmorpork
+  suspend: true

--- a/base/flux-apps/cloudflared.yaml
+++ b/base/flux-apps/cloudflared.yaml
@@ -10,3 +10,4 @@ spec:
   sourceRef:
     kind: GitRepository
     name: ankhmorpork
+  suspend: true

--- a/base/flux-apps/cnpg-system.yaml
+++ b/base/flux-apps/cnpg-system.yaml
@@ -10,4 +10,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: ankhmorpork
+  suspend: true
 

--- a/base/flux-apps/crowdsec.yaml
+++ b/base/flux-apps/crowdsec.yaml
@@ -10,3 +10,4 @@ spec:
   sourceRef:
     kind: GitRepository
     name: ankhmorpork
+  suspend: true

--- a/base/flux-apps/datalake-metrics.yaml
+++ b/base/flux-apps/datalake-metrics.yaml
@@ -8,7 +8,7 @@ spec:
   path: ./apps/datalake-metrics
   prune: true
   force: true
-  suspend: false
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: ankhmorpork

--- a/base/flux-apps/descheduler.yaml
+++ b/base/flux-apps/descheduler.yaml
@@ -10,4 +10,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: ankhmorpork
+  suspend: true
 

--- a/base/flux-apps/external-dns.yaml
+++ b/base/flux-apps/external-dns.yaml
@@ -10,3 +10,4 @@ spec:
   sourceRef:
     kind: GitRepository
     name: ankhmorpork
+  suspend: true

--- a/base/flux-apps/jellyfin.yaml
+++ b/base/flux-apps/jellyfin.yaml
@@ -10,3 +10,4 @@ spec:
   sourceRef:
     kind: GitRepository
     name: ankhmorpork
+  suspend: true

--- a/base/flux-apps/longhorn-system.yaml
+++ b/base/flux-apps/longhorn-system.yaml
@@ -11,3 +11,4 @@ spec:
   sourceRef:
     kind: GitRepository
     name: ankhmorpork
+  suspend: true

--- a/base/flux-apps/monitoring.yaml
+++ b/base/flux-apps/monitoring.yaml
@@ -11,4 +11,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: ankhmorpork
+  suspend: true
 

--- a/base/flux-apps/nut.yaml
+++ b/base/flux-apps/nut.yaml
@@ -10,4 +10,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: ankhmorpork
+  suspend: true
 

--- a/base/flux-apps/photos.yaml
+++ b/base/flux-apps/photos.yaml
@@ -10,3 +10,4 @@ spec:
   sourceRef:
     kind: GitRepository
     name: ankhmorpork
+  suspend: true

--- a/base/flux-apps/promtail.yaml
+++ b/base/flux-apps/promtail.yaml
@@ -10,4 +10,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: ankhmorpork
+  suspend: true
 

--- a/base/flux-apps/scripts-mon.yaml
+++ b/base/flux-apps/scripts-mon.yaml
@@ -10,3 +10,4 @@ spec:
   sourceRef:
     kind: GitRepository
     name: ankhmorpork
+  suspend: true

--- a/base/flux-apps/storage-system.yaml
+++ b/base/flux-apps/storage-system.yaml
@@ -10,4 +10,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: ankhmorpork
+  suspend: true
 

--- a/base/flux-apps/system-kured.yaml
+++ b/base/flux-apps/system-kured.yaml
@@ -10,3 +10,4 @@ spec:
   sourceRef:
     kind: GitRepository
     name: ankhmorpork
+  suspend: true

--- a/base/flux-apps/unifi.yaml
+++ b/base/flux-apps/unifi.yaml
@@ -10,4 +10,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: ankhmorpork
+  suspend: true
 

--- a/base/flux-apps/valheim.yaml
+++ b/base/flux-apps/valheim.yaml
@@ -10,3 +10,4 @@ spec:
   sourceRef:
     kind: GitRepository
     name: ankhmorpork
+  suspend: true

--- a/base/flux-apps/vector.yaml
+++ b/base/flux-apps/vector.yaml
@@ -10,3 +10,4 @@ spec:
   sourceRef:
     kind: GitRepository
     name: ankhmorpork
+  suspend: true

--- a/base/flux-apps/versity-test.yaml
+++ b/base/flux-apps/versity-test.yaml
@@ -10,3 +10,4 @@ spec:
   sourceRef:
     kind: GitRepository
     name: ankhmorpork
+  suspend: true

--- a/base/longhorn-system/release.yaml
+++ b/base/longhorn-system/release.yaml
@@ -30,3 +30,4 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: values
+  suspend: true


### PR DESCRIPTION
The fleet has been partially suspended since **2025-12-24**, when reconciliation was stopped so resources could be modified by hand while the beelink nodes were brought into the existing cluster. That was done imperatively, so git never knew: **43 objects suspended in-cluster, only 4 declared in git**, and `datalake-metrics` actively claiming `suspend: false` while suspended.

This mirrors reality into git for **35 objects** — 20 Kustomizations and 15 HelmReleases. **Nothing changes in the cluster; every application keeps running exactly as it is.** The point is that `flux diff`, `flux-build` and CI stop lying about what's actually reconciling.

Verified after the change: every suspended Kustomization and HelmRelease in the cluster now has a matching `suspend: true` in git — no gaps.

## `flux-apps` is deliberately left undeclared

It manages the directory its own definition lives in (`spec.path: ./base/flux-apps`). Writing `suspend: true` there would make it **re-suspend itself the moment it's resumed** — the resume wouldn't stick. So it stays imperative until you resume it, which is the next step.

## The one that mattered

`datalake-metrics` flips from `suspend: false` → `true`. Git declaring `false` while the cluster said `true` meant resuming `flux-apps` would have **silently un-suspended it**, because git wins for a field it explicitly declares. The other 21 children never declared the field at all, so server-side apply leaves their imperative suspend intact — that's why they stay suspended without this PR needing to touch cluster state.

## After this merges, resuming `flux-apps` should be undramatic

- 21 of 22 suspended children keep their suspend (field not owned by git, or now correctly declared)
- `kube-system` gets created, finally bringing the Intel GPU plugin under management — the outstanding half of #941
- The 40 child Kustomization definitions refresh from current master
- `chore/drop-unused-priorityclass` becomes mergeable, since the PriorityClass can then be pruned properly

## Diff hygiene

`apps/changedetection/release.yaml` was edited by hand rather than with `yq` — yq reformatted its `postRenderers` patch block. I checked with `kustomize build` before and after that the rendered output was identical, but it was needless review noise. Same for seven trailing newlines yq stripped elsewhere, restored.

Final diff is 35 insertions and the single `suspend: false` → `true` flip, nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)