### PR TITLE
jellyfin: drop privileged and the render-device hostPath

### DIFF
--- a/apps/jellyfin/app/values.yaml
+++ b/apps/jellyfin/app/values.yaml
@@ -34,13 +34,6 @@ resources:
   limits:
     gpu.intel.com/i915: "1"
 
-securityContext:
-  privileged: true
-
-podSecurityContext:
-  supplementalGroups:
-    - 109
-
 persistence:
   config:
     enabled: true
@@ -68,9 +61,6 @@ volumes:
     emptyDir:
       medium: Memory
       sizeLimit: 2Gi
-  - name: render-device
-    hostPath:
-      path: /dev/dri/renderD128
 
 volumeMounts:
   - name: media-tv
@@ -81,8 +71,6 @@ volumeMounts:
     mountPath: /media/books
   - name: transcodes
     mountPath: /cache/transcodes
-  - name: render-device
-    mountPath: /dev/dri/renderD128
 
 # postStart hook flips EnableMetrics in system.xml, so it survives a config reset.
 metrics:


### PR DESCRIPTION
The Intel device plugin injects both `card0` and `renderD128` via the `gpu.intel.com/i915` limit, so the hostPath was shadowing a device already present. Verified with `vainfo` in an unprivileged pod with no hostPath: iHD driver loads, full profile list intact.

`supplementalGroups: 109` goes too — the render node is group 993 on the host, and the container runs as root, so neither had any effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)