### PR TITLE
longhorn: 1.11.3 -> 1.12.1

### DIFF
--- a/base/longhorn-system/release.yaml
+++ b/base/longhorn-system/release.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: longhorn
-      version: "1.11.3"
+      version: "1.12.1"
       sourceRef:
         kind: HelmRepository
         name: longhorn


### PR DESCRIPTION
Final rung. 1.12.1 rather than the 1.12.0 renovate proposed — it is the latest patch.

Staying on the **v1 data engine**: all 17 volumes are `dataEngine: v1`, and v1 is not deprecated. v2 wants a dedicated CPU core per node (2 by default since 1.12.0), which is 27–54% of each 4-core master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)