### PR TITLE
Trim over-long comments in values files

### DIFF
--- a/apps/external-dns/values.yaml
+++ b/apps/external-dns/values.yaml
@@ -20,18 +20,7 @@ extraArgs:
   - --fqdn-template={{`{{`}}.Name{{`}}`}}.{{`{{`}}.Namespace{{`}}`}}.ankhmorpork.thaum.xyz
   - --service-type-filter=LoadBalancer
 
-# The webhook moved from kashalls/ to home-operations/; the old repository is a
-# redirect and its image stops at v0.9.0, so the tag also loses its `v` prefix.
-#
-# From 0.10.x it talks to UniFi's official Integration API
-# (/proxy/network/integration/v1/sites/{id}/dns/policies) instead of the
-# undocumented /proxy/network/v2/api/site/{site}/static-dns, which needs Network
-# 10.3.58+ and external-dns 0.21.0 -- hence the chart bump alongside it. Both
-# API paths are two views of one store, verified by reading the same 82 records
-# through each, so there is nothing to migrate and no duplicates to expect.
-#
-# UNIFI_EXTERNAL_CONTROLLER went away with that move: UNIFI_HOST now points at
-# the controller directly, and remote consoles use UNIFI_CONSOLE_ID instead.
+# Uses UniFi's Integration API; requires Network 10.3.58+ and external-dns 0.21.0.
 provider:
   name: webhook
   webhook:

--- a/apps/system-kured/values.yaml
+++ b/apps/system-kured/values.yaml
@@ -22,17 +22,9 @@ resources:
     cpu: 3m
     memory: 64Mi
 
-# kured is deliberately scheduled onto nothing: every node is labelled
-# kured=disabled, so this selector matches no node and the DaemonSet runs zero
-# pods. Node reboots are therefore a manual job, and all four nodes currently
-# report kured_reboot_required=1.
-#
-# This replaces an earlier stop-gap that held kured's own lock by hand, with
-# weave.works/kured-node-lock='{"nodeID":"manual"}' annotated onto the
-# DaemonSet. That lock is left in place as a backstop: without it, relabelling a
-# node back to kured=enabled would start a pod that immediately drains and
-# reboots, and then works through the rest one at a time. Re-enabling reboots
-# means relabelling *and* clearing that annotation, in that order.
+# Nodes are labelled kured=disabled, so this matches nothing and kured runs 0 pods.
+# To re-enable: relabel kured=enabled, THEN clear the DaemonSet's
+# weave.works/kured-node-lock annotation -- that order, or it reboots immediately.
 nodeSelector:
   kured: enabled
 

--- a/base/cloudflared/values.yaml
+++ b/base/cloudflared/values.yaml
@@ -11,31 +11,11 @@ ingressClass:
 
 replicaCount: 2
 
-# 0.1.0 merged the two ServiceMonitor value groups into one. This single switch
-# now creates ServiceMonitors for both the controller and the cloudflared
-# connectors, replacing cloudflaredServiceMonitor, which 0.1.0 no longer reads --
-# carrying the old key over would have gone silently inert and taken the
-# connector metrics with it.
-#
-# It is also a net gain: until now only the connector was scraped and the
-# controller had no metrics endpoint at all. The controller endpoint adds
-# controller-runtime reconcile and workqueue metrics plus
-# cloudflare_tunnel_ingress_controller_last_successful_sync_timestamp_seconds,
-# which is the signal for "tunnel configuration has stopped being updated" --
-# the failure that would otherwise silently strand every external hostname on a
-# stale config.
+# Covers both controller and connector endpoints; replaced cloudflaredServiceMonitor in 0.1.0.
 serviceMonitor:
   create: true
 
-# Pinned so Renovate tracks it. The chart otherwise carries this tag as a
-# default, which would move under us on any chart bump without showing up as a
-# reviewable change.
-#
-# 0.1.0 moves the connector off cloudflare/cloudflared onto the maintainer's
-# fork, which is what exposes the host metrics the connector ServiceMonitor
-# scrapes. Worth knowing: that fork publishes exactly one tag today and it
-# trails the official image, so Renovate has nothing to bump to until the
-# maintainer rebuilds.
+# Pinned so Renovate tracks it. Maintainer fork, carries the host-metrics patches.
 cloudflared:
   image:
     repository: ghcr.io/strrl/cloudflared


### PR DESCRIPTION
Comments-only: 45 lines of prose down to 6. Non-comment content byte-identical in all three files, so nothing re-renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)