### PR TITLE
cilium: 1.18.13 -> 1.19.7

### DIFF
--- a/core/kube-system/cilium/release.yaml
+++ b/core/kube-system/cilium/release.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     spec:
       chart: cilium
-      version: "1.18.13"
+      version: "1.19.7"
       sourceRef:
         kind: HelmRepository
         name: cilium


### PR DESCRIPTION
1.18 is e2e tested against k8s **1.30–1.33** only; this cluster runs **1.34**, so the current pairing sits outside the supported matrix. 1.19 covers 1.31–1.34. (1.20 covers 1.33–1.36 but Cilium only supports one minor at a time.)

Checked against the 1.19 upgrade notes:
- `CiliumLoadBalancerIPPool` already moved to `cilium.io/v2` in #1053 — this is a hard requirement, v2alpha1 is dropped
- no `CiliumBGPPeeringPolicy` objects; BGPv1 is removed in 1.19 and we use the v2 CRDs
- no CiliumNetworkPolicy or ClusterwideNetworkPolicy at all, so the `**` wildcard and `FromRequires`/`ToRequires` changes don't apply
- none of the removed flags (`custom-calls`, `svc-source-range-check`, `session-affinity`) appear in the rendered config
- `bpf.tproxy` stays unset, which netkit requires

🤖 Generated with [Claude Code](https://claude.com/claude-code)