### PR TITLE
grafana, jellyfin: use Recreate for RWO-backed deployments

### DIFF
--- a/apps/jellyfin/app/values.yaml
+++ b/apps/jellyfin/app/values.yaml
@@ -3,6 +3,10 @@
 jellyfin:
   enableDLNA: false
 
+# RWO config PVC: RollingUpdate deadlocks on multi-attach across nodes.
+deploymentStrategy:
+  type: Recreate
+
 # Ingress is carried outside the chart, see ingress.yaml
 ingress:
   enabled: false

--- a/apps/monitoring/manifests/grafana/deployment.yaml
+++ b/apps/monitoring/manifests/grafana/deployment.yaml
@@ -10,6 +10,9 @@ metadata:
   namespace: monitoring
 spec:
   replicas: 1
+  # RWO PVC: RollingUpdate deadlocks on multi-attach across nodes.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/component: grafana


### PR DESCRIPTION
grafana deadlocked on resume — the new pod landed on beelink02 while the old one held the RWO volume on beelink01, and `RollingUpdate` will not release it until the new pod is Ready. Needed a manual pod delete to break it.

jellyfin has the same shape via `jellyfin-config`. Today's upgrade only survived because both pods happened to schedule on beelink02, where RWO multi-attach is permitted.

Swept the fleet: these are the **only two** Deployments mounting an RWO PVC under RollingUpdate. Everything else with a PVC is either RWX or already `Recreate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)