### PR TITLE
Point the unifi poller at the current controller

### DIFF
--- a/apps/unifi/kustomization.yaml
+++ b/apps/unifi/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: unifi
+resources:
+  - namespace.yaml
+  - poller/
+  - restarter/

--- a/apps/unifi/namespace.yaml
+++ b/apps/unifi/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: unifi

--- a/apps/unifi/poller/configuration.yaml
+++ b/apps/unifi/poller/configuration.yaml
@@ -5,7 +5,6 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: unifi-poller
   name: poller
-  namespace: unifi
 spec:
   data:
     - remoteRef:
@@ -36,7 +35,10 @@ spec:
           [webserver]
               enable = false
           [unifi.defaults]
-              url = "https://192.168.2.1"
+              # The UDM Pro SE. Was 192.168.2.1, on the subnet the LAN was
+              # renumbered off: the poller had been re-authenticating and timing
+              # out every ~15s ever since, 510 restarts deep and reporting up=0.
+              url = "https://192.168.1.1"
               user = "{{ .user }}"
               pass = "{{ .pass }}"
               sites = ["all"]

--- a/apps/unifi/poller/deployment.yaml
+++ b/apps/unifi/poller/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: unifi-poller
   name: poller
-  namespace: unifi
 spec:
   replicas: 1
   selector:
@@ -14,14 +13,16 @@ spec:
       app.kubernetes.io/name: unifi-poller
   template:
     metadata:
-      annotations:
-        checksum.config/md5: 55923d20e1fadcf735c826cce4cb847f
-        checksum.credentials/md5: 985702d46b91fbbe23caedf6f32467cc
+      # The config arrives as a Secret mounted with subPath, which kubelet never
+      # updates in place -- so a credential or URL change does not reach the
+      # running pod until it is replaced. Two checksum annotations used to stand
+      # in for that, left over from the jsonnet build; they were hardcoded and
+      # so had stopped tracking anything. Dropped rather than kept as decoration:
+      # a config change needs a `kubectl rollout restart` either way.
       labels:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: unifi-poller
       name: poller
-      namespace: unifi
     spec:
       containers:
         - image: ghcr.io/unpoller/unpoller:v2.9.5

--- a/apps/unifi/poller/kustomization.yaml
+++ b/apps/unifi/poller/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - serviceaccount.yaml
+  - configuration.yaml
+  - deployment.yaml
+  - podmonitor.yaml

--- a/apps/unifi/poller/podmonitor.yaml
+++ b/apps/unifi/poller/podmonitor.yaml
@@ -5,7 +5,6 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: unifi-poller
   name: poller
-  namespace: unifi
 spec:
   podMetricsEndpoints:
     - interval: 30s

--- a/apps/unifi/poller/serviceaccount.yaml
+++ b/apps/unifi/poller/serviceaccount.yaml
@@ -5,4 +5,3 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: unifi-poller
   name: poller
-  namespace: unifi

--- a/apps/unifi/restarter/kustomization.yaml
+++ b/apps/unifi/restarter/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - prometheusrule.yaml

--- a/apps/unifi/restarter/prometheusrule.yaml
+++ b/apps/unifi/restarter/prometheusrule.yaml
@@ -3,7 +3,6 @@ kind: PrometheusRule
 metadata:
   labels: {}
   name: restarter
-  namespace: unifi
 spec:
   groups:
     - name: unifi-restarter

--- a/base/flux-apps/unifi.yaml
+++ b/base/flux-apps/unifi.yaml
@@ -5,10 +5,9 @@ metadata:
   namespace: flux-apps
 spec:
   interval: 120m0s
-  path: ./apps/unifi/manifests
+  path: ./apps/unifi
   prune: true
   sourceRef:
     kind: GitRepository
     name: ankhmorpork
-  suspend: true
 


### PR DESCRIPTION
The poller has been aimed at `https://192.168.2.1` since before the LAN was renumbered — re-authenticating and timing out every ~15s, **510 restarts**, `up=0`. The controller is a UDM Pro SE at `192.168.1.1`, which the cluster reaches fine.

**Deliberately left on unpoller v2.9.5.** v3.3.4 exists, but v3.0.0's notes warn it "may not work for older Unifi installations on 9.x network APIs and the earlier 10.x releases", and the Network version can't be read without credentials. So the address fix lands on its own where it's provable, rather than being confounded with a major bump. v3 follows separately.

Also flattens `manifests/`, adds a Namespace (never managed), and drops two hardcoded checksum annotations — jsonnet leftovers meant to roll the pod on config change, but static and so tracking nothing. The config is a subPath-mounted Secret, which kubelet never updates in place, so a change needs a rollout restart either way.