### PR TITLE
Upgrade unpoller to v3.3.4

### DIFF
--- a/apps/unifi/poller/deployment.yaml
+++ b/apps/unifi/poller/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       name: poller
     spec:
       containers:
-        - image: ghcr.io/unpoller/unpoller:v2.9.5
+        - image: ghcr.io/unpoller/unpoller:v3.3.4
           name: unifi-poller
           ports:
             - containerPort: 9130
@@ -33,11 +33,15 @@ spec:
               protocol: TCP
           resources:
             limits:
-              cpu: 20m
-              memory: 100Mi
+              cpu: 100m
+              # Raised from 100Mi: from v3.2.0 unpoller refreshes in the
+              # background every 60s and holds the result, rather than hitting
+              # the controller per scrape, so it now keeps a copy of the whole
+              # site's state resident.
+              memory: 256Mi
             requests:
               cpu: 5m
-              memory: 12Mi
+              memory: 32Mi
           volumeMounts:
             - mountPath: /etc/unpoller/up.conf
               name: config


### PR DESCRIPTION
Held back from the address fix so the two could be told apart. With metrics flowing again — **1,928 `unpoller_*` series across 8 devices** — this is now a single variable against a known-good baseline.

Config needs no changes: `[unifi.defaults]` carries the same keys in v3 as v2. Metric names are expected to have moved, accepted here since nothing was being collected before anyway.

Memory raised from 100Mi: from v3.2.0 unpoller refreshes in the background every 60s and serves the held result rather than querying per scrape, so it keeps site state resident.