### PR TITLE
Stop storage-system from being able to prune

### DIFF
--- a/base/flux-apps/storage-system.yaml
+++ b/base/flux-apps/storage-system.yaml
@@ -6,7 +6,14 @@ metadata:
 spec:
   interval: 120m0s
   path: ./base/storage-system
-  prune: true
+  # false, not true: this Kustomization's inventory still claims objects the live
+  # csi-nfs HelmRelease has since adopted -- CSIDriver/nfs.csi.k8s.io, the
+  # nfs-external-provisioner ClusterRole and its binding -- plus the three
+  # cluster-wide VolumeSnapshot CRDs, which nothing else owns. Pruning it would
+  # take the working NFS driver down and cascade-delete every VolumeSnapshot in
+  # the cluster. Removed in the follow-up, once this has landed and the objects
+  # can be orphaned safely.
+  prune: false
   sourceRef:
     kind: GitRepository
     name: ankhmorpork


### PR DESCRIPTION
The suspended `storage-system` Kustomization's inventory still claims objects the live `csi-nfs` HelmRelease has since adopted — `CSIDriver/nfs.csi.k8s.io`, `nfs-external-provisioner-role` and its binding — plus three cluster-wide VolumeSnapshot CRDs owned by nothing.

Unsuspending or deleting it with `prune: true` would take the NFS driver down and cascade-delete every VolumeSnapshot in the cluster, Longhorn's included.

Landing this before removing the directory, so the deletion can't race a `flux-apps` reconcile that restores `prune: true`.