### PR TITLE
Revert stirling-pdf to chart 2.2.0: v2 puts a public endpoint behind default credentials

### DIFF
--- a/apps/stirling-pdf/release.yaml
+++ b/apps/stirling-pdf/release.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     spec:
       chart: stirling-pdf-chart
-      version: "3.1.0"
+      version: "2.2.0"
       sourceRef:
         kind: HelmRepository
         name: stirling-pdf


### PR DESCRIPTION
v2 enables the `security` profile by default. Verified against the running 2.5.1
pod:

- `/` → **401**, `/login` → 200
- log: `InitialSecuritySetup - Default admin user created: admin`
- active profile: `security`

`pdf.krupa.net.pl` is publicly reachable, so this put a public service behind a
well-known default credential.

Worse, the chart mounts an **emptyDir**, so `./configs` and the user database do
not survive a restart — any password change is undone on the next reschedule and
the default admin recreated. Public + default creds + resets on restart is worse
than the previous state, which was simply open.

Reverting the chart to 2.2.0 (app 1.3.2). The kustomizeconfig removal and the
corrected ServiceMonitor comment stay.

Doing v2 properly needs a decision: should this service have accounts at all, and
if so it needs persistence for `/configs` plus an admin password seeded from a
Secret. That's a design question, not a version bump.