### PR TITLE
paperless, multimedia: add an explicit kustomization.yaml chain

### DIFF
--- a/apps/multimedia/manifests/kustomization.yaml
+++ b/apps/multimedia/manifests/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - prowlarr/
+  - prowlarrdb/
+  - radarr/
+  - radarrdb/
+  - shared/
+  - sonarr/
+  - sonarrdb/
+  - transmission/

--- a/apps/multimedia/manifests/prowlarr/kustomization.yaml
+++ b/apps/multimedia/manifests/prowlarr/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ingress.yaml
+  - prometheusRule.yaml
+  - service.yaml
+  - serviceAccount.yaml
+  - serviceMonitor.yaml
+  - statefulset.yaml

--- a/apps/multimedia/manifests/prowlarrdb/kustomization.yaml
+++ b/apps/multimedia/manifests/prowlarrdb/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - backup.yaml
+  - cluster.yaml
+  - credentialsAdmin.yaml
+  - credentialsBackup.yaml
+  - credentialsUser.yaml
+  - objectStore.yaml

--- a/apps/multimedia/manifests/radarr/kustomization.yaml
+++ b/apps/multimedia/manifests/radarr/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ingress.yaml
+  - prometheusRule.yaml
+  - service.yaml
+  - serviceAccount.yaml
+  - serviceMonitor.yaml
+  - statefulset.yaml

--- a/apps/multimedia/manifests/radarrdb/kustomization.yaml
+++ b/apps/multimedia/manifests/radarrdb/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - backup.yaml
+  - cluster.yaml
+  - credentialsAdmin.yaml
+  - credentialsBackup.yaml
+  - credentialsUser.yaml
+  - objectStore.yaml

--- a/apps/multimedia/manifests/shared/kustomization.yaml
+++ b/apps/multimedia/manifests/shared/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pv-downloads.yaml
+  - pv-movies.yaml
+  - pv-tv.yaml
+  - pvc-downloads.yaml
+  - pvc-movies.yaml
+  - pvc-tv.yaml

--- a/apps/multimedia/manifests/sonarr/kustomization.yaml
+++ b/apps/multimedia/manifests/sonarr/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ingress.yaml
+  - prometheusRule.yaml
+  - service.yaml
+  - serviceAccount.yaml
+  - serviceMonitor.yaml
+  - statefulset.yaml

--- a/apps/multimedia/manifests/sonarrdb/kustomization.yaml
+++ b/apps/multimedia/manifests/sonarrdb/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - backup.yaml
+  - cluster.yaml
+  - credentialsAdmin.yaml
+  - credentialsBackup.yaml
+  - credentialsUser.yaml
+  - objectStore.yaml

--- a/apps/multimedia/manifests/transmission/kustomization.yaml
+++ b/apps/multimedia/manifests/transmission/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - config.yaml
+  - deployment.yaml
+  - ingress.yaml
+  - podmonitor.yaml
+  - pvc-config.yaml
+  - service.yaml
+  - vpn-credentials.yaml

--- a/apps/paperless/manifests/app/kustomization.yaml
+++ b/apps/paperless/manifests/app/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - config.yaml
+  - databaseSecret.yaml
+  - ingress-cloudflare.yaml
+  - ingress.yaml
+  - middleware.yaml
+  - podMonitor.yaml
+  - prometheusRules.yaml
+  - pvConsume.yaml
+  - pvcBackups.yaml
+  - pvcConsume.yaml
+  - pvcData.yaml
+  - pvcMedia.yaml
+  - secretsExternal.yaml
+  - service.yaml
+  - serviceAccount.yaml
+  - serviceHeadless.yaml
+  - statefulSet.yaml

--- a/apps/paperless/manifests/backups/kustomization.yaml
+++ b/apps/paperless/manifests/backups/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cronjob.yaml

--- a/apps/paperless/manifests/broker/kustomization.yaml
+++ b/apps/paperless/manifests/broker/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - service.yaml
+  - serviceAccount.yaml
+  - serviceMonitor.yaml
+  - statefulSet.yaml

--- a/apps/paperless/manifests/gotenberg/kustomization.yaml
+++ b/apps/paperless/manifests/gotenberg/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/apps/paperless/manifests/kustomization.yaml
+++ b/apps/paperless/manifests/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - app/
+  - backups/
+  - broker/
+  - gotenberg/
+  - postgres/
+  - tika/

--- a/apps/paperless/manifests/postgres/kustomization.yaml
+++ b/apps/paperless/manifests/postgres/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - backup.yaml
+  - cluster.yaml
+  - credentialsAdmin.yaml
+  - credentialsBackup.yaml
+  - credentialsUser.yaml
+  - object-store.yaml
+  - pooler.yaml

--- a/apps/paperless/manifests/tika/kustomization.yaml
+++ b/apps/paperless/manifests/tika/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml


### PR DESCRIPTION
Preparation for the CNPG chart migration. These two apps were the only ones
applied as **plain directories** — no `kustomization.yaml` anywhere under
`spec.path`, so kustomize-controller collected every YAML file recursively and
each manifest carried its own `namespace:` field.

That works today, but it rules out `configMapGenerator`, which is how every
other component feeds Helm values from a `values.yaml`. Without this, paperless
and the three multimedia databases cannot be migrated onto `cnpg-database`
using the repo's established pattern.

### What changed

A parent `kustomization.yaml` listing subdirectories, plus one per
subdirectory. No `namespace:` field at the parent — every manifest already sets
its own, so introducing one would be redundant and could mask a future
omission.

### Verification

Rendered object sets compared against the previous plain-directory behaviour,
matching on `(apiVersion, kind, namespace, name)` and comparing full specs:

| app | objects | result |
|---|---|---|
| paperless | 33 | identical — no additions, removals or spec differences |
| multimedia | 49 | identical — no additions, removals or spec differences |

`make validate` green; target count 72 → 86 as the new kustomizations become
visible to CI.

This also unblocks the chart comparison for these apps: with the chain in
place, paperless and all three multimedia databases render from
`cnpg-database`, and prowlarr/radarr/sonarr come out byte-identical.