### PR TITLE
longhorn: 1.9.2 -> 1.10.2

### DIFF
--- a/base/longhorn-system/release.yaml
+++ b/base/longhorn-system/release.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: longhorn
-      version: "1.12.0"
+      version: "1.10.2"
       sourceRef:
         kind: HelmRepository
         name: longhorn


### PR DESCRIPTION
Second rung. Renovate jumped straight to 1.12.0, which the pre-upgrade job rejects from 1.9 — Longhorn allows one minor at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)