### PR TITLE
paperless: step through 2.20.15 before 3.x

### DIFF
--- a/apps/paperless/manifests/app/statefulSet.yaml
+++ b/apps/paperless/manifests/app/statefulSet.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: paperless
     spec:
       containers:
-        - image: ghcr.io/paperless-ngx/paperless-ngx:3.0.5
+        - image: ghcr.io/paperless-ngx/paperless-ngx:2.20.15
           name: paperless
           env:
             - name: POD_IP

--- a/apps/paperless/manifests/backups/cronjob.yaml
+++ b/apps/paperless/manifests/backups/cronjob.yaml
@@ -68,7 +68,7 @@ spec:
                     name: paperless-secrets
                 - secretRef:
                     name: paperless-db
-              image: ghcr.io/paperless-ngx/paperless-ngx:3.0.5
+              image: ghcr.io/paperless-ngx/paperless-ngx:2.20.15
               name: backup
               ports: []
               resources: {}


### PR DESCRIPTION
v3 refuses to migrate from anything older than 2.20.15:

```
HINT: Upgrading to v3 can only be performed from v2.20.15
```

The check runs **before** migrations, so 3.0.5 crashlooped without touching the database — `[init-db-wait] Connected to PostgreSQL` confirms `DBENGINE` was correct and it never fell back to sqlite.

Config already carries the 3.x settings; they're simply ignored on 2.x. 3.0.5 follows once this is running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)