### PR TITLE
cnpg: drop the prune guard from the eight adopted databases

### DIFF
--- a/apps/ai-gateway/manifests/db/values.yaml
+++ b/apps/ai-gateway/manifests/db/values.yaml
@@ -12,10 +12,6 @@ cluster:
     requests:
       cpu: 100m
       memory: 256Mi
-  annotations:
-    # Keeps the Cluster out of the Kustomization's prune inventory while the old
-    # manifests are removed. Dropped once adoption is confirmed.
-    kustomize.toolkit.fluxcd.io/prune: disabled
 
 backup:
   schedule: "0 30 23 * * *"

--- a/apps/atuin/manifests/postgres/values.yaml
+++ b/apps/atuin/manifests/postgres/values.yaml
@@ -20,10 +20,6 @@ cluster:
       memory: 300Mi
   bootstrap:
     enabled: false
-  annotations:
-    # Keeps the Cluster out of the Kustomization's prune inventory while the old
-    # manifests are removed. Dropped once adoption is confirmed.
-    kustomize.toolkit.fluxcd.io/prune: disabled
 
 backup:
   schedule: "0 17 23 * * *"

--- a/apps/grafana/manifests/postgres/values.yaml
+++ b/apps/grafana/manifests/postgres/values.yaml
@@ -12,10 +12,6 @@ cluster:
     requests:
       cpu: 130m
       memory: 300Mi
-  annotations:
-    # Keeps the Cluster out of the Kustomization's prune inventory while the old
-    # manifests are removed. Dropped once adoption is confirmed.
-    kustomize.toolkit.fluxcd.io/prune: disabled
 
 backup:
   schedule: "0 17 23 * * *"

--- a/apps/mealie/manifests/db/values.yaml
+++ b/apps/mealie/manifests/db/values.yaml
@@ -12,10 +12,6 @@ cluster:
     requests:
       cpu: 130m
       memory: 300Mi
-  annotations:
-    # Keeps the Cluster out of the Kustomization's prune inventory while the old
-    # manifests are removed. Dropped once adoption is confirmed.
-    kustomize.toolkit.fluxcd.io/prune: disabled
 
 backup:
   schedule: "0 17 23 * * *"

--- a/apps/multimedia/manifests/prowlarrdb/values.yaml
+++ b/apps/multimedia/manifests/prowlarrdb/values.yaml
@@ -14,10 +14,6 @@ cluster:
     postInitSQL:
       - CREATE DATABASE logs;
       - ALTER DATABASE logs OWNER TO prowlarr;
-  annotations:
-    # Keeps the Cluster out of the Kustomization's prune inventory while the old
-    # manifests are removed. Dropped once adoption is confirmed.
-    kustomize.toolkit.fluxcd.io/prune: disabled
 
 backup:
   schedule: "0 7 3 * * *"

--- a/apps/multimedia/manifests/radarrdb/values.yaml
+++ b/apps/multimedia/manifests/radarrdb/values.yaml
@@ -18,10 +18,6 @@ cluster:
     postInitSQL:
       - CREATE DATABASE logs;
       - ALTER DATABASE logs OWNER TO radarr;
-  annotations:
-    # Keeps the Cluster out of the Kustomization's prune inventory while the old
-    # manifests are removed. Dropped once adoption is confirmed.
-    kustomize.toolkit.fluxcd.io/prune: disabled
 
 backup:
   schedule: "0 17 3 * * *"

--- a/apps/multimedia/manifests/sonarrdb/values.yaml
+++ b/apps/multimedia/manifests/sonarrdb/values.yaml
@@ -14,10 +14,6 @@ cluster:
     postInitSQL:
       - CREATE DATABASE logs;
       - ALTER DATABASE logs OWNER TO sonarr;
-  annotations:
-    # Keeps the Cluster out of the Kustomization's prune inventory while the old
-    # manifests are removed. Dropped once adoption is confirmed.
-    kustomize.toolkit.fluxcd.io/prune: disabled
 
 backup:
   schedule: "0 27 3 * * *"

--- a/apps/pocket-id/manifests/postgres/values.yaml
+++ b/apps/pocket-id/manifests/postgres/values.yaml
@@ -12,10 +12,6 @@ cluster:
     requests:
       cpu: 130m
       memory: 300Mi
-  annotations:
-    # Keeps the Cluster out of the Kustomization's prune inventory while the old
-    # manifests are removed. Dropped once adoption is confirmed.
-    kustomize.toolkit.fluxcd.io/prune: disabled
 
 backup:
   schedule: "0 17 23 * * *"


### PR DESCRIPTION
Step 4 of the migration sequence for **ai-gateway, mealie, pocket-id, atuin,
grafana** and the **three multimedia clusters**. The annotation kept each Cluster
out of the Kustomization's prune inventory while the hand-written manifests were
removed. All eight are adopted and verified, so it has no further job.

### Adoption was confirmed before this

Each app was checked after its merge against a snapshot taken beforehand —
object generations, PVC UIDs and pod creation timestamps all unchanged, every
cluster healthy:

| app | objects verified unchanged |
|---|---|
| ai-gateway | 7 |
| mealie | 9 |
| pocket-id | 9 |
| atuin | 7 |
| grafana | 7 |
| multimedia (×3) | 21 |

Note the invariant is **generation unchanged**, not `generation == 1` — across
the fleet these sit anywhere from 1 to 11.

### What stays

`helm.sh/resource-policy: keep` on all eight Clusters and ObjectStores. That is
the annotation that matters long term: it stops any Helm action, including an
install-remediation uninstall, from deleting a Cluster and cascading through
`ownerReferences` into its PVCs. Confirmed present in the rendered output for all
eight after this change.

Diff is exactly 32 removed lines — the four-line guard block × 8 files, nothing
else. `make validate` green.

### This is only half the job

Removing the annotation from what the chart renders does **not** remove it from
the live objects. kustomize-controller still holds server-side apply ownership of
that field from before each cutover, and under SSA a field survives while any
manager claims it — it will never apply those objects again, so the claim is a
fossil. See #957.

`kubectl annotate <kind> <name> kustomize.toolkit.fluxcd.io/prune-` on each live
object follows immediately after this merges.

### Not included

paperless and photos. Their cutovers (#964, #969) have not merged yet and they
still need the guard.