### PR TITLE
stirling-pdf: authenticate at an oauth2-proxy sidecar, expose externally again

### DIFF
--- a/apps/stirling-pdf/ingress-cloudflare.yaml
+++ b/apps/stirling-pdf/ingress-cloudflare.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cloudflare-ingress
+  namespace: stirling-pdf
+spec:
+  ingressClassName: cloudflare
+  rules:
+  - host: pdf.krupa.net.pl
+    http:
+      paths:
+      - backend:
+          service:
+            name: stirling-pdf-stirling-pdf-chart
+            port:
+              number: 8080
+        path: /
+        pathType: ImplementationSpecific

--- a/apps/stirling-pdf/kustomization.yaml
+++ b/apps/stirling-pdf/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
   - repository.yaml
   - namespace.yaml
   - release.yaml
+  - ingress-cloudflare.yaml
+  - oidc-secret.yaml
 configMapGenerator:
   - name: values
     files:

--- a/apps/stirling-pdf/oidc-secret.yaml
+++ b/apps/stirling-pdf/oidc-secret.yaml
@@ -1,0 +1,61 @@
+# Credentials for the oauth2-proxy sidecar. Nothing here reaches Stirling itself,
+# which stays login-disabled -- the proxy is the authentication boundary.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: stirling-pdf-oidc
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-auth-api
+  target:
+    name: stirling-pdf-oidc
+    template:
+      engineVersion: v2
+      data:
+        clientID: "{{ .clientID }}"
+        clientSecret: "{{ .clientSecret }}"
+        # oauth2-proxy's authenticated-emails-file wants one address per line.
+        # Commas are rewritten so the Doppler value works either way.
+        emails: |
+          {{ .emails | replace "," "\n" }}
+  data:
+    - remoteRef:
+        key: STIRLING_PDF_OIDC_CLIENT_ID
+      secretKey: clientID
+    - remoteRef:
+        key: STIRLING_PDF_OIDC_CLIENT_SECRET
+      secretKey: clientSecret
+    - remoteRef:
+        key: STIRLING_PDF_OIDC_EMAILS
+      secretKey: emails
+---
+# The cookie secret only has to be 32 bytes and stable: regenerating it would
+# invalidate every session. Generated in-cluster so it never leaves the cluster,
+# with refreshInterval "0" so it is minted once rather than on every refresh.
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+metadata:
+  name: stirling-pdf-oauth2-cookie
+spec:
+  length: 32
+  digits: 8
+  symbols: 0
+  noUpper: false
+  allowRepeat: true
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: stirling-pdf-oauth2-cookie
+spec:
+  refreshInterval: "0"
+  target:
+    name: stirling-pdf-oauth2-cookie
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: stirling-pdf-oauth2-cookie

--- a/apps/stirling-pdf/oidc-secret.yaml
+++ b/apps/stirling-pdf/oidc-secret.yaml
@@ -11,15 +11,6 @@ spec:
     name: doppler-auth-api
   target:
     name: stirling-pdf-oidc
-    template:
-      engineVersion: v2
-      data:
-        clientID: "{{ .clientID }}"
-        clientSecret: "{{ .clientSecret }}"
-        # oauth2-proxy's authenticated-emails-file wants one address per line.
-        # Commas are rewritten so the Doppler value works either way.
-        emails: |
-          {{ .emails | replace "," "\n" }}
   data:
     - remoteRef:
         key: STIRLING_PDF_OIDC_CLIENT_ID
@@ -27,9 +18,6 @@ spec:
     - remoteRef:
         key: STIRLING_PDF_OIDC_CLIENT_SECRET
       secretKey: clientSecret
-    - remoteRef:
-        key: STIRLING_PDF_OIDC_EMAILS
-      secretKey: emails
 ---
 # The cookie secret only has to be 32 bytes and stable: regenerating it would
 # invalidate every session. Generated in-cluster so it never leaves the cluster,

--- a/apps/stirling-pdf/values.yaml
+++ b/apps/stirling-pdf/values.yaml
@@ -35,13 +35,6 @@ service:
   targetPort: oauth2
 
 deployment:
-  extraVolumes:
-    - name: oauth2-emails
-      secret:
-        secretName: stirling-pdf-oidc
-        items:
-          - key: emails
-            path: emails
   sidecarContainers:
     oauth2:
       image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3
@@ -55,10 +48,12 @@ deployment:
         - --http-address=0.0.0.0:4180
         # Stirling listens on localhost in this pod; it is never published.
         - --upstream=http://127.0.0.1:8080
-        # Allow-list comes from Doppler, one address per line.
-        - --authenticated-emails-file=/etc/oauth2-proxy/emails
-        # email_domains defaults to nothing, which would reject everyone even
-        # when the address is on the list above.
+        # Authorisation lives in pocket-id: the client is group-restricted, so
+        # IsUserGroupAllowedToAuthorize refuses to issue a token for anyone
+        # outside the allowed groups and this proxy never sees them. Keeping a
+        # second allow-list here would only be one more thing to drift.
+        # email_domain must still be set to something -- unset it defaults to
+        # allowing nothing and would reject every address.
         - --email-domain=*
         - --scope=openid email profile
         # Behind an ingress, so trust X-Forwarded-* for redirect construction.
@@ -82,10 +77,6 @@ deployment:
             secretKeyRef:
               name: stirling-pdf-oauth2-cookie
               key: password
-      volumeMounts:
-        - name: oauth2-emails
-          readOnly: true
-          mountPath: /etc/oauth2-proxy
       resources:
         requests:
           cpu: 10m

--- a/apps/stirling-pdf/values.yaml
+++ b/apps/stirling-pdf/values.yaml
@@ -11,19 +11,15 @@ resources:
 
 ingress:
   enabled: true
-  # Internal only. The cloudflared tunnel is gone and this no longer sits on the
-  # "public" class, because with login disabled anything reachable from outside
-  # would be an unauthenticated PDF processor open to the internet.
-  ingressClassName: private
+  # External again, but every request terminates at the oauth2-proxy sidecar first
+  # (see service.targetPort), so Stirling is never reached unauthenticated.
+  ingressClassName: public
   annotations:
-    # dns01, not the http01-backed letsencrypt-prod: an internally reachable host
-    # cannot satisfy an HTTP-01 challenge, so renewals would fail.
-    cert-manager.io/cluster-issuer: letsencrypt-dns01
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     reloader.homer/group: Ankh Cloud
     reloader.homer/logo: https://cdn.jsdelivr.net/npm/@loganmarchione/homelab-svg-assets@latest/assets/stirlingpdf.svg
     reloader.homer/name: Stirling PDF
     reloader.homer/subtitle: PDF manipulation tool
-    reloader.homer/tag: local
   labels:
     probe: enabled
     reloader.homer/enabled: "true"
@@ -32,6 +28,71 @@ ingress:
       path: /
       tls: true
       tlsSecret: pdf.krupa.net.pl
+
+service:
+  # Named port on the oauth2-proxy sidecar rather than Stirling's own http port.
+  # Without this the Service would bypass the proxy entirely.
+  targetPort: oauth2
+
+deployment:
+  extraVolumes:
+    - name: oauth2-emails
+      secret:
+        secretName: stirling-pdf-oidc
+        items:
+          - key: emails
+            path: emails
+  sidecarContainers:
+    oauth2:
+      image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3
+      ports:
+        - name: oauth2
+          containerPort: 4180
+      args:
+        - --provider=oidc
+        - --oidc-issuer-url=https://login.krupa.net.pl
+        - --redirect-url=https://pdf.krupa.net.pl/oauth2/callback
+        - --http-address=0.0.0.0:4180
+        # Stirling listens on localhost in this pod; it is never published.
+        - --upstream=http://127.0.0.1:8080
+        # Allow-list comes from Doppler, one address per line.
+        - --authenticated-emails-file=/etc/oauth2-proxy/emails
+        # email_domains defaults to nothing, which would reject everyone even
+        # when the address is on the list above.
+        - --email-domain=*
+        - --scope=openid email profile
+        # Behind an ingress, so trust X-Forwarded-* for redirect construction.
+        - --reverse-proxy=true
+        - --cookie-secure=true
+        # Straight to pocket-id rather than showing an interstitial sign-in page.
+        - --skip-provider-button=true
+      env:
+        - name: OAUTH2_PROXY_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: stirling-pdf-oidc
+              key: clientID
+        - name: OAUTH2_PROXY_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: stirling-pdf-oidc
+              key: clientSecret
+        - name: OAUTH2_PROXY_COOKIE_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: stirling-pdf-oauth2-cookie
+              key: password
+      volumeMounts:
+        - name: oauth2-emails
+          readOnly: true
+          mountPath: /etc/oauth2-proxy
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          cpu: 200m
+          memory: 128Mi
 
 serviceMonitor:
   # Stays disabled on v2, but for a different reason than before. The metrics do
@@ -48,11 +109,11 @@ envs:
 # through to `anyRequest().permitAll()` and installs no authentication filter. It
 # also disables X-Frame-Options automatically.
 #
-# That is only acceptable because this ingress is on the private class. Do NOT
-# re-enable login expecting SSO to protect it: OAuth2 is licence-gated in v2 --
-# isOAuthEligible blocks both non-grandfathered users and auto-creation -- so the
-# route to authenticated access is a forwardAuth / oauth2-proxy layer in front,
-# with this staying false.
+# That is safe only because the oauth2-proxy sidecar terminates every request
+# first and the Service points at it, not at Stirling. Do NOT re-enable login
+# expecting SSO from it: OAuth2 is licence-gated in v2 -- isOAuthEligible blocks
+# both non-grandfathered users and auto-creation -- which is exactly why
+# authentication lives in the proxy instead.
 - name: SECURITY_ENABLELOGIN
   value: "false"
 # Hides the settings button while login is disabled, so anonymous users are not


### PR DESCRIPTION
The private ingress was a stop-gap for SSO being licence-gated *inside* Stirling.
Running oauth2-proxy in the same pod moves authentication outside the app, so the
licence never applies and the service can be public again.

The chart supports this directly — `deployment.sidecarContainers` plus
`service.targetPort`. Stirling then only listens on `127.0.0.1:8080` inside the
pod, so there's no path through the Service that skips the proxy.

**Authorisation is pocket-id's job.** `IsUserGroupAllowedToAuthorize` denies the
authorize request for users outside the client's allowed groups, so the proxy
never sees them — no second allow-list to drift. `--email-domain=*` stays because
unset it defaults to allowing *nothing* and would reject everyone.

> [!IMPORTANT]
> This relies on the pocket-id client being **group-restricted**.
> `IsGroupRestricted` defaults to false, and in that state any pocket-id user can
> authorise. Confirm the restriction before merging.

- cookie secret generated in-cluster, `refreshInterval: "0"` (regenerating signs
  everyone out)
- back to `public` class + `letsencrypt-prod`; `reloader.homer/tag: local` dropped
- both ingresses reference port 8080 by number and the Service keeps 8080, so
  neither needed changing
- `STIRLING_PDF_OIDC_EMAILS` can be deleted from Doppler

`make validate` green.