### PR TITLE
photos: resume reconciliation and pin the ServiceMonitor jobLabel

### DIFF
--- a/apps/photos/release.yaml
+++ b/apps/photos/release.yaml
@@ -29,4 +29,3 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: values
-  suspend: true

--- a/apps/photos/values.yaml
+++ b/apps/photos/values.yaml
@@ -43,7 +43,10 @@ valkey:
 server:
   controllers:
     main:
-      replicas: 3
+      # Matches what has actually been running since before 2025-11-30. git said
+      # 3, the cluster ran 2, and no field manager claimed the field, so an
+      # upgrade might or might not have scaled up. Declaring 2 settles it.
+      replicas: 2
       strategy: RollingUpdate
       rollingUpdate:
         unavailable: 1

--- a/apps/photos/values.yaml
+++ b/apps/photos/values.yaml
@@ -63,6 +63,14 @@ server:
               cpu: 100m
               memory: 160Mi
 
+  serviceMonitor:
+    main:
+      # Chart 0.12.0 switched the default to app.kubernetes.io/name, whose value
+      # here is "server" -- a label that says nothing and collides with anything
+      # else generic. app.kubernetes.io/service carries "immich-server", so this
+      # keeps job="immich-server" and existing series stay continuous.
+      jobLabel: app.kubernetes.io/service
+
   ingress:
     main:
       enabled: true

--- a/base/flux-apps/photos.yaml
+++ b/base/flux-apps/photos.yaml
@@ -10,4 +10,3 @@ spec:
   sourceRef:
     kind: GitRepository
     name: ankhmorpork
-  suspend: true


### PR DESCRIPTION
Removes `suspend` from **both** switches — the Kustomization
(`base/flux-apps/photos.yaml`) and the HelmRelease (`apps/photos/release.yaml`) —
after auditing what resuming actually does. photos froze at `21aba685` on
2025-12-24, 306 commits back, while the app itself stayed healthy.

## The audit came out clean

Every hand-edit from the February barman migration has since been codified in
git, so **resuming reverts nothing**:

| object | hand-edited field | status |
|---|---|---|
| `Cluster/postgres` | `spec.storage.size`, `spec.plugins` | matches git |
| `ObjectStore/backblaze` | entire `spec.configuration` | matches git |
| `PVC/postgres-11`, `-16` | `spec.resources.requests.storage` | matches git |
| `Ingress/immich-server` | `probe-uri`, `probetest`, `ingressClassName` (2024) | untouched by git |

The `values` ConfigMap was byte-identical (`values-97b264bd8f`, 239d old), so the
chart version was the only pending HelmRelease change.

**The immich image is `v2.3.1` on both sides.** This is a chart upgrade, not an
application upgrade — no database migration is involved. That is the main reason
this is safe.

## Complete upgrade delta, 0.10.3 → 0.12.0

Rendered both versions and diffed. This is everything:

- 3 new ServiceAccounts; Deployments move off `default` and set
  `automountServiceAccountToken: false`
- valkey `9.0-alpine` → `9.1-alpine`
- `Service/immich-server` gains `appProtocol: kubernetes.io/ws`
- `ServiceMonitor` `jobLabel` (see below)

No env, volume, probe, resource, PVC, Ingress-spec or PDB changes.

## The jobLabel override

Chart 0.12.0 defaults `jobLabel` to `app.kubernetes.io/name`, whose value here is
`server` — so Prometheus would relabel `job="immich-server"` to `job="server"`,
a name that says nothing and collides with anything else generic. Nothing in the
repo keys on it, but the series would break continuity.

`app.kubernetes.io/service` carries `immich-server`, so pointing at that keeps
`job="immich-server"` while referencing a label that actually exists — the old
`jobLabel: immich-server` only worked by falling back to the Service name.

Verified the chart's merge order allows this: `templates/server.yaml` hardcodes
only `serviceMonitor.main.enabled` and `.endpoints`, so a user-supplied
`jobLabel` merges in. Rendered output confirms both endpoints survive.

## Kustomization-layer effects

- adopts `ObjectStore/backblaze` into the inventory — hand-created in February,
  never Flux-managed
- **prunes `ObjectStore/minio`** — dead since 2025-12-19, referenced by nothing
  (the Cluster's plugin names `backblaze` only). Verified it is the sole prune
  candidate by diffing the Kustomization inventory against the git build.
- applies the migration guards from #956, which never reached photos

## Expected disruption

- rolling restart of all three deployments, from the ServiceAccount change.
  PDB `minAvailable: 1` with `maxUnavailable: 1` covers the server.
- valkey loses its job queue. Already `emptyDir`, so already ephemeral —
  background jobs re-queue.

## To verify after merge

- `ObjectStore/minio` gone, `backblaze` labelled with the Flux inventory
- HelmRelease Ready at `immich@0.12.0`, three pods back up
- Prometheus target still shows `job="immich-server"`
Replicas are no longer a question — see below.

### immich-server replicas

git said 3, the cluster has run 2 since before 2025-11-30, and no field manager
claimed `.spec.replicas`, so whether the upgrade would scale up was genuinely
unpredictable: Helm's three-way merge is documented to revert drift like this,
yet release v42 applied a manifest saying 3 in December and live stayed 2.

Rather than leave that to merge semantics, `values.yaml` now declares
`replicas: 2` to match what is actually running. A server-side dry run confirms
the Deployment shows no replica change, and the only remaining diffs are the
intended chart upgrade.

Release history is intact at v42, so a failed upgrade can be rolled back.
`make validate` green.
