### PR TITLE
Move pod and filename to structured metadata

### DIFF
--- a/apps/alloy/values.yaml
+++ b/apps/alloy/values.yaml
@@ -89,6 +89,18 @@ alloy:
       loki.process "pod_logs" {
         // containerd writes CRI-format lines.
         stage.cri {}
+
+        // pod changes on every restart and filename is unique per container
+        // instance, so as stream labels they multiply cardinality for no query
+        // benefit. As structured metadata they stay queryable without being
+        // indexed. Naming a label here removes it from the label set.
+        stage.structured_metadata {
+          values = {
+            pod      = "",
+            filename = "",
+          }
+        }
+
         forward_to = [loki.write.default.receiver]
       }
 


### PR DESCRIPTION
Both are high-cardinality as stream labels: `pod` takes a new value on every restart, `filename` is unique per container instance. Neither earns a place in the index — `container` already carries the useful part of the path — but both stay worth querying, which is what structured metadata is for.

Naming a label in `stage.structured_metadata` removes it from the label set. Remaining stream labels: `namespace`, `app`, `container`, `node`, `job`, `environment`.

Config checked with `alloy validate` (EXIT=0). Runtime effect verified against Loki's label list after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)