### PR TITLE
cnpg: drop the prune guard from paperless and photos

### DIFF
--- a/apps/paperless/manifests/postgres/values.yaml
+++ b/apps/paperless/manifests/postgres/values.yaml
@@ -13,10 +13,6 @@ cluster:
     requests:
       cpu: 100m
       memory: 400Mi
-  annotations:
-    # Keeps the Cluster out of the Kustomization's prune inventory while the old
-    # manifests are removed. Dropped once adoption is confirmed.
-    kustomize.toolkit.fluxcd.io/prune: disabled
 
 backup:
   schedule: "0 36 22 * * *"

--- a/apps/photos/postgres-values.yaml
+++ b/apps/photos/postgres-values.yaml
@@ -22,10 +22,6 @@ cluster:
       - 'CREATE EXTENSION IF NOT EXISTS cube WITH SCHEMA pg_catalog;'
       - 'CREATE EXTENSION IF NOT EXISTS earthdistance WITH SCHEMA pg_catalog;'
       - 'ALTER SCHEMA vectors OWNER TO immich;'
-  annotations:
-    # Keeps the Cluster out of the Kustomization's prune inventory while the old
-    # manifests are removed. Dropped once adoption is confirmed.
-    kustomize.toolkit.fluxcd.io/prune: disabled
 
 backup:
   schedule: "0 13 2 * * *"


### PR DESCRIPTION
Step 4 for the last two databases. Both are adopted and verified, so the guard
has no further job. **This completes the migration — all eleven databases are on
the `cnpg-database` chart with no guards left.**

### Adoption confirmed first

Against snapshots taken before each merge — generations, PVC UIDs and pod
creation timestamps all unchanged, both clusters healthy:

| app | objects verified unchanged |
|---|---|
| paperless | 10 |
| photos | 9 |

Two specific risks were checked and cleared:

- **paperless's Pooler** stayed at `generation: 2`, and its pgbouncer Deployment
  kept the `cnpg.io/poolerName` selector with 2/2 ready. The extra
  `app.kubernetes.io/name` label the chart adds was as harmless as predicted —
  Deployment labels are generated wholly by CloudNativePG and do not inherit the
  Pooler's.
- **photos kept immich's hashed values ConfigMap** (`values-km8ftc4tk8`), so the
  immich release stayed at revision 43 instead of being upgraded for nothing.
  That is what the per-generator `disableNameSuffixHash` was for.

### Backups

Fresh base backups taken and confirmed `completed` immediately before each
cutover, with both object stores' `lastSuccessfulBackupTime` advancing:

| app | backup | window advanced to |
|---|---|---|
| paperless | `postgres-precutover-202607290627` | 2026-07-29T06:27:46Z |
| photos | `postgres-precutover-202607290627` | 2026-07-29T06:28:14Z |

### What stays

`helm.sh/resource-policy: keep` on both Clusters and ObjectStores.

Removing the annotation from the live objects still needs `kubectl annotate`,
for the reason in #957 — kustomize-controller holds server-side apply ownership
of that field and never relinquishes it. That follows immediately.

`make validate` green.