### PR TITLE
paperless: pass the exporter command explicitly in the backup job

### DIFF
--- a/apps/paperless/manifests/backups/cronjob.yaml
+++ b/apps/paperless/manifests/backups/cronjob.yaml
@@ -48,8 +48,10 @@ spec:
                   name: backups
           containers:
             - args:
-                # paperless-config sets OCR languages the export image does not
-                # ship; the exporter never OCRs, so skip the django checks.
+                # The wrapper script hardcodes "document_exporter /export" and
+                # drops arguments, so hand s6 the whole command instead.
+                - /usr/local/bin/document_exporter
+                - /export
                 - --skip-checks
               #  - --use-folder-prefix
               #  - --zip


### PR DESCRIPTION
Follow-up to #1071, which didn't work.

The wrapper script is `exec /usr/local/bin/document_exporter /export` with **no argument forwarding**, and s6 execs whatever `args` are given *as the command* — so a bare `--skip-checks` was run as a binary:

```
/run/s6/basedir/scripts/rc.init: 91: --skip-checks: not found
```

Handing s6 the full command line gets the flag through to `document_exporter`.

The checks need skipping because `paperless-config` sets `PAPERLESS_OCR_LANGUAGE=pol+eng`, while the export image only carries `deu/eng/fra/ita/osd/spa` — `pol` is installed at runtime by paperless' s6 init scripts, which this image removes on purpose.

Image stays at 1.4.0: it is built on paperless-ngx **2.20.0**, matching the app exactly. 2.0.0 rebases onto **3.0.4** and would point a 3.x exporter at a 2.20 database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)