### PR TITLE
cilium: 1.19.7 -> 1.20.1

### DIFF
--- a/core/kube-system/cilium/release.yaml
+++ b/core/kube-system/cilium/release.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     spec:
       chart: cilium
-      version: "1.19.7"
+      version: "1.20.1"
       sourceRef:
         kind: HelmRepository
         name: cilium


### PR DESCRIPTION
1.19.7 is already the latest 1.19 patch, and 1.20 is e2e tested against k8s **1.33–1.36**, so 1.34 stays covered.

Against the 1.20 upgrade notes:
- no `CiliumNodeConfig` objects, so the `v2alpha1` → `v2` removal does not apply
- no CiliumNetworkPolicy/ClusterwideNetworkPolicy at all, so the Kafka and Envoy Go extension removals are moot, as is the SocketLB NodePort policy change
- cilium's Gateway API is disabled and no `TLSRoute` type is installed
- `bpf.tproxy` stays unset, required for netkit
- `KUBERNETES_SERVICE_HOST/PORT` still render, so the k3s loopback change from #1055 carries over

Chart only gained keys between these versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)