### PR TITLE
Add two more NPD checks

### DIFF
--- a/base/node-problem-detector/values.yaml
+++ b/base/node-problem-detector/values.yaml
@@ -47,6 +47,12 @@ resources:
     cpu: 3m
     memory: 18Mi
 
+# hostNetwork so network_problem.sh sees the host conntrack table; in the pod
+# netns nf_conntrack_count reads 0. ClusterFirstWithHostNet keeps cluster DNS,
+# which dns_problem.sh needs to resolve kubernetes.default.
+hostNetwork: true
+dnsPolicy: ClusterFirstWithHostNet
+
 settings:
   #log_monitors:
   #  - /config/kernel-monitor.json
@@ -56,7 +62,11 @@ settings:
     - /config/kernel-monitor.json
     - /config/readonly-monitor.json
 
-  #custom_plugin_monitors:
+  custom_plugin_monitors:
+    # FrequentUnregisterNetDevice node condition, counted from journald.
+    - /config/kernel-monitor-counter.json
+    # ConntrackFull and DNSUnreachable events.
+    - /config/network-problem-monitor.json
     # - /config/health-checker-containerd.json
     # - /config/custom-plugin-monitor.json ## This is NTP monitor. Disabled as it requires systemctl to be present in the container.
 


### PR DESCRIPTION
Enables two monitors that ship in the image but were never loaded:

- **`kernel-monitor-counter.json`** — counts `unregister_netdevice` in journald and sets a **`FrequentUnregisterNetDevice` node condition** (3 hits in 20m). Verified `log-counter` runs against `/var/log/journal` in-cluster, which the chart already mounts.
- **`network-problem-monitor.json`** — adds `ConntrackFull` and `DNSUnreachable`. Temporary rules, so events/counters rather than conditions.

Both need `hostNetwork`: in the pod netns `nf_conntrack_count` reads **0** against a max of 524288, so the conntrack check would have watched an empty table and reported healthy forever.

hostNetwork then forces the dnsPolicy question — `dns_problem.sh` resolves `kubernetes.default`, and the chart default `ClusterFirst` would send that to the host resolver, which has no cluster DNS: a guaranteed false `DNSUnreachable` on every node every 30s. `ClusterFirstWithHostNet` keeps cluster DNS.

Nothing else binds host port 20257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)