### PR TITLE
photos: upgrade immich v2.3.1 -> v2.7.0

### DIFF
--- a/apps/photos/values.yaml
+++ b/apps/photos/values.yaml
@@ -6,7 +6,7 @@ controllers:
       main:
         image:
           repository: ghcr.io/immich-app/immich-server
-          tag: "v2.3.1"
+          tag: "v2.7.0"
         env:
           TZ: "Europe/Warsaw"
           LOG_LEVEL: "debug"


### PR DESCRIPTION
Pinned at **2.7.0**, not the v3.0.3 Renovate proposes — 2.7.0 is the last release
before v3.0.0, which upstream says carries breaking changes.

Checked every release 2.4.0 → 2.7.0: no mandatory server-side action, and **no
database extension change** — pgvecto.rs and the `vectors` extension stay as they
are. Fresh base backup confirmed `completed` first
(`postgres-preimmich27-202607291534`, window → `2026-07-29T15:35:08Z`).

Worth knowing: the **old timeline is removed** in this release, and 2.6.0 added an
`immich-admin schema-check` that runs at startup — a clean post-upgrade signal.

Render diff: values ConfigMap hash rolls, HelmRelease reference follows, both
immich images move together. `postgres-values` untouched. `make validate` green.