### PR TITLE
metal: k3s v1.34.10

### DIFF
--- a/metal/group_vars/k3s.yml
+++ b/metal/group_vars/k3s.yml
@@ -2,7 +2,7 @@
 kube_vip_image: ghcr.io/kube-vip/kube-vip:v0.8.9
 kube_vip_ip: "192.168.50.30"  # VIP IP managed by kube-vip
 
-k3s_version: v1.34.2+k3s1 #v1.35.3+k3s1
+k3s_version: v1.34.10+k3s1 #next rungs: v1.35.7+k3s1, then v1.36.3+k3s1
 #k3s_master_ip: "{{ hostvars[groups['k3s_control_plane'][0]]['ansible_default_ipv4']['address'] }}"
 k3s_master_ip: "{{ kube_vip_ip }}"
 


### PR DESCRIPTION
Levels every node on the latest 1.34 before the 1.35 and 1.36 hops.

master02 is still on `v1.34.1+k3s1` with containerd `2.1.4-k3s2` while the other three run `v1.34.2+k3s1` / `2.1.5-k3s1`, so this also clears the skew before stepping minors.

k3s follows the Kubernetes version-skew policy and **forbids skipping minors**, and the upgrade controller explicitly does not enforce it — so the ladder is manual: **1.34.10 → 1.35.7 → 1.36.3**.

The riskiest step in this range, etcd 3.5 → 3.6, is already behind us: the cluster reports `etcd_cluster_version 3.6` / `etcd_server_version 3.6.5` with a healthy leader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)