### PR TITLE
base/kube-system: drop unused production-high PriorityClass

### DIFF
--- a/base/kube-system/manifests/kustomization.yaml
+++ b/base/kube-system/manifests/kustomization.yaml
@@ -3,4 +3,3 @@ kind: Kustomization
 namespace: kube-system
 resources:
   - device-plugins/
-  - other/

--- a/base/kube-system/manifests/other/kustomization.yaml
+++ b/base/kube-system/manifests/other/kustomization.yaml
@@ -1,5 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-namespace: kube-system
-resources:
-  - priorityClass-production-high.yaml

--- a/base/kube-system/manifests/other/priorityClass-production-high.yaml
+++ b/base/kube-system/manifests/other/priorityClass-production-high.yaml
@@ -1,8 +1,0 @@
-apiVersion: scheduling.k8s.io/v1
-kind: PriorityClass
-description: High priority production applications
-metadata:
-  name: production-high
-preemptionPolicy: PreemptLowerPriority
-value: 30000
-globalDefault: false


### PR DESCRIPTION
Follow-up to #941, which had to wait for `flux-apps` to be resumed.

`PriorityClass/production-high` is referenced by nothing. Verified both ways: no `priorityClassName` in the repo points at it (only `system-cluster-critical` / `system-node-critical` are used), and in-cluster there are **0 pods and 0 workloads** using it. It has existed for 3y354d.

## Why this is a separate PR

The PriorityClass had never been in any Flux inventory, so deleting it from git while unmanaged would have left the object orphaned in-cluster permanently. #941 first brought the directory under management; now that `kube-system` owns it —

```
$ kubectl -n flux-apps get kustomization kube-system -o jsonpath='{.status.inventory.entries[*].id}'
_production-high_scheduling.k8s.io_PriorityClass
```

— removing it from git makes kustomize-controller prune it properly on the next reconcile.

I'd originally put this in the same commit series as #941 and then split it out, because all commits in one PR reach the cluster as a single state: Flux would never have seen the object in an inventory, and it would have been orphaned exactly as if it had never been adopted.

## Verification

- `make validate` → 72 targets (down one, since `other/` and its kustomization.yaml go away)
- `make validate-flux` → 42 live paths, unchanged
- `base/kube-system/manifests` now renders exactly the three GPU objects: `DaemonSet/intel-gpu-plugin` and both `NodeFeatureRule`s

Expect one pruned object on the next `kube-system` reconcile, and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)