### PR TITLE
Fix Loki monolithic startup

### DIFF
--- a/apps/datalake-logs/values.yaml
+++ b/apps/datalake-logs/values.yaml
@@ -25,6 +25,14 @@ singleBinary:
     # when a node reboots.
     storageClass: longhorn
 
+# The memberlist Service is headless and, by default, only publishes ready
+# endpoints. With one replica that deadlocks at startup: the pod is not ready
+# until it joins, it cannot join until the name resolves, and the name does not
+# resolve until it is an endpoint. abort_if_cluster_join_fails then crashloops it.
+memberlist:
+  service:
+    publishNotReadyAddresses: true
+
 # Not used in monolithic mode.
 write:
   replicas: 0
@@ -67,6 +75,9 @@ monitoring:
 
 loki:
   auth_enabled: false
+  commonConfig:
+    # Chart default is 3, which cannot be satisfied by a single ingester.
+    replication_factor: 1
   analytics:
     reporting_enabled: false
 


### PR DESCRIPTION
Two chart defaults that don't work at one replica, both caught by the install crashlooping rather than by the render:

- **`memberlist.service.publishNotReadyAddresses: false`** — the Service is headless, so startup deadlocks: pod isn't ready until it joins memberlist, the name doesn't resolve until it's a *ready* endpoint, and `abort_if_cluster_join_fails` turns that into a crashloop.
- **`commonConfig.replication_factor: 3`** — unsatisfiable with a single ingester.

🤖 Generated with [Claude Code](https://claude.com/claude-code)