### PR TITLE
monitoring: resume

### DIFF
--- a/base/flux-apps/monitoring.yaml
+++ b/base/flux-apps/monitoring.yaml
@@ -11,5 +11,4 @@ spec:
   sourceRef:
     kind: GitRepository
     name: ankhmorpork
-  suspend: true
 


### PR DESCRIPTION
Last suspended object in the fleet. `flux diff` shows **7 drifted objects and nothing created or deleted**, so `prune: true` has nothing to remove:

| kind | objects |
|---|---|
| ExternalSecret | alertmanager-main, github-receiver-credentials, grafana-oidc, uptimerobot |
| DaemonSet | goldpinger |
| Deployment | grafana |
| Ingress | pyrra-api |

No HelmReleases in this path, so the manifests are the whole change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)