### PR TITLE
Set the S3 region Loki signs with

### DIFF
--- a/apps/datalake-logs/values.yaml
+++ b/apps/datalake-logs/values.yaml
@@ -107,6 +107,10 @@ loki:
       ruler: loki
     s3:
       endpoint: http://versitygw.datalake-logs.svc.cluster.local:7070
+      # Must match the gateway's VGW_REGION, which the versitygw chart defaults
+      # to us-east-1. Unset, the loki chart signs with "dummy" and versitygw
+      # rejects it as AuthorizationHeaderMalformed.
+      region: us-east-1
       s3ForcePathStyle: true
       insecure: true
       accessKeyId: "${S3_ACCESS_KEY}"


### PR DESCRIPTION
Unset, the chart signs with region `dummy` and versitygw rejects it:

```
AuthorizationHeaderMalformed: the region "dummy" is wrong; expecting "us-east-1"
```

`VGW_REGION` on the gateway is `us-east-1`. Same mismatch that had to be resolved for the Longhorn BackupTarget against the other versitygw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)