### PR TITLE
kured: restore normal cadence, add a lock TTL

### DIFF
--- a/apps/system-kured/values.yaml
+++ b/apps/system-kured/values.yaml
@@ -5,16 +5,18 @@ configuration:
   concurrency: 1
   # Abort drain after this time
   drainTimeout: "2h"
-  # TEMPORARY: 2h/1h cannot clear a 4-node backlog inside the 5h window.
-  # Revert to period 2h / lockReleaseDelay 1h once every node is rebooted.
-  period: "1m"
+  period: "2h"
   rebootDays:
   - mo
   - we
   - th
   startTime: "07:00:00"
   endTime: "12:00:00"
-  lockReleaseDelay: "5m"
+  lockReleaseDelay: "1h"
+  # Without a TTL an interrupted holder strands the lock forever -- restarting
+  # the daemonset mid-reboot does exactly that, since the release delay is
+  # only held in memory. Longer than a real cycle (drain + reboot + delay).
+  lockTtl: "3h"
 
 resources:
   limits:


### PR DESCRIPTION
The `1m`/`5m` tuning was only to clear the four-node backlog inside one window. All four are rebooted and clean, so this restores `period: 2h` and `lockReleaseDelay: 1h`.

`lockTtl: 3h` closes the hole we hit today: the lock release delay lives **in memory**, so restarting the DaemonSet while a node held the lock stranded it with `TTL: 0` — blocking every further reboot until cleared by hand. A TTL makes that self-heal.

3h is comfortably above a real cycle (drain + reboot + uncordon + the 1h release delay); observed cycles today were around 1h10m.

🤖 Generated with [Claude Code](https://claude.com/claude-code)