### PR TITLE
mended-drum: drop the prune guard now adoption is confirmed

### DIFF
--- a/apps/mended-drum/manifests/db/values.yaml
+++ b/apps/mended-drum/manifests/db/values.yaml
@@ -12,10 +12,6 @@ cluster:
     requests:
       cpu: 100m
       memory: 256Mi
-  annotations:
-    # Detaches the Cluster from the Kustomization's prune inventory during the
-    # cutover. Dropped once adoption is confirmed.
-    kustomize.toolkit.fluxcd.io/prune: disabled
 
 backup:
   schedule: "0 30 23 * * *"


### PR DESCRIPTION
Commit C of the CNPG migration sequence for the canary. Removes the
`kustomize.toolkit.fluxcd.io/prune: disabled` annotation that detached the
Cluster from the Kustomization's prune inventory during cutover.

### Why it is safe now

Verified against the live cluster after #953 reconciled:

| check | result |
|---|---|
| HelmRelease | Ready — `cnpg-database@0.1.0`, `postgres.v1` |
| Cluster / ScheduledBackup / ObjectStore | all still `generation: 1` — Helm changed no spec field |
| ExternalSecrets | kept original `2026-06-22T13:38:35Z` creationTimestamps |
| PVC UIDs | unchanged, PVs flipped to `Retain` |
| PGDATA | `PG_VERSION` mtime is still the original initdb time |
| primary promotion | 867h ago — no failover, no pod restart |
| backups | WAL archiving OK, window 2026-06-28 → 2026-07-28 |

### What stays

`helm.sh/resource-policy: keep` on the Cluster and ObjectStore, which the chart
sets from `retain: true`. That is the annotation that actually matters long
term: it stops any Helm action from deleting the Cluster and cascading through
its `ownerReferences` into the PVCs.

Rendered diff is a single removed line. `make validate` green (72 targets).