### PR TITLE
TEMP: probe whether prune:disabled protects an object

### DIFF
--- a/apps/mended-drum/manifests/db/kustomization.yaml
+++ b/apps/mended-drum/manifests/db/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - credentialsUser.yaml
   - credentialsBackup.yaml
   - objectStore.yaml
+  - prune-test.yaml

--- a/apps/mended-drum/manifests/db/prune-test.yaml
+++ b/apps/mended-drum/manifests/db/prune-test.yaml
@@ -1,0 +1,12 @@
+# TEMPORARY probe. Verifies that kustomize.toolkit.fluxcd.io/prune: disabled
+# actually protects an object from garbage collection in this Flux version,
+# before relying on it to protect a production database during the chart cutover.
+# Removed again in the follow-up commit.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prune-disabled-probe
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+data:
+  purpose: "prune behaviour probe; safe to delete"


### PR DESCRIPTION
Temporary probe, removed in a follow-up. Verifies that `kustomize.toolkit.fluxcd.io/prune: disabled` actually protects an object from garbage collection in Flux 2.9.1 **before** relying on it to protect a production database during the `cnpg-database` cutover.

## Why this exists

The cutover for mended-drum removes six files whose objects must survive, protected by that annotation. But `flux diff` reports all six as **deleted** — including `Cluster/mended-drum/postgres`, whose `ownerReferences` hold the PVCs on `reclaimPolicy: Delete` storage.

I established that `flux diff` computes deletions from inventory-versus-build and does not consult the annotation (the six objects are still listed in the Kustomization's `status.inventory` despite carrying it). So the warning is *probably* a reporting artifact.

"Probably" isn't good enough here, and my plan asserted this annotation works without ever testing it. This proves it on a throwaway ConfigMap.

## Protocol

1. Merge this → `ConfigMap/prune-disabled-probe` is created in `mended-drum`
2. Follow-up commit removes it from git
3. Reconcile → if the ConfigMap **survives**, the annotation works and the cutover is safe
4. If it's **deleted**, the annotation does not protect and the cutover needs a different approach

Either way the ConfigMap is deleted by hand afterwards and both commits are reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)