### PR TITLE
renovate: fix three config gaps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -46,8 +46,8 @@
     },
     {
       "customType": "regex",
-      "fileMatch": [
-        "^\\.github\\/workflows\\/[^/]+\\.ya?ml$"
+      "managerFilePatterns": [
+        "/^\\.github\\/workflows\\/[^/]+\\.ya?ml$/"
       ],
       "matchStrings": [
         "kustomize-version:\\s(?<currentValue>.*?)\\n"
@@ -58,8 +58,8 @@
     },
     {
       "customType": "regex",
-      "fileMatch": [
-        "^\\.github\\/workflows\\/[^/]+\\.ya?ml$"
+      "managerFilePatterns": [
+        "/^\\.github\\/workflows\\/[^/]+\\.ya?ml$/"
       ],
       "matchStrings": [
         "kubescape-version:\\s(?<currentValue>.*?)\\n"
@@ -69,8 +69,8 @@
     },
     {
       "customType": "regex",
-      "fileMatch": [
-        "^\\.github\\/workflows\\/[^/]+\\.ya?ml$"
+      "managerFilePatterns": [
+        "/^\\.github\\/workflows\\/[^/]+\\.ya?ml$/"
       ],
       "matchStrings": [
         "yq-version:\\s(?<currentValue>.*?)\\n"
@@ -92,13 +92,25 @@
       "automerge": true
     },
     {
+      "description": "Bare metal: its own group, deliberately never automerged. Sharing a groupName with base/** put these in the same PR, which inherited automerge and defeated the point.",
       "addLabels": [
         "dependencies/hosting"
       ],
-      "groupName": "hosting infrastructure",
+      "groupName": "bare metal",
       "matchFileNames": [
         "metal/**"
       ]
+    },
+    {
+      "description": "core/ bootstraps the cluster (cert-manager, external-secrets, flux2). Soaked and labelled, deliberately not automerged: a bad flux2 or cert-manager bump takes everything else with it.",
+      "addLabels": [
+        "dependencies/core"
+      ],
+      "groupName": "core infrastructure",
+      "matchFileNames": [
+        "core/**"
+      ],
+      "minimumReleaseAge": "10 days"
     },
     {
       "addLabels": [
@@ -125,19 +137,6 @@
       "automerge": true
     },
     {
-      "versioning": "regex:^RELEASE\\.(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})",
-      "addLabels": [
-        "dependencies/apps",
-        "dependencies/automerge"
-      ],
-      "groupName": "applications",
-      "minimumReleaseAge": "20 days",
-      "automerge": true,
-      "matchPackageNames": [
-        "/^minio/"
-      ]
-    },
-    {
       "description": "Own images (ghcr.io/thaum-xyz/*): skip the 20-day apps soak so CalVer bumps deploy fast (interim until Flux Image Automation)",
       "matchPackageNames": [
         "/^ghcr\\.io\\/thaum-xyz\\//"
@@ -154,13 +153,14 @@
   "kubernetes": {
     "managerFilePatterns": [
       "base/**",
-      "apps/**"
+      "apps/**",
+      "core/**"
     ]
   },
   "flux": {
     "managerFilePatterns": [
-      "/(?:^|/)release\\.ya?ml$/",
-      "/(?:^|/)repository\\.ya?ml$/"
+      "/(?:^|/)[^/]*release\\.ya?ml$/",
+      "/(?:^|/)[^/]*repository\\.ya?ml$/"
     ]
   }
 }


### PR DESCRIPTION
Three real problems in `.github/renovate.json`, plus the `fileMatch` rename I
introduced myself.

## 1. photos' database chart was invisible to Renovate

The flux manager matched `(?:^|/)release\.ya?ml$`. photos is the one flat app
directory, so its files are prefixed — `postgres-release.yaml` and
`postgres-repository.yaml` — and neither matched. Its `cnpg-database` chart would
never have been bumped.

Both patterns now allow a prefix. Verified against every tracked file:

| pattern | before | after | newly covered | lost |
|---|---|---|---|---|
| release | 44 | 45 | `apps/photos/postgres-release.yaml` | none |
| repository | 40 | 41 | `apps/photos/postgres-repository.yaml` | none |

## 2. `metal/**` could ride along in an automerged PR

`metal/**` and `base/**` shared `groupName: "hosting infrastructure"`, so they
landed in the same PR. `base/**` sets `automerge: true`; `metal/**` deliberately
does not — and a shared group made that distinction meaningless. `metal/**` now
has its own group.

Expect the stale #802 to be recreated without the metal deps, which is the point.

## 3. `core/**` had no rule at all

`core/` holds cert-manager, external-secrets, flux2 and cilium. The flux manager
was already picking their HelmReleases up, but with no matching `packageRule` they
arrived **ungrouped, unlabelled and with no soak**.

Now grouped as `core infrastructure`, labelled, 10-day soak, and **deliberately
not automerged** — a bad flux2 or cert-manager bump takes the rest of the cluster
with it.

`core/**` is also added to the `kubernetes` manager for symmetry with `base` and
`apps`. That adds no dependencies today — core has no bare `image:` references —
but it stops the gap reopening when one appears.

## Plus the `fileMatch` rename, which is mine to clean up

Three `customManagers` used the deprecated `fileMatch`, and the dead `minio`
packageRule is dropped (minio removed in `4ebc9f4a`).

To be clear about provenance: this is **not** something Renovate missed.
`d22fb6af` (#937) migrated the entire file on 2026-07-27, and `eb253e64`
reintroduced `fileMatch` the next morning when those three managers were added —
by me. Renovate is already offering to fix it again: the Dependency Dashboard
(#114) carries a **"Config Migration Needed"** checkbox for exactly this.

Doing it here just saves the round-trip, since the file is being edited anyway.

> An earlier revision of this PR also added a `renovate-config-validator` job to
> CI, on the false premise that the deprecated syntax had gone unnoticed. It
> hadn't — Renovate flags renames via migration PRs and the dashboard on its own.
> That job has been removed; the diff is now `renovate.json` only.

Config validates clean against Renovate 44.0.1 with `--strict`.