### PR TITLE
kured: shorten polling while the reboot backlog clears

### DIFF
--- a/apps/system-kured/values.yaml
+++ b/apps/system-kured/values.yaml
@@ -5,14 +5,16 @@ configuration:
   concurrency: 1
   # Abort drain after this time
   drainTimeout: "2h"
-  period: "2h"
+  # TEMPORARY: 2h/1h cannot clear a 4-node backlog inside the 5h window.
+  # Revert to period 2h / lockReleaseDelay 1h once every node is rebooted.
+  period: "1m"
   rebootDays:
   - mo
   - we
   - th
   startTime: "07:00:00"
   endTime: "12:00:00"
-  lockReleaseDelay: "1h"
+  lockReleaseDelay: "5m"
 
 resources:
   limits:


### PR DESCRIPTION
**Temporary.** `period: 2h` is the sentinel *check* interval, so combined with a 1h `lockReleaseDelay` a four-node backlog can't finish inside the 5h window — beelink01 rebooted at 08:16 and the next wouldn't even start until 09:23.

Dropping to 1m polling with a 5m settle keeps kured doing the drain, cordon/uncordon and lock serialisation, just without the artificial waits. Three nodes remain.

Revert to `period: 2h` / `lockReleaseDelay: 1h` once every node reports clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)