### PR TITLE
Move pod to structured metadata and drop filename

### DIFF
--- a/apps/alloy/values.yaml
+++ b/apps/alloy/values.yaml
@@ -94,15 +94,25 @@ alloy:
         // containerd writes CRI-format lines.
         stage.cri {}
 
-        // pod changes on every restart and filename is unique per container
-        // instance, so as stream labels they multiply cardinality for no query
-        // benefit. As structured metadata they stay queryable without being
-        // indexed. Naming a label here removes it from the label set.
+        // pod changes on every restart, so as a stream label it multiplies
+        // cardinality. Keep it queryable as structured metadata instead.
+        //
+        // stage.structured_metadata reads the extracted map, and pod is a
+        // stream label, which never lands there -- naming it directly is a
+        // no-op. stage.template does resolve stream labels though (undocumented
+        // but verified with loki.echo), so it bridges the two.
+        stage.template {
+          source   = "pod_sm"
+          template = "{{ .pod }}"
+        }
         stage.structured_metadata {
-          values = {
-            pod      = "",
-            filename = "",
-          }
+          values = { pod = "pod_sm" }
+        }
+
+        // filename is dropped rather than kept: namespace, pod and container
+        // already identify the source, so the path adds nothing queryable.
+        stage.label_drop {
+          values = ["pod", "filename"]
         }
 
         forward_to = [loki.write.default.receiver]


### PR DESCRIPTION
The previous attempt named `pod` and `filename` directly in `stage.structured_metadata`, which **did nothing** — that stage reads the *extracted map*, and both are stream labels which never land there. Verified against the running cluster: both stayed as labels.

`stage.template` **does** resolve stream labels, which the docs don't mention. Confirmed with `loki.echo` on a synthetic file:

```
labels="{namespace=\"demo\"}"
structured_metadata="{\"pod\":\"my-pod-abc123\"}"
```

So the working sequence is: `template` copies the label into the extracted map → `structured_metadata` promotes it → `label_drop` removes the original.

`filename` is dropped outright — `namespace`, `pod` and `container` already identify the source, so the path indexes nothing worth querying.

Remaining stream labels: `namespace`, `app`, `container`, `node`, `job`, `environment`.

`alloy validate` EXIT=0.