### PR TITLE
cnpg-system: upgrade operator and barman plugin, resume reconciliation

### DIFF
--- a/base/cnpg-system/barman/release.yaml
+++ b/base/cnpg-system/barman/release.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: plugin-barman-cloud
-      version: "0.3.1"
+      version: "0.7.0"
       sourceRef:
         kind: HelmRepository
         name: cnpg
@@ -27,4 +27,3 @@ spec:
     timeout: 20m
     disableWait: false
     crds: CreateReplace
-  suspend: true

--- a/base/cnpg-system/operator/release.yaml
+++ b/base/cnpg-system/operator/release.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: cloudnative-pg
-      version: "0.27.0"
+      version: "0.29.0"
       sourceRef:
         kind: HelmRepository
         name: cnpg
@@ -30,4 +30,3 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: values
-  suspend: true

--- a/base/flux-apps/cnpg-system.yaml
+++ b/base/flux-apps/cnpg-system.yaml
@@ -10,5 +10,4 @@ spec:
   sourceRef:
     kind: GitRepository
     name: ankhmorpork
-  suspend: true
 


### PR DESCRIPTION
| component | chart | app |
|---|---|---|
| cloudnative-pg | 0.27.0 → **0.29.0** | 1.28.0 → **1.30.0** |
| plugin-barman-cloud | 0.3.1 → **0.7.0** | v0.9.0 → **v0.13.0** |

Both were suspended since 2025-12-24; this resumes them, dropping `suspend` from the Kustomization and both HelmReleases.

## Compatibility checked before bumping

- **`ObjectStore` CRD stays at `barmancloud.cnpg.io/v1`** in both 0.3.1 and 0.7.0 — no API migration for the 12 existing ObjectStore objects. This was the main risk in a 4-minor jump on the backup plugin.
- Chart `kubeVersion: >=1.29.0-0`; server is 1.34.1.
- 0.29.0 and 0.7.0 are the current pairing, so operator 1.30.0 + plugin v0.13.0 is what upstream ships together.
- `flux-build` renders the chain cleanly — 42 objects, images `cloudnative-pg:1.30.0` and `plugin-barman-cloud:v0.13.0`.

## Backups were taken first — deliberately out of the requested order

Upgrading the operator rolls the instance managers, which **restarts Postgres primaries**. Five of the eleven databases had nothing recoverable, so doing that first would have been the wrong order. April's on-demand backups proved backups work with the *current* plugin, so there was no need to upgrade first.

On-demand backups for grafana, pocket-id and multimedia's three all completed in ~45s. Every ObjectStore now reports a recovery point minutes old instead of 111 days:

```
grafana      postgres            2026-07-28T12:51:43Z   1min
multimedia   postgres-prowlarr   2026-07-28T12:51:43Z   1min
multimedia   postgres-radarr     2026-07-28T12:51:42Z   1min
multimedia   postgres-sonarr     2026-07-28T12:51:41Z   1min
pocket-id    postgres            2026-07-28T12:51:42Z   1min
```

## The seven-month backup stall is fixed

Root cause: those five ScheduledBackups had status frozen at `2025-12-25T06:34:10Z` — one instant, all five — with `nextScheduleTime` in the past. So the controller kept trying to create a Backup named after that timestamp, which **already existed** from the final legacy `barmanObjectStore` run:

```
Error while creating backup object
error: backups.postgresql.cnpg.io "postgres-20251225231700" already exists
```

`AlreadyExists` → reconcile error → retry, forever, never advancing. Deleting just the five blocking Backup records let it recover. **All eleven schedules now point at tonight.**

Two corrections to earlier analysis, for the record:
- I'd reported "zero Backup objects exist" — wrong. `kubectl get backups` silently resolves to `backups.longhorn.io`, since three CRDs register that short name. They exist under `backups.postgresql.cnpg.io`.
- I'd suggested deleting the ScheduledBackups as the cleaner fix. `backupOwnerReference: self` means the *ScheduledBackup* owns the Backups (`controller: true`), so that would have cascade-deleted the entire backup history.

## Note on reconciliation

`flux-apps` is still suspended, so it can't propagate the Kustomization's `suspend` removal. The `cnpg-system` Kustomization needs one imperative resume for this to apply; after that it's self-consistent with git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)