### PR TITLE
paperless: run backups from the official image

### DIFF
--- a/apps/paperless/manifests/backups/cronjob.yaml
+++ b/apps/paperless/manifests/backups/cronjob.yaml
@@ -47,15 +47,19 @@ spec:
                 - mountPath: /export
                   name: backups
           containers:
-            - args:
-                # The wrapper script hardcodes "document_exporter /export" and
-                # drops arguments, so hand s6 the whole command instead.
-                - /usr/local/bin/document_exporter
+            # Calling manage.py directly bypasses s6, so none of the paperless
+            # services start. The document_exporter wrapper is not usable here:
+            # it is with-contenv and needs an environment only s6 assembles.
+            # --skip-checks because init-tesseract-langs, which installs the pol
+            # pack that paperless-config asks for, is part of that same init.
+            - command:
+                - python3
+                - manage.py
+                - document_exporter
                 - /export
                 - --skip-checks
-              #  - --use-folder-prefix
-              #  - --zip
-              #  - --no-color
+              workingDir: /usr/src/paperless/src
+              args: []
               env: []
               envFrom:
                 - configMapRef:
@@ -64,12 +68,14 @@ spec:
                     name: paperless-secrets
                 - secretRef:
                     name: paperless-db
-              image: ghcr.io/community-tooling/oci-images/paperless-export:1.4.0
+              image: ghcr.io/paperless-ngx/paperless-ngx:2.20.0
               name: backup
               ports: []
               resources: {}
               securityContext:
                 privileged: false
+                runAsUser: 1000
+                runAsGroup: 1000
               volumeMounts:
                 - mountPath: /usr/src/paperless/data
                   name: data


### PR DESCRIPTION
Drops `ghcr.io/community-tooling/oci-images/paperless-export`, which exists only to stop the s6 services from starting. Overriding `command` achieves the same thing by bypassing `/init` — `svc-webserver`, `svc-worker`, `svc-consumer`, `svc-scheduler` and `svc-flower` never come up.

`document_exporter` itself can't be the command: it's a `#!/command/with-contenv` wrapper needing the environment s6 assembles, and fails with `s6-envdir: fatal: unable to envdir /run/s6/container_environment`. All it does is `cd $PAPERLESS_SRC_DIR` then run `manage.py document_exporter "$@"` as uid 1000 — which `workingDir` and `securityContext` reproduce exactly.

`--skip-checks` is still required: `init-tesseract-langs` installs the `pol` pack `paperless-config` asks for, and it's part of the same init we're skipping.

Verified working on a test pod against the live database before switching.

Side benefit: the backup image now tracks the app image, so they can't drift — the trap that made export `2.0.0` (paperless 3.0.4) unusable against the app's 2.20.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)