### PR TITLE
CLAUDE.md: correct how the prune guard actually comes off

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,16 @@ Sequence, as separate PRs — one state per merge:
 3. Replace the manifests with `release.yaml` + `values.yaml`. Never copy
    `install.remediation` from another release — its strategy is *uninstall*, which
    on an adopted Cluster deletes it and its PVCs.
-4. Drop the prune annotation via a values change.
+4. Drop the prune annotation from `values.yaml`, then **remove it from the live
+   objects by hand** — `kubectl annotate <kind> <name> kustomize.toolkit.fluxcd.io/prune-`
+   on all six. A values change alone does not do it. The chart only ever rendered
+   the annotation on the Cluster, so Helm has nothing to strip from the other
+   five; and even on the Cluster, kustomize-controller still holds server-side
+   apply ownership of that field from before the cutover. Under SSA a field lives
+   as long as any manager claims it, and kustomize-controller never applies the
+   object again — it is gone from the Kustomization's inventory — so its claim is
+   a fossil that never expires. Verify with
+   `kubectl get ... -o json --show-managed-fields=true`.
 
 Helm adopts existing objects without ownership metadata: `disableTakeOwnership`
 defaults to false. Rendered resource names must match what's live — `postgres-rw`


### PR DESCRIPTION
#954 said Helm's three-way merge would strip
`kustomize.toolkit.fluxcd.io/prune` on the next upgrade. It doesn't — all six
mended-drum objects still carried it three releases later. Found while verifying
that PR against the cluster.

### Why

Two separate reasons:

1. **The chart only renders that annotation on the Cluster** (via
   `cluster.annotations`). The ScheduledBackup, ObjectStore and three
   ExternalSecrets got it from the arming commit, applied by
   kustomize-controller — Helm has nothing to strip from them.
2. **On the Cluster, kustomize-controller still owns the field.** Helm did drop
   it from its manifest and field set at revision 2:

   | revision | rendered Cluster annotations |
   |---|---|
   | 1 | `resource-policy: keep`, `prune: disabled` |
   | 2, 3 | `resource-policy: keep` |

   But `managedFields` shows `kustomize-controller` still claiming
   `f:kustomize.toolkit.fluxcd.io/prune` alongside `helm-controller`, which no
   longer does. Under server-side apply a field lives as long as *any* manager
   claims it, and kustomize-controller will never apply this object again — it
   left the Kustomization's inventory when the YAML was deleted (inventory is now
   just the ConfigMap and the HelmRelease). The claim is a fossil that never
   expires.

Same mechanism as the stale `managedFields` that broke three Kustomizations
during the Flux 2.9.1 upgrade.

### Done

Removed by hand on all six objects. They stayed removed through a forced
reconcile, with `helm.sh/resource-policy: keep` still in place on the Cluster and
ObjectStore and the Cluster healthy at `generation: 1`.

This matters for the ten databases armed in #956 — step 4 needs the manual
removal each time, not just a values edit.