### PR TITLE
stirling-pdf: tie the admin account to pocket-id SSO

### DIFF
--- a/apps/stirling-pdf/admin-secret.yaml
+++ b/apps/stirling-pdf/admin-secret.yaml
@@ -1,0 +1,50 @@
+# Seeds the single admin account, whose username is the pocket-id identity.
+#
+# Stirling only ever takes a role from the local user record -- its OAUTH2 config
+# has no group or role mapping -- so an SSO login cannot arrive as an admin. What
+# it does do is match an existing user by username on first SSO login and attach
+# the provider to it, keeping that user's role. Seeding the account with the same
+# email pocket-id presents therefore produces exactly one user: yours, with
+# ROLE_ADMIN, logging in through SSO.
+#
+# The password is required by InitialSecuritySetup -- without both a username and
+# a password it falls through and creates the default `admin` with the documented
+# default password instead. It is never usable for login once loginMethod is
+# oauth2, so it is generated in-cluster and nobody, including us, ever sees it.
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+metadata:
+  name: stirling-pdf-admin
+spec:
+  length: 40
+  digits: 10
+  # No symbols: the value only has to exist and be unguessable, and this keeps it
+  # free of anything that needs escaping if it is ever echoed into a config file.
+  symbols: 0
+  noUpper: false
+  allowRepeat: true
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: stirling-pdf-admin
+spec:
+  # Generate once. On any non-zero interval the generator mints a fresh password
+  # each refresh, which would change the Secret and restart the pod every time --
+  # churn for a credential that is never used.
+  refreshInterval: "0"
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-auth-api
+  target:
+    name: stirling-pdf-admin
+  data:
+    - remoteRef:
+        key: STIRLING_PDF_ADMIN_EMAIL
+      secretKey: username
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: stirling-pdf-admin

--- a/apps/stirling-pdf/kustomization.yaml
+++ b/apps/stirling-pdf/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
   - namespace.yaml
   - release.yaml
   - ingress-cloudflare.yaml
+  - oidc-secret.yaml
+  - admin-secret.yaml
 configMapGenerator:
   - name: values
     files:

--- a/apps/stirling-pdf/oidc-secret.yaml
+++ b/apps/stirling-pdf/oidc-secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: stirling-pdf-oidc
+spec:
+  data:
+    - remoteRef:
+        key: STIRLING_PDF_OIDC_CLIENT_SECRET
+      secretKey: clientSecret
+    - remoteRef:
+        key: STIRLING_PDF_OIDC_CLIENT_ID
+      secretKey: clientID
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-auth-api

--- a/apps/stirling-pdf/values.yaml
+++ b/apps/stirling-pdf/values.yaml
@@ -32,6 +32,51 @@ serviceMonitor:
   enabled: false
 
 envs:
+# --- SSO through pocket-id -------------------------------------------------
+# loginMethod stays "all" for now. Tightening it to "oauth2" disables password
+# login entirely, which is the goal -- but only once an SSO login has been shown
+# to come back with ROLE_ADMIN. Setting it before that verification risks locking
+# admin out with no local fallback.
+- name: SECURITY_ENABLELOGIN
+  value: "true"
+- name: SECURITY_LOGINMETHOD
+  value: "all"
+- name: SECURITY_OAUTH2_ENABLED
+  value: "true"
+- name: SECURITY_OAUTH2_ISSUER
+  value: "https://login.krupa.net.pl"
+# Becomes the Spring registrationId, so the redirect URI is
+# https://pdf.krupa.net.pl/login/oauth2/code/pocket-id and must match pocket-id.
+- name: SECURITY_OAUTH2_PROVIDER
+  value: "pocket-id"
+- name: SECURITY_OAUTH2_SCOPES
+  value: "openid,profile,email"
+# Must match the seeded admin username, or SSO creates a second, non-admin user.
+- name: SECURITY_OAUTH2_USEASUSERNAME
+  value: "email"
+- name: SECURITY_OAUTH2_AUTOCREATEUSER
+  value: "true"
+- name: SECURITY_OAUTH2_CLIENTID
+  valueFrom:
+    secretKeyRef:
+      name: stirling-pdf-oidc
+      key: clientID
+- name: SECURITY_OAUTH2_CLIENTSECRET
+  valueFrom:
+    secretKeyRef:
+      name: stirling-pdf-oidc
+      key: clientSecret
+- name: SECURITY_INITIALLOGIN_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: stirling-pdf-admin
+      key: username
+- name: SECURITY_INITIALLOGIN_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: stirling-pdf-admin
+      key: password
+# ---------------------------------------------------------------------------
 - name: UI_APP_NAME
   value: "Stirling PDF"
 - name: UI_HOME_DESCRIPTION


### PR DESCRIPTION
v2 enables its security profile by default and otherwise creates the documented
default admin on a public host — recreated every restart, since the chart mounts
an `emptyDir`. This makes the one account an SSO account instead.

Stirling only reads a role from the local user record (its OAUTH2 config has no
group/role mapping), but `processSSOPostLogin` matches an existing user **by
username** and attaches the provider, preserving the role. Seeding the account
with the same email pocket-id presents yields exactly one user: yours, ROLE_ADMIN,
via SSO.

`InitialSecuritySetup` requires a password or it falls back to the default admin,
so one is **generated in-cluster** by the ESO password generator — no Doppler key,
never usable for login once `loginMethod: oauth2`. `refreshInterval: "0"` mints it
once; any non-zero value regenerates and restarts the pod each refresh.

`loginMethod` stays `all` this merge — tightening to `oauth2` before confirming an
SSO login returns ROLE_ADMIN risks locking admin out. That follows separately.

Redirect URI: `https://pdf.krupa.net.pl/login/oauth2/code/pocket-id`.