### PR TITLE
Move the versity HelmRepository into versity/

### DIFF
--- a/apps/datalake-logs/repository.yaml
+++ b/apps/datalake-logs/repository.yaml
@@ -7,12 +7,3 @@ metadata:
 spec:
   interval: 5m
   url: https://grafana-community.github.io/helm-charts
----
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
-metadata:
-  name: versity
-spec:
-  type: oci
-  interval: 15m
-  url: oci://ghcr.io/versity/versitygw/charts

--- a/apps/datalake-logs/versity/kustomization.yaml
+++ b/apps/datalake-logs/versity/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 # Namespace is created and owned by the parent.
 namespace: datalake-logs
 resources:
+  - repository.yaml
   - release.yaml
   - credentials-generator.yaml
   - credentials-secret.yaml

--- a/apps/datalake-logs/versity/repository.yaml
+++ b/apps/datalake-logs/versity/repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: versity
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/versity/versitygw/charts


### PR DESCRIPTION
One object per file: `repository.yaml` held both `grafana-community` and `versity`. The versity one belongs next to the release that uses it.

Rendered object set is identical (11 objects, verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)