### PR TITLE
Add unattended-upgrades monitoring to NPD

### DIFF
--- a/base/node-problem-detector/values.yaml
+++ b/base/node-problem-detector/values.yaml
@@ -104,11 +104,69 @@ settings:
         ]
       }
 
+    apt-monitor.json: |
+      {
+        "plugin": "custom",
+        "pluginConfig": {
+          "invoke_interval": "10m",
+          "timeout": "1m",
+          "max_output_length": 80,
+          "concurrency": 1
+        },
+        "source": "apt-monitor",
+        "metricsReporting": true,
+        "conditions": [
+          {
+            "type": "UnattendedUpgradeUnhealthy",
+            "reason": "UnattendedUpgradeIsHealthy",
+            "message": "unattended-upgrades is functioning properly"
+          },
+          {
+            "type": "APTLongRunning",
+            "reason": "APTNotLongRunning",
+            "message": "no apt job has been running for an unusual length of time"
+          }
+        ],
+        "rules": [
+          {
+            "type": "permanent",
+            "condition": "UnattendedUpgradeUnhealthy",
+            "reason": "UnattendedUpgradeFailed",
+            "path": "/home/kubernetes/bin/log-counter",
+            "args": [
+              "--journald-source=systemd",
+              "--log-path=/var/log/journal",
+              "--lookback=24h",
+              "--count=1",
+              "--pattern=apt-daily[a-z-]*\\.service: Failed with result.*"
+            ],
+            "timeout": "1m"
+          },
+          {
+            "type": "permanent",
+            "condition": "APTLongRunning",
+            "reason": "APTLongRunning",
+            "path": "/home/kubernetes/bin/log-counter",
+            "args": [
+              "--journald-source=systemd",
+              "--log-path=/var/log/journal",
+              "--lookback=6h",
+              "--count=1",
+              "--pattern=Starting apt-daily[a-z-]*\\..*",
+              "--revert-pattern=Finished apt-daily[a-z-]*\\..*"
+            ],
+            "timeout": "1m"
+          }
+        ]
+      }
+
   custom_plugin_monitors:
     # FrequentUnregisterNetDevice node condition, counted from journald.
     - /config/kernel-monitor-counter.json
     # FrequentK3sRestart node condition; definition above.
     - /custom-config/k3s-monitor-counter.json
+    # UnattendedUpgradeUnhealthy node condition; definition above.
+    - /custom-config/apt-monitor.json
     # ConntrackFull and DNSUnreachable events.
     - /config/network-problem-monitor.json
     # - /config/health-checker-containerd.json


### PR DESCRIPTION
Two node conditions from journald, same log-counter mechanism as the k3s monitor:

- **`UnattendedUpgradeUnhealthy`** — fires on `apt-daily*.service: Failed with result`, covering a failed run and one systemd killed on timeout.
- **`APTLongRunning`** — counts `Starting apt-daily*` and discounts `Finished apt-daily*` over 6h. A start with no matching finish means the job is wedged: the dpkg-lock style hang that leaves the unit activating forever without systemd ever marking it failed.

Patterns validated against the live journal — start pattern matches, revert cancels it to zero, failure pattern finds nothing in 24h.

The `APTLongRunning` window is safe because runs are short (unattended-upgrades logs start→completion in ~2s) against a 10m check interval, so sampling mid-run is rare.

Baseline is clean: `apt-daily`/`apt-daily-upgrade` only ever log "Deactivated successfully" (29/28 times), no ERROR lines in `unattended-upgrades.log`. `unattended_automatic_reboot: false` in ansible, so reboots stay with kured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)