### PR TITLE
kured: resume automatic reboots

### DIFF
--- a/apps/system-kured/values.yaml
+++ b/apps/system-kured/values.yaml
@@ -22,9 +22,9 @@ resources:
     cpu: 3m
     memory: 64Mi
 
-# Nodes are labelled kured=disabled, so this matches nothing and kured runs 0 pods.
-# To re-enable: relabel kured=enabled, THEN clear the DaemonSet's
-# weave.works/kured-node-lock annotation -- that order, or it reboots immediately.
+# Per-node kill switch: relabel a node kured=disabled to stop it rebooting.
+# Turning one back on: relabel first, then clear the DaemonSet's
+# weave.works/kured-node-lock annotation -- that order, or it reboots at once.
 nodeSelector:
   kured: enabled
 


### PR DESCRIPTION
All four nodes are relabelled `kured=enabled` and the manual lock annotation is cleared, so kured reboots again in its **Mon/Wed/Thu 07:00–12:00 UTC** window.

It was stopped while apps were in a fragile state; the fleet is healthy now — 40/40 HelmReleases Ready, nothing suspended.

All four nodes currently have `/var/run/reboot-required`, and two of them need a reboot to pick up the corrected grub cmdline (master01 to drop `ipv6.disable=1`, master02 to regain IPv6). master01 also has a pending kernel update, `6.8.0-88` vs `6.8.0-107` elsewhere.

The `nodeSelector` stays as a per-node kill switch, so the comment now documents that rather than the fleet-wide pause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)