### PR TITLE
multimedia: upgrade radarr 5.17.2 -> 6.3.0

### DIFF
--- a/apps/multimedia/manifests/radarr/statefulset.yaml
+++ b/apps/multimedia/manifests/radarr/statefulset.yaml
@@ -34,7 +34,7 @@ spec:
               value: "1000"
             - name: GUID
               value: "1000"
-          image: lscr.io/linuxserver/radarr:5.17.2
+          image: lscr.io/linuxserver/radarr:6.3.0
           imagePullPolicy: IfNotPresent
           name: radarr
           ports:


### PR DESCRIPTION
Radarr 6.0 migrates the Postgres schema **irreversibly**. Fresh base backup taken
and confirmed `completed` first — `postgres-radarr-preupgrade-202607291526`,
recovery window advanced to `2026-07-29T15:26:10Z`.

Upstream changes worth knowing: Basic auth is removed and converted to Forms on
first start (this cluster is on `AuthenticationMethod=Basic`, so the browser login
changes shape — exportarr and prowlarr use the API key and are unaffected);
quality profiles default to Original language; movie file tokens are rejected in
Movie Folder Format. The last two are settings to review afterwards.

Render diff across the whole multimedia build is one line. `make validate` green.