### PR TITLE
flux: bump chart 2.16.0 → 2.19.0 (storage-version migration done)

### DIFF
--- a/core/flux-system/controllers/release.yaml
+++ b/core/flux-system/controllers/release.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     spec:
       chart: flux2
-      version: "2.16.0"
+      version: "2.19.0"
       sourceRef:
         kind: HelmRepository
         name: fluxcd-community


### PR DESCRIPTION
Flux **2.6.1 → 2.9.1**. Unblocked by a storage-version migration performed against the live cluster.

## The blocker, and how it was cleared

Before this, all ten chart-managed CRDs had beta versions lingering in `status.storedVersions` that 2.19.0 stops serving. With `crds: CreateReplace` set on both install and upgrade, helm-controller would attempt the replacement and the API server would reject it:

```
status.storedVersions[0]: Invalid value: "v1beta2": missing from spec.versions;
v1beta2 was previously a storage version, and must remain in spec.versions until a
storage migration ensures no data remains persisted in v1beta2 and removes v1beta2
from status.storedVersions
```

Two phases, in this order — and **the order is the safety property**:

**1. Re-persist every object at its CRD's storage version.** 143 objects across ten kinds:

| kind | objects |
|---|---|
| Kustomization | 42 |
| HelmRelease | 33 |
| HelmChart | 33 |
| HelmRepository | 32 |
| GitRepository | 2 |
| Receiver | 1 |
| Bucket / OCIRepository / Alert / Provider | 0 |

Done with an add-then-remove annotation, so `metadata.generation` never changed and **no reconcile was triggered** — the write exists purely to make the API server rewrite the object at the storage version. 143 rewritten, 0 failures.

**2. Prune `status.storedVersions`** to the single storage version on each of the ten CRDs:

```
alerts            ["v1beta1","v1beta2","v1beta3"] -> ["v1beta3"]
helmreleases      ["v2beta1","v2beta2","v2"]      -> ["v2"]
kustomizations    ["v1beta1","v1beta2","v1"]      -> ["v1"]
ocirepositories   ["v1beta2","v1"]                -> ["v1"]
...
```

Phase 1 must precede phase 2: pruning a version that still had an object persisted in it would leave that object **undecodable**, which is the one way this operation loses data.

## Verification

After the migration, before this bump:

- **143 objects still present** — counts identical to baseline across all six populated kinds
- every kind fully readable (`kubectl get -o json` on each)
- **42/42 Kustomizations Ready**
- server-side dry-run of the 2.19.0 CRDs now **applies cleanly** where the identical command was rejected minutes earlier

The two HelmReleases not Ready are pre-existing and suspended: `datalake-metrics/thanos` failing since **2025-10-29** (`context deadline exceeded`) and `longhorn-system/longhorn` since **2025-11-30** (`pre-upgrade hooks failed`). Both predate this work by 8–9 months, and being stuck is plausibly why they were suspended in December.

## One thing that turned out simpler than planned

Pruning to the storage version unblocks the **whole** path in a single step, so the intermediate 2.17.0 hop I'd sketched isn't needed — 2.19.0's CRDs are satisfied directly.

`make validate` 72 targets, `make validate-flux` 42 paths, no deprecated APIs.

Note `core` isn't suspended, so merging applies immediately. Worth watching that all four controllers come up on 2.9.1 and the 42 Kustomizations stay Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)