### PR TITLE
mended-drum: canary cnpg-database 0.2.0, which fixes cnpg.io/reload

### DIFF
--- a/apps/mended-drum/manifests/db/release.yaml
+++ b/apps/mended-drum/manifests/db/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.1.1"
+      version: "0.2.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts


### PR DESCRIPTION
Canary for [thaum-xyz/helm-charts#3](https://github.com/thaum-xyz/helm-charts/pull/3).
One-line change: chart `0.1.1` → `0.2.0` for mended-drum only.

### What 0.2.0 changes

`cnpg.io/reload` moves from an **annotation on the ExternalSecret** to a **label
on the generated Secret**, via `spec.target.template.metadata`. That is where
CloudNativePG documents it — under predefined *labels*, "Available on `ConfigMap`
and `Secret` resources. When set to `true`, a change in the resource is
automatically reloaded by the operator" — and the only placement where a rotated
Doppler password actually triggers a reload.

Rendered result for this app:

| ExternalSecret | ExternalSecret annotations | `template.metadata` | `mergePolicy` |
|---|---|---|---|
| `postgres-admin` | none | `labels.cnpg.io/reload: "true"` | — |
| `postgres-user` | none | `labels.cnpg.io/reload: "true"` | — |
| `postgres-backup` | none | `labels.cnpg.io/reload: "true"` | **Merge** |

### Why this is a canary rather than a fleet-wide bump

The backup ExternalSecret's new template carries **metadata only**. External
Secrets defaults to `mergePolicy: Replace`, which keeps *just* the templated
content — and for a data-less template that means **a Secret with no keys at
all**. The chart sets `mergePolicy: Merge` precisely to avoid this, but the
failure mode is silently emptying the object-store credentials, so it is worth
confirming on one database before the other ten follow.

mended-drum is the right subject: smallest database, non-critical consumer, and
the one already used as the migration canary.

### To verify after merge

1. `postgres-backup` still holds `S3_ACCESS_KEY` and `S3_SECRET_KEY`, with
   unchanged values.
2. All three Secrets gain `cnpg.io/reload: "true"` as a **label**.
3. The Cluster's generation is unchanged and the cluster stays healthy.
4. A backup still completes.

Then the remaining ten follow in one PR.

`make validate` green; full chain rendered with `flux-build` and inspected.