### PR TITLE
Add a versity S3 gateway to longhorn-system

### DIFF
--- a/base/flux-apps/longhorn-versity.yaml
+++ b/base/flux-apps/longhorn-versity.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: longhorn-versity
+  namespace: flux-apps
+spec:
+  # Deliberately separate from the longhorn-system Kustomization, which is
+  # suspended because its HelmRelease fails its pre-upgrade hooks. Folding this
+  # in would mean unsuspending that to deploy this, retrying the broken 1.10.1
+  # -> 1.12.0 upgrade as a side effect. The manifests still live under
+  # base/longhorn-system/versity so they sit next to what they serve; that
+  # directory is not in the parent kustomization's resources.
+  interval: 30m0s
+  path: ./base/longhorn-system/versity
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: ankhmorpork

--- a/base/longhorn-system/versity/credentials-generator.yaml
+++ b/base/longhorn-system/versity/credentials-generator.yaml
@@ -1,0 +1,18 @@
+# See apps/versity-test/credentials-generator.yaml for why these are generated
+# in-cluster rather than kept in Doppler. Both ends -- the gateway and
+# longhorn-manager -- live in this namespace and read the same Secret, so the
+# value never needs to leave the cluster.
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+metadata:
+  name: versitygw-root
+spec:
+  length: 40
+  digits: 8
+  # SigV4 copes with symbols; a number of S3 clients do not.
+  symbols: 0
+  noUpper: false
+  allowRepeat: true
+  secretKeys:
+    - accessKey
+    - secretKey

--- a/base/longhorn-system/versity/credentials-secret.yaml
+++ b/base/longhorn-system/versity/credentials-secret.yaml
@@ -1,0 +1,28 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: versitygw-credentials
+spec:
+  # Minted once. The gateway reads its root credentials at startup and Longhorn
+  # caches them in the BackupTarget, so a refresh would desync the two.
+  refreshInterval: "0"
+  target:
+    name: versitygw-credentials
+    template:
+      data:
+        # What the versitygw chart looks for.
+        rootAccessKeyId: "{{ .accessKey }}"
+        rootSecretAccessKey: "{{ .secretKey }}"
+        # What longhorn-manager looks for in a BackupTarget credentialSecret --
+        # the names are fixed in its source (types.AWSAccessKey and friends), so
+        # the same generated pair is published twice under both spellings rather
+        # than maintained as two secrets that could drift apart.
+        AWS_ACCESS_KEY_ID: "{{ .accessKey }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .secretKey }}"
+        AWS_ENDPOINTS: "http://versitygw.longhorn-system.svc.cluster.local:7070"
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: versitygw-root

--- a/base/longhorn-system/versity/job.yaml
+++ b/base/longhorn-system/versity/job.yaml
@@ -1,0 +1,34 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: bootstrap-bucket
+spec:
+  # Creates the bucket the BackupTarget will point at. Longhorn will not create
+  # one for itself, and a missing bucket surfaces as an opaque "unavailable"
+  # backup target rather than anything that names the actual problem.
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: mc
+          image: minio/mc:latest
+          env:
+            - name: BUCKET_NAME
+              value: longhorn
+            - name: VGW_ENDPOINT
+              value: http://versitygw:7070
+            - name: ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: versitygw-credentials
+                  key: rootAccessKeyId
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: versitygw-credentials
+                  key: rootSecretAccessKey
+          command: ["/bin/sh", "-lc"]
+          args:
+            - |
+              mc alias set vgw "$VGW_ENDPOINT" "$ACCESS_KEY" "$SECRET_KEY" --api S3v4
+              mc mb --ignore-existing vgw/$BUCKET_NAME

--- a/base/longhorn-system/versity/kustomization.yaml
+++ b/base/longhorn-system/versity/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# The namespace is created and owned by base/longhorn-system, so it is not
+# declared again here.
+namespace: longhorn-system
+resources:
+  - repository.yaml
+  - release.yaml
+  - credentials-generator.yaml
+  - credentials-secret.yaml
+  - job.yaml
+configMapGenerator:
+  # Not "values": base/longhorn-system already generates a ConfigMap by that
+  # name in this namespace. It is hashed today and so does not collide, but it
+  # would the moment its kustomizeconfig.yaml is dropped.
+  - name: versity-values
+    files:
+      - values.yaml=values.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/base/longhorn-system/versity/release.yaml
+++ b/base/longhorn-system/versity/release.yaml
@@ -1,0 +1,24 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: versitygw
+spec:
+  chart:
+    spec:
+      chart: versitygw
+      version: "0.3.5"
+      sourceRef:
+        kind: HelmRepository
+        name: versity
+      interval: 15m
+  interval: 30m
+  timeout: 10m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: versity-values

--- a/base/longhorn-system/versity/repository.yaml
+++ b/base/longhorn-system/versity/repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: versity
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/versity/versitygw/charts

--- a/base/longhorn-system/versity/values.yaml
+++ b/base/longhorn-system/versity/values.yaml
@@ -1,0 +1,40 @@
+# Config reference: https://github.com/versity/versitygw/blob/main/chart/values.yaml
+#
+# An S3 gateway sitting next to its consumer, the way a cnpg-database sits next
+# to the app that needs postgres. This one exists to become Longhorn's backup
+# target: the current one is nfs://192.168.40.10/var/nfs/shared/longhornbackups,
+# which has been unavailable since 2025-02-11 and is why every Longhorn backup
+# errors. Wiring the BackupTarget CR to it is a separate step.
+
+# Pinned. The chart defaults to :latest.
+image:
+  tag: "v1.7.0"
+
+auth:
+  existingSecret: versitygw-credentials
+
+gateway:
+  backend:
+    type: posix
+    args: "/mnt/data"
+    # Keeps object metadata as ordinary files rather than extended attributes,
+    # which is what lets the whole thing live on an NFSv3 share.
+    sidecarDir: "/mnt/metadata"
+
+# One claim, with the chart mounting data/, metadata/ and iam/ from it as
+# subPaths. 200Gi against 31.8GiB of actual Longhorn data today, on a share with
+# 8.8T free -- and nfs.csi.k8s.io does not enforce the request anyway, so this
+# is a label rather than a reservation.
+persistence:
+  enabled: true
+  create: true
+  size: 200Gi
+  storageClassName: unifi-nas
+  accessMode: ReadWriteMany
+
+resources:
+  limits:
+    memory: 1Gi
+  requests:
+    cpu: 50m
+    memory: 128Mi


### PR DESCRIPTION
Same shape as `apps/versity-test`, deployed next to its consumer the way a `cnpg-database` sits next to the app needing postgres.

It exists to become Longhorn's backup target. The current one is `nfs://192.168.40.10/var/nfs/shared/longhornbackups`, **unavailable since 2025-02-11** — which is why every Longhorn backup errors. Wiring the `BackupTarget` CR to it is a separate step.

Gets **its own Kustomization** rather than joining `base/longhorn-system`, which is suspended because its HelmRelease fails its pre-upgrade hooks — folding it in would mean unsuspending that to deploy this, retrying the broken 1.10.1→1.12.0 upgrade as a side effect. Manifests still live under `base/longhorn-system/versity`, which the parent kustomization doesn't reference.

The generated Secret publishes the pair under **both** spellings — `rootAccessKeyId`/`rootSecretAccessKey` for the chart, `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_ENDPOINTS` for longhorn-manager (names fixed in its source). One generator, so they can't drift.