### PR TITLE
paperless: upgrade to 3.0.5

### DIFF
--- a/apps/paperless/manifests/app/config.yaml
+++ b/apps/paperless/manifests/app/config.yaml
@@ -8,12 +8,14 @@ metadata:
   namespace: paperless
 data:
   PAPERLESS_BIND_ADDR: "0.0.0.0"
-  PAPERLESS_CONSUMER_POLLING: "60"
-  PAPERLESS_CONSUMER_POLLING_DELAY: "30"
-  PAPERLESS_CONSUMER_POLLING_RETRY_COUNT: "20"
+  # watchfiles replaced the old polling settings in 3.x. Kept explicit because
+  # the consume dir is NFS, where inotify is unreliable.
+  PAPERLESS_CONSUMER_POLLING_INTERVAL: "60"
+  PAPERLESS_CONSUMER_STABILITY_DELAY: "30"
   PAPERLESS_CORS_ALLOWED_HOSTS: http://paperless-headless.paperless.svc,http://paperless.paperless.svc,https://papers.krupa.net.pl,https://paperless.motmot-prometheus.ts.net
-  PAPERLESS_DB_POOLSIZE: "10"
   PAPERLESS_DB_READ_CACHE_ENABLED: "false" # using pgBouncer, so no need for read cache
+  # 3.x defaults to sqlite and requires this to be explicit for postgres.
+  PAPERLESS_DBENGINE: postgresql
   PAPERLESS_ENABLE_FLOWER: "true"
   PAPERLESS_FILENAME_FORMAT: '{{created_year}}/{{correspondent}}/{{asn}} - {{title}}'
   PAPERLESS_OCR_LANGUAGE: pol+eng

--- a/apps/paperless/manifests/app/databaseSecret.yaml
+++ b/apps/paperless/manifests/app/databaseSecret.yaml
@@ -25,5 +25,6 @@ spec:
         PAPERLESS_DBNAME: paperless
         PAPERLESS_DBPASS: '{{ .PAPERLESS_DBPASS }}'
         PAPERLESS_DBPORT: "5432"
-        PAPERLESS_DBSSLMODE: prefer
+        # 3.x replaced DBSSLMODE and DB_POOLSIZE with one options string.
+        PAPERLESS_DB_OPTIONS: sslmode=prefer,pool.max_size=10
         PAPERLESS_DBUSER: paperless

--- a/apps/paperless/manifests/app/statefulSet.yaml
+++ b/apps/paperless/manifests/app/statefulSet.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: paperless
     spec:
       containers:
-        - image: ghcr.io/paperless-ngx/paperless-ngx:2.20.0
+        - image: ghcr.io/paperless-ngx/paperless-ngx:3.0.5
           name: paperless
           env:
             - name: POD_IP

--- a/apps/paperless/manifests/backups/cronjob.yaml
+++ b/apps/paperless/manifests/backups/cronjob.yaml
@@ -68,7 +68,7 @@ spec:
                     name: paperless-secrets
                 - secretRef:
                     name: paperless-db
-              image: ghcr.io/paperless-ngx/paperless-ngx:2.20.0
+              image: ghcr.io/paperless-ngx/paperless-ngx:3.0.5
               name: backup
               ports: []
               resources: {}


### PR DESCRIPTION
Major upgrade, 2.20.0 → 3.0.5. Four of the nine breaking changes touch this deployment.

| current | 3.x |
|---|---|
| *(unset)* | **`PAPERLESS_DBENGINE=postgresql`** |
| `PAPERLESS_DBSSLMODE` + `PAPERLESS_DB_POOLSIZE` | `PAPERLESS_DB_OPTIONS="sslmode=prefer,pool.max_size=10"` |
| `PAPERLESS_CONSUMER_POLLING` | `PAPERLESS_CONSUMER_POLLING_INTERVAL` |
| `PAPERLESS_CONSUMER_POLLING_DELAY` | `PAPERLESS_CONSUMER_STABILITY_DELAY` |
| `PAPERLESS_CONSUMER_POLLING_RETRY_COUNT` | removed, no successor |

**`DBENGINE` is the dangerous one** — it defaults to `sqlite` and the docs require postgres users to set it explicitly. Without it 3.x starts against an empty sqlite file and presents an empty library rather than failing.

`DB_OPTIONS` is folded into the ExternalSecret template, which already carried `sslmode` as a literal — no Doppler change.

Consumer settings kept explicit because the consume dir is **NFS**, where watchfiles can't rely on inotify.

Not affected: no pre/post-consume scripts, no document encryption, and the barcode change only removes the scanner-choice setting (never set here) — zxing-cpp becomes the sole reader. OCR decoupling removes `skip`/`skip_noarchive`/`OCR_SKIP_ARCHIVE_FILE`, none of which are set.

First start migrates whoosh → tantivy (full reindex) and md5 → sha256 checksums. Document export (811 files) and an on-demand CNPG backup both taken beforehand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)