### PR TITLE
Point blackbox-exporter at a nameserver that exists

### DIFF
--- a/apps/monitoring/manifests/blackboxExporter/deployment.yaml
+++ b/apps/monitoring/manifests/blackboxExporter/deployment.yaml
@@ -122,9 +122,20 @@ spec:
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
+      # dnsPolicy None on purpose: the probes should resolve the way a LAN
+      # client does, so split-horizon sends the internal hostnames to traefik
+      # instead of out and back through the tunnel.
+      #
+      # The nameserver was 192.168.2.4, on the subnet the LAN was renumbered off.
+      # It had been unreachable long enough that every probe was failing on DNS
+      # before it ever opened a connection -- probe_success was 0 across all 11
+      # targets, so there was no working uptime monitoring at all, while the
+      # dashboards still looked configured. 192.168.1.1 is the UDM, and resolves
+      # every current probe target: internal hosts to 192.168.50.129/130,
+      # keep.krupa.net.pl to the cloudflare tunnel, and external names normally.
       dnsConfig:
         nameservers:
-          - 192.168.2.4
+          - 192.168.1.1
         searches:
           - thaum.xyz
       dnsPolicy: None

--- a/apps/monitoring/manifests/blackboxExporter/deployment.yaml
+++ b/apps/monitoring/manifests/blackboxExporter/deployment.yaml
@@ -122,17 +122,6 @@ spec:
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
-      # dnsPolicy None on purpose: the probes should resolve the way a LAN
-      # client does, so split-horizon sends the internal hostnames to traefik
-      # instead of out and back through the tunnel.
-      #
-      # The nameserver was 192.168.2.4, on the subnet the LAN was renumbered off.
-      # It had been unreachable long enough that every probe was failing on DNS
-      # before it ever opened a connection -- probe_success was 0 across all 11
-      # targets, so there was no working uptime monitoring at all, while the
-      # dashboards still looked configured. 192.168.1.1 is the UDM, and resolves
-      # every current probe target: internal hosts to 192.168.50.129/130,
-      # keep.krupa.net.pl to the cloudflare tunnel, and external names normally.
       dnsConfig:
         nameservers:
           - 192.168.1.1


### PR DESCRIPTION
Its `dnsConfig` named `192.168.2.4`, on the subnet the LAN was renumbered off. That address is unreachable — ping and every query time out — so probes died at resolution before opening a connection. **`probe_success` was 0 across all 11 targets**: no working external uptime monitoring at all, while dashboards and alerts still looked configured.

`192.168.1.1` is the UDM. Verified it resolves every current target — internal hosts to `192.168.50.129/130` via split horizon, `keep.krupa.net.pl` to the cloudflare tunnel, `zmc`/`registry.avsystem.com` out to the internet — and that `recipes.krupa.net.pl` and `registry.avsystem.com` both answer 200 through it.

`dnsPolicy: None` stays; it's deliberate, so internal hostnames reach traefik rather than looping out through the tunnel.

Note `monitoring` is suspended, so this needs applying by hand.