### PR TITLE
paperless: skip django checks in the backup job

### DIFF
--- a/apps/paperless/manifests/backups/cronjob.yaml
+++ b/apps/paperless/manifests/backups/cronjob.yaml
@@ -47,11 +47,13 @@ spec:
                 - mountPath: /export
                   name: backups
           containers:
-            - args: []
+            - args:
+                # paperless-config sets OCR languages the export image does not
+                # ship; the exporter never OCRs, so skip the django checks.
+                - --skip-checks
               #  - --use-folder-prefix
               #  - --zip
               #  - --no-color
-              #  - --skip-checks
               env: []
               envFrom:
                 - configMapRef:


### PR DESCRIPTION
The export image doesn't ship the tesseract language packs, but the job inherits `PAPERLESS_OCR_LANGUAGE=pol+eng` from `paperless-config` via `envFrom`. Django runs system checks before every management command, so it aborts with `SystemCheckError` before `document_exporter` ever starts — **paperless backups have never produced anything**.

The exporter doesn't OCR, so `--skip-checks` is the correct fix, and it was already sitting commented out in the args.

🤖 Generated with [Claude Code](https://claude.com/claude-code)