### PR TITLE
paperless: put backups on NFS instead of longhorn

### DIFF
--- a/apps/paperless/manifests/app/pvcBackups.yaml
+++ b/apps/paperless/manifests/app/pvcBackups.yaml
@@ -7,9 +7,11 @@ metadata:
   name: backups
   namespace: paperless
 spec:
+  # Exports land on the NAS directly. Longhorn was keeping two replicas of a
+  # backup and then shipping them to that same NAS via its backup target.
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   resources:
     requests:
       storage: 10Gi
-  storageClassName: longhorn-r2
+  storageClassName: unifi-nas

--- a/apps/paperless/manifests/backups/cronjob.yaml
+++ b/apps/paperless/manifests/backups/cronjob.yaml
@@ -31,7 +31,8 @@ spec:
             - command:
                 - sh
                 - -c
-                - chmod 0777 /export
+                # best effort: the NAS refuses mode changes over NFS
+                - chmod 0777 /export || true
               image: busybox
               name: permissions
               volumeMounts:


### PR DESCRIPTION
The export volume was on `longhorn-r2`, so Longhorn kept **two replicas of a backup directory** and then shipped them to the NAS through its backup target — three copies of the same thing. Pointing the claim at `unifi-nas` writes them to the NAS once.

Existing contents are discarded; the nightly job regenerates the export (811 files / 935MB when last run).

The init container's `chmod` becomes best-effort, since the NAS refuses mode changes over NFS — the same reason the StatefulSet logs `chown: ... Operation not permitted` on the consume volume.

Requires deleting the existing PVC, as `storageClassName` is immutable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)