### PR TITLE
stirling-pdf: enable S256 PKCE on the oauth2-proxy sidecar

### DIFF
--- a/apps/stirling-pdf/values.yaml
+++ b/apps/stirling-pdf/values.yaml
@@ -56,6 +56,8 @@ deployment:
         # allowing nothing and would reject every address.
         - --email-domain=*
         - --scope=openid email profile
+        # pocket-id advertises S256 and oauth2-proxy warns when it is left off.
+        - --code-challenge-method=S256
         # Behind an ingress, so trust X-Forwarded-* for redirect construction.
         - --reverse-proxy=true
         - --cookie-secure=true


### PR DESCRIPTION
pocket-id advertises `plain` and `S256`, and oauth2-proxy warns on startup when no
challenge method is set. Enabling it removes the warning and binds the
authorization code to this client.

> An earlier revision also passed `--insecure-oidc-allow-unverified-email` to work
> around `email in id_token isn't verified`. That was the wrong fix — pocket-id has
> an **"Emails verified"** toggle, so the claim can be made true at the source
> instead of having the proxy ignore it. With that set the id_token arrives
> verified and no flag is needed. Dropped.

`make validate` green.