### PR TITLE
Serve grafana over traefik by default, cloudflare alongside

### DIFF
--- a/apps/grafana/grafana/ingress-cloudflare.yaml
+++ b/apps/grafana/grafana/ingress-cloudflare.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cloudflare-ingress
+spec:
+  ingressClassName: cloudflare
+  rules:
+    - host: grafana.krupa.net.pl
+      http:
+        paths:
+          - backend:
+              service:
+                name: grafana
+                port:
+                  number: 80
+            path: /
+            pathType: Prefix

--- a/apps/grafana/grafana/kustomization.yaml
+++ b/apps/grafana/grafana/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - release.yaml
   - admin-creds.yaml
   - oidc-secret.yaml
+  - ingress-cloudflare.yaml
 configMapGenerator:
   - name: values
     files:

--- a/apps/grafana/grafana/values.yaml
+++ b/apps/grafana/grafana/values.yaml
@@ -6,24 +6,37 @@ headlessService: true
 podDisruptionBudget:
   maxUnavailable: 1
 
+# The chart renders the traefik route; ingress-cloudflare.yaml carries the same
+# host for outside access.
+#
+# This was cloudflare-only, which left grafana.krupa.net.pl with no internal A
+# record -- external-dns published just the tunnel CNAME, and
+# *.cfargotunnel.com resolves nowhere outside Cloudflare's edge, so the host was
+# unreachable from the tailnet. Note the grafana at grafana.ankhmorpork.thaum.xyz
+# is a different instance, kube-prometheus's in the monitoring namespace, so it
+# was not covering for this one.
+#
+# probe-uri and the probe label are restored along with it: blackbox takes its
+# scheme from whether the Ingress declares TLS, so only the traefik route is
+# probeable.
 ingress:
   enabled: true
-  #ingressClassName: public
-  ingressClassName: cloudflare
+  ingressClassName: public
   annotations:
-    #cert-manager.io/cluster-issuer: letsencrypt-prod
-    #probe-uri: /-/healthy
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    probe-uri: /-/healthy
     reloader.homer/group: Administration
     reloader.homer/logo: https://grafana.com/static/img/logos/grafana_logo_swirl-events.svg
     reloader.homer/name: grafana
   labels:
     reloader.homer/enabled: "true"
+    probe: enabled
   hosts:
     - "grafana.krupa.net.pl"
-  #tls:
-  #  - hosts:
-  #    - grafana.krupa.net.pl
-  #    secretName: ingress-grafana-tls
+  tls:
+    - hosts:
+        - grafana.krupa.net.pl
+      secretName: ingress-grafana-tls
 
 resources:
   requests:


### PR DESCRIPTION
`grafana.krupa.net.pl` was cloudflare-only, so it had no internal A record — external-dns published just the tunnel CNAME, and `*.cfargotunnel.com` resolves nowhere outside Cloudflare's edge, leaving it unreachable from the tailnet.

Worth noting the grafana at `grafana.ankhmorpork.thaum.xyz` is a **different instance** — kube-prometheus's, in the `monitoring` namespace — so it wasn't covering for this one.

The chart's ingress block goes back to class `public` with cert-manager and TLS (all already present, commented out), and a separate `ingress-cloudflare.yaml` carries the outside route. Same layout as karakeep and mended-drum.

`probe-uri` and a `probe` label come back too, so grafana joins the blackbox targets — which only works on the traefik route, since blackbox derives its scheme from whether the Ingress declares TLS.

`root_url` is unchanged; only which ingress serves the host internally.