### PR TITLE
stirling-pdf: give the probes room for a JVM start

### DIFF
--- a/apps/stirling-pdf/values.yaml
+++ b/apps/stirling-pdf/values.yaml
@@ -85,6 +85,31 @@ deployment:
           cpu: 200m
           memory: 128Mi
 
+# The chart defaults to initialDelaySeconds 5 with failureThreshold 3 on a
+# 10s period, giving the app 25s to answer before liveness restarts it. Stirling
+# takes ~12s to boot on an idle node, so the margin is thin enough that a busy
+# node turns a slow start into a restart loop. The chart exposes no startupProbe,
+# so the budget is widened here instead.
+#
+# Note these are on the stirling container and kubelet dials it directly, so the
+# oauth2-proxy sidecar is not in the path -- probe failures are never an auth
+# problem.
+probes:
+  liveness:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 2
+    successThreshold: 1
+    failureThreshold: 6
+  readiness:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 5
+    timeoutSeconds: 2
+    successThreshold: 1
+    failureThreshold: 12
+
 serviceMonitor:
   # Stays disabled on v2, but for a different reason than before. The metrics do
   # exist now -- Spring MeterRegistry, plus ClusterMetrics -- but the scrape


### PR DESCRIPTION
Chart defaults: `initialDelaySeconds: 5`, `periodSeconds: 10`, `failureThreshold: 3`
— so liveness restarts the container if it hasn't answered within **25s**.
Stirling logs `Started SPDFApplication in 12.309 seconds` on an idle node. Thin
margin: a busier node turns a slow boot into a restart loop.

Liveness budget → 90s, readiness → 70s. The chart exposes no `startupProbe`
(which would be the right mechanism), so the existing probes are widened instead.

**Not caused by oauth2-proxy**, despite the timing. Both probes target the
stirling container and kubelet dials it directly — nothing traverses the proxy,
so no path exclusion would change anything. The `connection refused` was the app
not yet listening, not a request being rejected.

`make validate` green.