### PR TITLE
Upgrade cloudflared to 0.1.0 and pin the connector image

### DIFF
--- a/base/cloudflared/release.yaml
+++ b/base/cloudflared/release.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: cloudflare-tunnel-ingress-controller
-      version: "0.0.24"
+      version: "0.1.0"
       sourceRef:
         kind: HelmRepository
         name: strrl

--- a/base/cloudflared/values.yaml
+++ b/base/cloudflared/values.yaml
@@ -11,5 +11,32 @@ ingressClass:
 
 replicaCount: 2
 
-cloudflaredServiceMonitor:
+# 0.1.0 merged the two ServiceMonitor value groups into one. This single switch
+# now creates ServiceMonitors for both the controller and the cloudflared
+# connectors, replacing cloudflaredServiceMonitor, which 0.1.0 no longer reads --
+# carrying the old key over would have gone silently inert and taken the
+# connector metrics with it.
+#
+# It is also a net gain: until now only the connector was scraped and the
+# controller had no metrics endpoint at all. The controller endpoint adds
+# controller-runtime reconcile and workqueue metrics plus
+# cloudflare_tunnel_ingress_controller_last_successful_sync_timestamp_seconds,
+# which is the signal for "tunnel configuration has stopped being updated" --
+# the failure that would otherwise silently strand every external hostname on a
+# stale config.
+serviceMonitor:
   create: true
+
+# Pinned so Renovate tracks it. The chart otherwise carries this tag as a
+# default, which would move under us on any chart bump without showing up as a
+# reviewable change.
+#
+# 0.1.0 moves the connector off cloudflare/cloudflared onto the maintainer's
+# fork, which is what exposes the host metrics the connector ServiceMonitor
+# scrapes. Worth knowing: that fork publishes exactly one tag today and it
+# trails the official image, so Renovate has nothing to bump to until the
+# maintainer rebuilds.
+cloudflared:
+  image:
+    repository: ghcr.io/strrl/cloudflared
+    tag: "2026.7.3-host-metrics.1"


### PR DESCRIPTION
Chart 0.0.24 → 0.1.0 with the values migration it requires: `cloudflaredServiceMonitor` is replaced by a single `serviceMonitor` group covering both endpoints. Carrying the old key over would have gone **silently inert** and dropped connector metrics.

**Observability is the point.** Today only the connector is scraped and the controller has no metrics endpoint at all — one target. 0.1.0 adds a controller metrics Service on 9090 with controller-runtime reconcile/workqueue metrics plus `cloudflare_tunnel_ingress_controller_last_successful_sync_timestamp_seconds` — the missing signal for "tunnel config stopped updating", the failure that otherwise strands every external hostname on a stale config with no alert. Health probes move to 8081.

**Connector image pinned** so Renovate tracks it instead of the chart default floating. The `helm-values` manager already does this elsewhere (it bumps immich-server in `apps/photos/values.yaml`). Verified the pin isn't inert — it reaches the controller as `CLOUDFLARED_IMAGE`.

Caveat worth knowing: 0.1.0 moves the connector onto `ghcr.io/strrl/cloudflared`, a maintainer fork carrying the host-metrics patches. It publishes exactly one tag today and trails the official image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)