### PR TITLE
Backdate the Loki schema and tail pod logs from the end

### DIFF
--- a/apps/alloy/values.yaml
+++ b/apps/alloy/values.yaml
@@ -84,6 +84,10 @@ alloy:
       loki.source.file "pod_logs" {
         targets    = local.file_match.pod_logs.targets
         forward_to = [loki.process.pod_logs.receiver]
+        // Start at the end on first sight of a file. Otherwise every existing
+        // pod log is replayed, and anything past Loki's 7 day
+        // reject_old_samples_max_age is dropped anyway.
+        tail_from_end = true
       }
 
       loki.process "pod_logs" {

--- a/apps/datalake-logs/values.yaml
+++ b/apps/datalake-logs/values.yaml
@@ -81,11 +81,15 @@ loki:
   analytics:
     reporting_enabled: false
 
-  # Required from chart 6.x: no schema is assumed. Single entry from the
-  # cutover, since the old data is not being carried over.
+  # Required from chart 6.x: no schema is assumed.
+  #
+  # Backdated deliberately. Dating this at the cutover rejected every log line
+  # older than the install with "no schema config found for time ...", and pod
+  # log files on disk go back days. A schema boundary at install time is a trap;
+  # there is no data before this either way.
   schemaConfig:
     configs:
-      - from: "2026-08-18"
+      - from: "2024-01-01"
         store: tsdb
         object_store: s3
         schema: v13


### PR DESCRIPTION
Alloy was dropping **every batch**:

```
failed to create stream: no schema config found for time 1786574252
```

That timestamp is 2026-08-11. The schema started at the cutover date, so any line older than the install had no schema to land in — and pod log files on disk go back days, which `loki.source.file` replays from the beginning by default. A schema boundary at install time is a trap for exactly this case; there's no data before it either way, so it's backdated to 2024-01-01.

`tail_from_end = true` stops the replay. Lines past Loki's 7-day `reject_old_samples_max_age` would be refused regardless, so reading history only produced dropped batches and log noise.

Both verified: `alloy validate` EXIT=0, schema renders as 2024-01-01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)