### PR TITLE
Drop storage-system from velero's excluded namespaces

### DIFF
--- a/base/velero/values.yaml
+++ b/base/velero/values.yaml
@@ -80,7 +80,6 @@ schedules:
       - longhorn-system
       - node-feature-discovery
       - node-problem-detector
-      - storage-system
       - traefik
       - velero
 


### PR DESCRIPTION
The namespace is gone. `base/csi-nfs` replaced its NFS CSI driver 501 days ago, and the leftovers — a leader-election lease last renewed in February, two endpoints from provisioners that no longer exist, and a kubescape ConfigMap for an uninstalled product — have been removed.

Excluding a namespace that can't exist is just noise in the backup config. Last remaining reference to `storage-system` in the repo.