### PR TITLE
cnpg: arm the migration guards on the remaining ten databases

### DIFF
--- a/apps/ai-gateway/manifests/db/backup.yaml
+++ b/apps/ai-gateway/manifests/db/backup.yaml
@@ -1,6 +1,8 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres

--- a/apps/ai-gateway/manifests/db/cluster.yaml
+++ b/apps/ai-gateway/manifests/db/cluster.yaml
@@ -1,6 +1,9 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/name: postgres
   name: postgres

--- a/apps/ai-gateway/manifests/db/credentialsAdmin.yaml
+++ b/apps/ai-gateway/manifests/db/credentialsAdmin.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-admin

--- a/apps/ai-gateway/manifests/db/credentialsBackup.yaml
+++ b/apps/ai-gateway/manifests/db/credentialsBackup.yaml
@@ -1,6 +1,8 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-backup

--- a/apps/ai-gateway/manifests/db/credentialsUser.yaml
+++ b/apps/ai-gateway/manifests/db/credentialsUser.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-user

--- a/apps/ai-gateway/manifests/db/objectStore.yaml
+++ b/apps/ai-gateway/manifests/db/objectStore.yaml
@@ -1,6 +1,9 @@
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
   name: backblaze
   namespace: ai-gateway
 spec:

--- a/apps/atuin/manifests/postgres/backup.yaml
+++ b/apps/atuin/manifests/postgres/backup.yaml
@@ -1,6 +1,8 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres

--- a/apps/atuin/manifests/postgres/cluster.yaml
+++ b/apps/atuin/manifests/postgres/cluster.yaml
@@ -1,6 +1,9 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/name: postgres
   name: postgres

--- a/apps/atuin/manifests/postgres/credentialsAdmin.yaml
+++ b/apps/atuin/manifests/postgres/credentialsAdmin.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-admin

--- a/apps/atuin/manifests/postgres/credentialsBackup.yaml
+++ b/apps/atuin/manifests/postgres/credentialsBackup.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-backup

--- a/apps/atuin/manifests/postgres/credentialsUser.yaml
+++ b/apps/atuin/manifests/postgres/credentialsUser.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-user

--- a/apps/atuin/manifests/postgres/objectStore.yaml
+++ b/apps/atuin/manifests/postgres/objectStore.yaml
@@ -1,6 +1,9 @@
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
   name: backblaze
   namespace: atuin
 spec:

--- a/apps/grafana/manifests/postgres/backup.yaml
+++ b/apps/grafana/manifests/postgres/backup.yaml
@@ -1,6 +1,8 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres

--- a/apps/grafana/manifests/postgres/cluster.yaml
+++ b/apps/grafana/manifests/postgres/cluster.yaml
@@ -1,6 +1,9 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/name: postgres
   name: postgres

--- a/apps/grafana/manifests/postgres/credentialsAdmin.yaml
+++ b/apps/grafana/manifests/postgres/credentialsAdmin.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-admin

--- a/apps/grafana/manifests/postgres/credentialsBackup.yaml
+++ b/apps/grafana/manifests/postgres/credentialsBackup.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-backup

--- a/apps/grafana/manifests/postgres/credentialsUser.yaml
+++ b/apps/grafana/manifests/postgres/credentialsUser.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-user

--- a/apps/grafana/manifests/postgres/objectStore.yaml
+++ b/apps/grafana/manifests/postgres/objectStore.yaml
@@ -1,6 +1,9 @@
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
   name: backblaze
 spec:
   retentionPolicy: 3d

--- a/apps/mealie/manifests/db/backup.yaml
+++ b/apps/mealie/manifests/db/backup.yaml
@@ -1,6 +1,8 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres

--- a/apps/mealie/manifests/db/cluster.yaml
+++ b/apps/mealie/manifests/db/cluster.yaml
@@ -1,6 +1,9 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/name: postgres
   name: postgres

--- a/apps/mealie/manifests/db/credentialsAdmin.yaml
+++ b/apps/mealie/manifests/db/credentialsAdmin.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-admin

--- a/apps/mealie/manifests/db/credentialsBackup.yaml
+++ b/apps/mealie/manifests/db/credentialsBackup.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-backup

--- a/apps/mealie/manifests/db/credentialsUser.yaml
+++ b/apps/mealie/manifests/db/credentialsUser.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-user

--- a/apps/mealie/manifests/db/objectStore.yaml
+++ b/apps/mealie/manifests/db/objectStore.yaml
@@ -1,6 +1,9 @@
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
   name: backblaze
   namespace: mealie
 spec:

--- a/apps/multimedia/manifests/prowlarrdb/backup.yaml
+++ b/apps/multimedia/manifests/prowlarrdb/backup.yaml
@@ -1,6 +1,8 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-prowlarr

--- a/apps/multimedia/manifests/prowlarrdb/cluster.yaml
+++ b/apps/multimedia/manifests/prowlarrdb/cluster.yaml
@@ -1,6 +1,9 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-prowlarr

--- a/apps/multimedia/manifests/prowlarrdb/credentialsAdmin.yaml
+++ b/apps/multimedia/manifests/prowlarrdb/credentialsAdmin.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-prowlarr-admin

--- a/apps/multimedia/manifests/prowlarrdb/credentialsBackup.yaml
+++ b/apps/multimedia/manifests/prowlarrdb/credentialsBackup.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-prowlarr-backup

--- a/apps/multimedia/manifests/prowlarrdb/credentialsUser.yaml
+++ b/apps/multimedia/manifests/prowlarrdb/credentialsUser.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-prowlarr-user

--- a/apps/multimedia/manifests/prowlarrdb/objectStore.yaml
+++ b/apps/multimedia/manifests/prowlarrdb/objectStore.yaml
@@ -1,6 +1,9 @@
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
   name: backblaze-prowlarr
   namespace: multimedia
 spec:

--- a/apps/multimedia/manifests/radarrdb/backup.yaml
+++ b/apps/multimedia/manifests/radarrdb/backup.yaml
@@ -1,6 +1,8 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-radarr

--- a/apps/multimedia/manifests/radarrdb/cluster.yaml
+++ b/apps/multimedia/manifests/radarrdb/cluster.yaml
@@ -1,6 +1,9 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-radarr

--- a/apps/multimedia/manifests/radarrdb/credentialsAdmin.yaml
+++ b/apps/multimedia/manifests/radarrdb/credentialsAdmin.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-radarr-admin

--- a/apps/multimedia/manifests/radarrdb/credentialsBackup.yaml
+++ b/apps/multimedia/manifests/radarrdb/credentialsBackup.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-radarr-backup

--- a/apps/multimedia/manifests/radarrdb/credentialsUser.yaml
+++ b/apps/multimedia/manifests/radarrdb/credentialsUser.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-radarr-user

--- a/apps/multimedia/manifests/radarrdb/objectStore.yaml
+++ b/apps/multimedia/manifests/radarrdb/objectStore.yaml
@@ -1,6 +1,9 @@
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
   name: backblaze-radarr
   namespace: multimedia
 spec:

--- a/apps/multimedia/manifests/sonarrdb/backup.yaml
+++ b/apps/multimedia/manifests/sonarrdb/backup.yaml
@@ -1,6 +1,8 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-sonarr

--- a/apps/multimedia/manifests/sonarrdb/cluster.yaml
+++ b/apps/multimedia/manifests/sonarrdb/cluster.yaml
@@ -1,6 +1,9 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-sonarr

--- a/apps/multimedia/manifests/sonarrdb/credentialsAdmin.yaml
+++ b/apps/multimedia/manifests/sonarrdb/credentialsAdmin.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-sonarr-admin

--- a/apps/multimedia/manifests/sonarrdb/credentialsBackup.yaml
+++ b/apps/multimedia/manifests/sonarrdb/credentialsBackup.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-sonarr-backup

--- a/apps/multimedia/manifests/sonarrdb/credentialsUser.yaml
+++ b/apps/multimedia/manifests/sonarrdb/credentialsUser.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-sonarr-user

--- a/apps/multimedia/manifests/sonarrdb/objectStore.yaml
+++ b/apps/multimedia/manifests/sonarrdb/objectStore.yaml
@@ -1,6 +1,9 @@
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
   name: backblaze-sonarr
   namespace: multimedia
 spec:

--- a/apps/paperless/manifests/postgres/backup.yaml
+++ b/apps/paperless/manifests/postgres/backup.yaml
@@ -1,6 +1,8 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres

--- a/apps/paperless/manifests/postgres/cluster.yaml
+++ b/apps/paperless/manifests/postgres/cluster.yaml
@@ -1,6 +1,9 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/name: postgres
   name: postgres

--- a/apps/paperless/manifests/postgres/credentialsAdmin.yaml
+++ b/apps/paperless/manifests/postgres/credentialsAdmin.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-admin

--- a/apps/paperless/manifests/postgres/credentialsBackup.yaml
+++ b/apps/paperless/manifests/postgres/credentialsBackup.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-backup

--- a/apps/paperless/manifests/postgres/credentialsUser.yaml
+++ b/apps/paperless/manifests/postgres/credentialsUser.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-user

--- a/apps/paperless/manifests/postgres/object-store.yaml
+++ b/apps/paperless/manifests/postgres/object-store.yaml
@@ -1,6 +1,9 @@
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
   name: backblaze
   namespace: paperless
 spec:

--- a/apps/paperless/manifests/postgres/pooler.yaml
+++ b/apps/paperless/manifests/postgres/pooler.yaml
@@ -1,6 +1,8 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Pooler
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
   name: pooler
   namespace: paperless
 spec:

--- a/apps/photos/postgres-backup.yaml
+++ b/apps/photos/postgres-backup.yaml
@@ -1,6 +1,8 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres

--- a/apps/photos/postgres-cluster.yaml
+++ b/apps/photos/postgres-cluster.yaml
@@ -1,6 +1,9 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/name: postgres
   name: postgres

--- a/apps/photos/postgres-creds-admin.yaml
+++ b/apps/photos/postgres-creds-admin.yaml
@@ -1,6 +1,8 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-admin

--- a/apps/photos/postgres-creds-backup.yaml
+++ b/apps/photos/postgres-creds-backup.yaml
@@ -1,6 +1,8 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-backup

--- a/apps/photos/postgres-creds-user.yaml
+++ b/apps/photos/postgres-creds-user.yaml
@@ -1,6 +1,8 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-user

--- a/apps/photos/postgres-object-store.yaml
+++ b/apps/photos/postgres-object-store.yaml
@@ -1,6 +1,9 @@
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
   name: backblaze
 spec:
   retentionPolicy: 14d

--- a/apps/pocket-id/manifests/postgres/backup.yaml
+++ b/apps/pocket-id/manifests/postgres/backup.yaml
@@ -1,6 +1,8 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres

--- a/apps/pocket-id/manifests/postgres/cluster.yaml
+++ b/apps/pocket-id/manifests/postgres/cluster.yaml
@@ -1,6 +1,9 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/name: postgres
   name: postgres

--- a/apps/pocket-id/manifests/postgres/credentialsAdmin.yaml
+++ b/apps/pocket-id/manifests/postgres/credentialsAdmin.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-admin

--- a/apps/pocket-id/manifests/postgres/credentialsBackup.yaml
+++ b/apps/pocket-id/manifests/postgres/credentialsBackup.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-backup

--- a/apps/pocket-id/manifests/postgres/credentialsUser.yaml
+++ b/apps/pocket-id/manifests/postgres/credentialsUser.yaml
@@ -3,6 +3,7 @@ kind: ExternalSecret
 metadata:
   annotations:
     cnpg.io/reload: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: postgres
   name: postgres-user

--- a/apps/pocket-id/manifests/postgres/objectStore.yaml
+++ b/apps/pocket-id/manifests/postgres/objectStore.yaml
@@ -1,6 +1,9 @@
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    helm.sh/resource-policy: keep
   name: backblaze
 spec:
   retentionPolicy: 30d


### PR DESCRIPTION
Metadata only, no restarts. Prepares every database still on hand-written
manifests for the move onto `cnpg-database`, following the sequence the
mended-drum canary proved end to end.

### What it adds

| annotation | objects | why |
|---|---|---|
| `kustomize.toolkit.fluxcd.io/prune: disabled` | all 61 | at cutover, kustomize-controller applies the HelmRelease and prunes the removed YAML in **one** reconcile against its own inventory. Without this the Cluster is deleted in that window, and its `ownerReferences` take the PVCs with it. |
| `helm.sh/resource-policy: keep` | 10 Clusters, 10 ObjectStores | once Helm owns them, no Helm action — including an install-remediation *uninstall* — can delete them. |

61 objects: 10 Cluster, 10 ObjectStore, 10 ScheduledBackup, 30 ExternalSecret,
1 Pooler.

### Why textual insertions, not yq

A `yq -i` round-trip reindents nested sequences. The same logical change came out
as 165 insertions and 49 deletions, burying two meaningful lines per file in
stylistic churn — not something to review against running databases. Inserting
the lines directly gives **116 insertions, 0 deletions**.

### Verification

Every changed file parsed on both sides and compared against `master`: the only
difference anywhere is an added guard annotation. Nothing outside
`metadata.annotations` moved, no existing annotation was removed or altered, and
`resource-policy: keep` appears on exactly the Clusters and ObjectStores.

`make validate` green.

### Out of band, already done

All 24 remaining Postgres PVs flipped from `reclaimPolicy: Delete` to `Retain`
(26/26 now `Retain`). On `lvm-thin` — node-local, single-copy thin LVM — `Delete`
meant a deleted PVC destroyed the logical volume. This is the plan's
cheapest-highest-value safeguard and is arguably permanent for databases.

Backups also re-verified before arming: all 11 clusters have a base backup from
2026-07-27/28, including the five that had been stalled since December.

The guards come off per app after each cutover is confirmed, as in #954.