### PR TITLE
cnpg: roll cnpg-database 0.2.0 to the remaining ten databases

### DIFF
--- a/apps/ai-gateway/manifests/db/release.yaml
+++ b/apps/ai-gateway/manifests/db/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.1.1"
+      version: "0.2.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/apps/atuin/manifests/postgres/release.yaml
+++ b/apps/atuin/manifests/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.1.1"
+      version: "0.2.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/apps/grafana/manifests/postgres/release.yaml
+++ b/apps/grafana/manifests/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.1.1"
+      version: "0.2.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/apps/mealie/manifests/db/release.yaml
+++ b/apps/mealie/manifests/db/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.1.1"
+      version: "0.2.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/apps/multimedia/manifests/prowlarrdb/release.yaml
+++ b/apps/multimedia/manifests/prowlarrdb/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.1.1"
+      version: "0.2.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/apps/multimedia/manifests/radarrdb/release.yaml
+++ b/apps/multimedia/manifests/radarrdb/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.1.1"
+      version: "0.2.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/apps/multimedia/manifests/sonarrdb/release.yaml
+++ b/apps/multimedia/manifests/sonarrdb/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.1.1"
+      version: "0.2.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/apps/paperless/manifests/postgres/release.yaml
+++ b/apps/paperless/manifests/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.1.1"
+      version: "0.2.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/apps/photos/postgres-release.yaml
+++ b/apps/photos/postgres-release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.1.1"
+      version: "0.2.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/apps/photos/postgres-values.yaml
+++ b/apps/photos/postgres-values.yaml
@@ -30,9 +30,6 @@ backup:
     pathSuffix: photos
 
 externalSecrets:
-  # null, not {}: Helm deep-merges maps, so {} would leave the chart's default
-  # cnpg.io/reload in place. These three ExternalSecrets carry none live.
-  annotations: null
   admin:
     remoteKey: IMMICH_POSTGRES_ADMIN_PASS
   user:

--- a/apps/pocket-id/manifests/postgres/release.yaml
+++ b/apps/pocket-id/manifests/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.1.1"
+      version: "0.2.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts


### PR DESCRIPTION
Follows the mended-drum canary in #972. Bumps the other ten databases to chart
`0.2.0`.

> [!IMPORTANT]
> **Do not merge until #972 is confirmed on the cluster.** The backup
> ExternalSecret's new template carries metadata only, and if `mergePolicy: Merge`
> did not behave as documented, the Secret would come back with **no keys**,
> taking the object-store credentials with it. That is the one thing the canary
> exists to rule out.

### What 0.2.0 changes

`cnpg.io/reload` moves from an annotation on the ExternalSecret to a **label on
the generated Secret**, via `spec.target.template.metadata`. CloudNativePG
documents it under predefined *labels* — "Available on `ConfigMap` and `Secret`
resources. When set to `true`, a change in the resource is automatically reloaded
by the operator" — so the previous placement did nothing.

Verified in the rendered chain for every app, including the awkward ones:

| app | admin / user | backup |
|---|---|---|
| photos | `labels.cnpg.io/reload` | + `mergePolicy: Merge` |
| paperless | `labels.cnpg.io/reload` | + `mergePolicy: Merge` |
| multimedia ×3 | `labels.cnpg.io/reload` | + `mergePolicy: Merge` |

### Also in here

Drops photos' `externalSecrets.annotations: null`. That existed only to clear a
default that no longer exists — 0.2.0 defaults the annotations knob to empty, and
photos now gets the reload label like everything else, so the fleet is uniform.

### Verification

`make validate` green (86 targets). Full Flux chain rendered with `flux-build`
for photos, paperless and multimedia and inspected object by object.

### After merge

Confirm across the fleet that each `postgres-backup` Secret still holds both S3
keys, and that all Secrets carry the `cnpg.io/reload` label. Then a password
rotation in Doppler should propagate without a manual restart — which is the
whole point.