### PR TITLE
mended-drum: arm the db bundle for Helm adoption (1/2)

### DIFF
--- a/apps/mended-drum/manifests/db/backup.yaml
+++ b/apps/mended-drum/manifests/db/backup.yaml
@@ -3,7 +3,12 @@ kind: ScheduledBackup
 metadata:
   labels:
     app.kubernetes.io/name: postgres
+    app.kubernetes.io/managed-by: Helm
   name: postgres
+  annotations:
+    meta.helm.sh/release-name: postgres
+    meta.helm.sh/release-namespace: mended-drum
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   backupOwnerReference: self
   cluster:

--- a/apps/mended-drum/manifests/db/cluster.yaml
+++ b/apps/mended-drum/manifests/db/cluster.yaml
@@ -3,7 +3,13 @@ kind: Cluster
 metadata:
   labels:
     app.kubernetes.io/name: postgres
+    app.kubernetes.io/managed-by: Helm
   name: postgres
+  annotations:
+    meta.helm.sh/release-name: postgres
+    meta.helm.sh/release-namespace: mended-drum
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   affinity:
     enablePodAntiAffinity: true

--- a/apps/mended-drum/manifests/db/credentialsAdmin.yaml
+++ b/apps/mended-drum/manifests/db/credentialsAdmin.yaml
@@ -3,8 +3,12 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    meta.helm.sh/release-name: postgres
+    meta.helm.sh/release-namespace: mended-drum
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
+    app.kubernetes.io/managed-by: Helm
   name: postgres-admin
 spec:
   data:

--- a/apps/mended-drum/manifests/db/credentialsBackup.yaml
+++ b/apps/mended-drum/manifests/db/credentialsBackup.yaml
@@ -3,7 +3,12 @@ kind: ExternalSecret
 metadata:
   labels:
     app.kubernetes.io/name: postgres
+    app.kubernetes.io/managed-by: Helm
   name: postgres-backup
+  annotations:
+    meta.helm.sh/release-name: postgres
+    meta.helm.sh/release-namespace: mended-drum
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   data:
     - remoteRef:

--- a/apps/mended-drum/manifests/db/credentialsUser.yaml
+++ b/apps/mended-drum/manifests/db/credentialsUser.yaml
@@ -3,8 +3,12 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    meta.helm.sh/release-name: postgres
+    meta.helm.sh/release-namespace: mended-drum
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
+    app.kubernetes.io/managed-by: Helm
   name: postgres-user
 spec:
   data:

--- a/apps/mended-drum/manifests/db/objectStore.yaml
+++ b/apps/mended-drum/manifests/db/objectStore.yaml
@@ -3,6 +3,13 @@ kind: ObjectStore
 metadata:
   name: backblaze
   namespace: mended-drum
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    meta.helm.sh/release-name: postgres
+    meta.helm.sh/release-namespace: mended-drum
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
 spec:
   retentionPolicy: 30d
   configuration:


### PR DESCRIPTION
First of two PRs moving mended-drum's database onto [`cnpg-database`](https://github.com/thaum-xyz/helm-charts/pull/1) — the canary for all 11.

**Metadata only. No spec changes, no removals, nothing restarts.**

Adds to all six objects: `app.kubernetes.io/managed-by: Helm`, `meta.helm.sh/release-name`, `meta.helm.sh/release-namespace`, `kustomize.toolkit.fluxcd.io/prune: disabled` — plus `helm.sh/resource-policy: keep` on the Cluster and ObjectStore.

## Why each one

- **The three Helm ownership fields** are what Helm requires before it will adopt a pre-existing object. Without them it refuses outright and the HelmRelease sticks — which is the *safe* failure mode, and why this is worth doing explicitly rather than hoping.
- **`kustomize.toolkit.fluxcd.io/prune: disabled`** detaches the six objects from the Kustomization's prune inventory. kustomize-controller applies and prunes in a single reconcile against its own inventory, so there is no ordering trick that avoids the prune — this annotation is the only thing that does.
- **`helm.sh/resource-policy: keep`** makes Helm structurally unable to delete the Cluster. That matters because CNPG PVCs are held by `ownerReferences` on the Cluster, and `lvm-thin` is `reclaimPolicy: Delete` on node-local single-copy storage.

## Why it's a separate PR

This has to land *and reconcile* before the cutover. Both commits in one PR would reach the cluster as a single state, and the protection would never have existed at the moment it was needed.

## Verification

`kubectl diff` through the **parent** kustomization — six objects differing, and every changed line is one of the annotations or labels above:

```
   6 +    app.kubernetes.io/managed-by: Helm
   2 +    helm.sh/resource-policy: keep
   6 +    kustomize.toolkit.fluxcd.io/prune: disabled
   6 +    meta.helm.sh/release-name: postgres
   6 +    meta.helm.sh/release-namespace: mended-drum
   4 +  annotations:
```

Zero spec lines, zero removals.

Worth noting for whoever repeats this on the other ten: diffing the `db/` subdirectory alone is misleading. The namespace is injected by the parent kustomization, so building `db/` renders the objects namespace-less, `kubectl` defaults them to `default`, and the diff reports six brand-new objects with full spec bodies. It looks alarming and means nothing. Build the parent.

## What follows

Once this reconciles: patch the two PVs to `reclaimPolicy: Retain`, take and verify a fresh backup, then the cutover PR replaces the six files with a `repository.yaml` + `release.yaml` pair. The cutover deliberately omits `install.remediation` — its strategy is *uninstall*, which on an adopted Cluster would delete it and its PVCs.

Baseline before starting: cluster healthy 2/2, last backup 15h old, all three ExternalSecrets synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)