### PR TITLE
longhorn: point the oidc middleware at the plugin's real key

### DIFF
--- a/base/longhorn-system/middleware.yaml
+++ b/base/longhorn-system/middleware.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: longhorn-system
 spec:
   plugin:
-    traefik-oidc-auth: # same key as in the static configuration
+    oidc: # same key as in the static configuration
       Secret: "urn:k8s:secret:oidc-secret:pluginSecret"
       Provider:
         # You could just write strings here for the values.


### PR DESCRIPTION
Traefik names plugins after the key in `experimental.plugins`, which is **`oidc`**. The middleware asked for `traefik-oidc-auth` — the *module* name — so traefik rejected the router with `unknown plugin type` and served 404.

Broken since the middleware was written on 2025-11-26, three days after the plugin was registered. It stayed invisible because `longhorn-system` was suspended: the live ingress kept the old chart's annotations and never carried the `router.middlewares` reference until the 1.12.1 upgrade applied it.

So longhorn's OIDC has never actually been enforced — the UI was reachable without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)