### PR TITLE
Add flux-app-change skill, trim CLAUDE.md

### DIFF
--- a/.claude/skills/flux-app-change/SKILL.md
+++ b/.claude/skills/flux-app-change/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: flux-app-change
+description: Change an app in thaum-xyz/ankhmorpork and prove it safe — kustomizeconfig removal, chart/image upgrades, or any edit that alters what Flux applies. Use when editing anything under apps/, base/ or core/, or when converting an app off kustomizeconfig.yaml.
+---
+
+# Changing a Flux-managed app
+
+## Prove the render before touching the cluster
+
+1. Capture the baseline **before editing**: `kustomize build <parent> > before.yaml`.
+2. Edit, then `kustomize build <parent> > after.yaml`.
+3. Compare object *sets* keyed on `(apiVersion, kind, namespace, name)`, then full
+   specs. Anything unintended is a real change to a running workload.
+
+For anything involving a HelmRelease, `kustomize build` is not enough — it does
+not render the chart. Use `flux-build --api-versions monitoring.coreos.com/v1 <path>`
+for the full chain. It cannot resolve releases whose values come from a runtime
+Secret (pocket-id, cloudflared); fall back to `helm template` against the chart.
+
+## Traps that have actually bitten
+
+- **Build the parent, never the subdirectory.** The namespace is injected by the
+  parent, so building a subdir yields namespace-less objects and `kubectl diff`
+  compares them against `default` — reporting every object as new.
+- **Three apps have no `namespace:` on their parent kustomization**: pocket-id,
+  paperless, multimedia. Their manifests each carried their own. A new bundle that
+  forgets to declare one silently targets `default`. Assert the namespace of every
+  emitted object.
+- **Removing a field from git does not remove it from the object.** If a previous
+  manager (usually kustomize-controller) holds server-side apply ownership of that
+  field and no longer applies the object, its claim is a fossil that never expires.
+  Finish with `kubectl annotate <kind> <name> <key>-`. Check with
+  `kubectl get ... -o json --show-managed-fields=true`.
+- **`kubectl get backup` resolves to `backups.longhorn.io`.** Always
+  `backups.postgresql.cnpg.io`. This has produced false "no phase" readings twice.
+- **`generation` unchanged is the adoption test, not `generation == 1`.** Across
+  this fleet they sit anywhere from 1 to 26. Snapshot before, compare after.
+- **Helm deep-merges maps.** `{}` in a values file does not clear a chart default;
+  only an explicit `null` does.
+- Homebrew's `python3` lacks pyyaml here — use `/usr/bin/python3`.
+
+## Removing a kustomizeconfig.yaml
+
+32 of these exist. Each does one thing: a `nameReference` rewriting
+`spec.valuesFrom[].name` on a HelmRelease so it tracks a hashed ConfigMap name.
+
+Replace it with a stable name instead:
+
+1. Add `generatorOptions.disableNameSuffixHash: true` to the kustomization
+   (or per-generator `options:` when the file has more than one generator —
+   photos needs this, or immich's release is upgraded for nothing).
+2. Drop `configurations: [kustomizeconfig.yaml]` and delete the file.
+3. `valuesFrom.name` becomes the literal generator name. Names must be unique per
+   namespace: most apps generate `values`, so name others distinctly
+   (`postgres-values`).
+4. Verify the render: the only diff should be the ConfigMap losing its hash suffix
+   and the HelmRelease reference following it.
+
+The ConfigMap name change makes helm-controller re-render, so expect one release
+revision per app. It detects value changes via `status.lastAttemptedConfigDigest`,
+so the hash was never needed for change detection.
+
+## After merge
+
+`flux reconcile kustomization <app> -n flux-apps --with-source`, then confirm the
+HelmRelease is Ready and object generations are unchanged. Roughly 21 components
+are suspended by design — check `spec.suspend` before wondering why nothing moved.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,10 @@ Flux-managed k3s homelab. `core/` bootstraps the cluster, `base/` is infrastruct
 `apps/` is workloads. Every component has a Flux Kustomization in
 `base/flux-apps/<name>.yaml`.
 
+Changing anything Flux applies: see the `flux-app-change` skill in
+`.claude/skills/`. It covers proving the render, the traps that have bitten, and
+removing `kustomizeconfig.yaml`.
+
 ## Validation
 
 ```bash
@@ -14,84 +18,31 @@ make validate-flux   # asserts every live Flux Kustomization path exists
 `make validate` also fails on deprecated Flux API versions. Note both scripts read
 **git-tracked** files, so a new manifest is invisible until staged.
 
+Kubeconfig: `~/.kube/clusters/ankhmorpork`.
+
 ## Helm chart values
 
 Values live in `values.yaml`, fed in via `configMapGenerator` and `valuesFrom` —
-not inline in `spec.values`. Two reasons: Renovate's `helm-values` manager reads
-`values.yaml` but cannot see inside a HelmRelease, and 33 of 34 releases already
-do it this way.
-
-New components should set `generatorOptions.disableNameSuffixHash: true` and skip
-`kustomizeconfig.yaml`. helm-controller detects value changes through
-`status.lastAttemptedConfigDigest`, so the hash suffix isn't needed, and without it
-there's no generated name for `nameReference` to rewrite — which is all
-`kustomizeconfig.yaml` does. Older components still carry it; that's historical.
-
-With the hash disabled, ConfigMap names must be unique per namespace. Most apps
-already generate one called `values`, so name others distinctly
-(e.g. `postgres-values`). Trade-off: a values edit no longer changes the
-HelmRelease spec, so it applies at the next reconcile rather than instantly —
-`flux reconcile hr <name> -n <ns>` forces it.
-
-## Verifying against the cluster
-
-Kubeconfig: `~/.kube/clusters/ankhmorpork`.
-
-**Build the parent kustomization, not a subdirectory.** The namespace is injected
-by the parent, so building `db/` alone yields namespace-less objects that
-`kubectl diff` compares against `default` — reporting every object as new with a
-full spec body. Alarming and meaningless. Same for `helm template`: pass
-`-n <namespace>`.
-
-**`flux diff` only sees what a Kustomization applies**, not what Helm renders from
-a HelmRelease. Use [`flux-build`](https://github.com/DoodleScheduling/flux-build)
-for the full chain. `core` needs `--api-versions monitoring.coreos.com/v1`;
-components taking values from a runtime Secret can't be rendered offline.
-
-**`flux diff` ignores `kustomize.toolkit.fluxcd.io/prune: disabled`.** It computes
-deletions from inventory-versus-build, so protected objects show as `deleted`. The
-annotation does work — verified empirically. Don't panic at that output.
+not inline in `spec.values`. Renovate's `helm-values` manager reads `values.yaml`
+but cannot see inside a HelmRelease.
 
 ## Suspended components
 
-Roughly half the fleet is suspended, declared in git. This is deliberate: leftovers
-from emergency work in Dec 2025 when nodes failed and reconciliation was stopped to
-allow manual edits. Some were *already failing* before suspension, so **don't
-resume one without reading why it stopped** — check its HelmRelease conditions
-first. `flux-apps` itself is the exception: never declare `suspend` on it, since it
-manages its own definition and would re-suspend itself on resume.
+Roughly half the fleet is suspended, declared in git — leftovers from emergency
+work in Dec 2025 when nodes failed and reconciliation was stopped to allow manual
+edits. Some were *already failing* before suspension, so **don't resume one
+without reading why it stopped**. `flux-apps` is the exception: never declare
+`suspend` on it, since it manages its own definition and would re-suspend itself.
 
 ## Postgres (CloudNativePG)
 
-Databases use the `cnpg-database` chart from
-`oci://ghcr.io/thaum-xyz/helm-charts`. Migrating a hand-written bundle onto it is
-**data-destructive if rushed**: PVCs are held by `ownerReferences` on the Cluster,
-and `lvm-thin` is `reclaimPolicy: Delete` on node-local single-copy storage.
+All eleven databases use the `cnpg-database` chart from
+`oci://ghcr.io/thaum-xyz/helm-charts`.
 
-Sequence, as separate PRs — one state per merge:
-
-1. Add `kustomize.toolkit.fluxcd.io/prune: disabled` to every object, plus
-   `helm.sh/resource-policy: keep` on the Cluster and ObjectStore. Metadata only.
-   Must reconcile before step 3, or the protection never exists when needed.
-2. Out of band: flip the PVs to `reclaimPolicy: Retain`, take a backup, confirm it
-   reaches `completed`.
-3. Replace the manifests with `release.yaml` + `values.yaml`. Never copy
-   `install.remediation` from another release — its strategy is *uninstall*, which
-   on an adopted Cluster deletes it and its PVCs.
-4. Drop the prune annotation from `values.yaml`, then **remove it from the live
-   objects by hand** — `kubectl annotate <kind> <name> kustomize.toolkit.fluxcd.io/prune-`
-   on all six. A values change alone does not do it. The chart only ever rendered
-   the annotation on the Cluster, so Helm has nothing to strip from the other
-   five; and even on the Cluster, kustomize-controller still holds server-side
-   apply ownership of that field from before the cutover. Under SSA a field lives
-   as long as any manager claims it, and kustomize-controller never applies the
-   object again — it is gone from the Kustomization's inventory — so its claim is
-   a fossil that never expires. Verify with
-   `kubectl get ... -o json --show-managed-fields=true`.
-
-Helm adopts existing objects without ownership metadata: `disableTakeOwnership`
-defaults to false. Rendered resource names must match what's live — `postgres-rw`
-is hardcoded by consumers, so the chart's fullname is the bare release name.
+Rendered names must match what's live — `postgres-rw` is hardcoded by consumers,
+so the chart's fullname is the bare release name and `releaseName` is pinned.
+Never copy `install.remediation` from another release: its strategy is *uninstall*,
+which on an adopted Cluster deletes it and, through `ownerReferences`, its PVCs.
 
 Backups: `barman_cloud_cloudnative_pg_io_*` metrics are the real signal.
 `cnpg_collector_last_available_backup_timestamp` reads **0** for plugin-method


### PR DESCRIPTION
Adds `.claude/skills/flux-app-change/SKILL.md` — the procedure for changing
anything Flux applies, plus the traps that have actually cost time this week
(building a subdir instead of the parent, the three apps with no `namespace:` on
their parent kustomization, SSA fossils outliving git). It also documents the
`kustomizeconfig.yaml` removal, which is the next sweep.

CLAUDE.md drops what the skill now owns, and the CNPG migration sequence, which
is spent — all eleven databases are on the chart. 104 lines → 54.

`make validate` green.