### PR TITLE
paperless: 2.20.15 -> 3.0.5

### DIFF
--- a/apps/paperless/manifests/app/statefulSet.yaml
+++ b/apps/paperless/manifests/app/statefulSet.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: paperless
     spec:
       containers:
-        - image: ghcr.io/paperless-ngx/paperless-ngx:2.20.15
+        - image: ghcr.io/paperless-ngx/paperless-ngx:3.0.5
           name: paperless
           env:
             - name: POD_IP

--- a/apps/paperless/manifests/backups/cronjob.yaml
+++ b/apps/paperless/manifests/backups/cronjob.yaml
@@ -68,7 +68,7 @@ spec:
                     name: paperless-secrets
                 - secretRef:
                     name: paperless-db
-              image: ghcr.io/paperless-ngx/paperless-ngx:2.20.15
+              image: ghcr.io/paperless-ngx/paperless-ngx:3.0.5
               name: backup
               ports: []
               resources: {}


### PR DESCRIPTION
The upgrade gate is satisfied now that 2.20.15 is running. The 3.x config from #1074 is already in place, so this is only the image bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)