### PR TITLE
paperless: keep the backup chmod strict

### DIFF
--- a/apps/paperless/manifests/backups/cronjob.yaml
+++ b/apps/paperless/manifests/backups/cronjob.yaml
@@ -31,8 +31,9 @@ spec:
             - command:
                 - sh
                 - -c
-                # best effort: the NAS refuses mode changes over NFS
-                - chmod 0777 /export || true
+                # csi-nfs creates the subdir 0755 owned by uid 977; the export
+                # runs as 1000 and cannot write without this.
+                - chmod 0777 /export
               image: busybox
               name: permissions
               volumeMounts:


### PR DESCRIPTION
Reverts the `|| true` added in #1081 on a wrong assumption.

Measured on a throwaway PVC: csi-nfs creates the subdirectory as **`mode=755 uid=977 gid=988`**. The export runs as **uid 1000** — not the owner, not in the group — so only `other` applies (`r-x`) and it cannot write. The chmod is load-bearing.

The mount does not root-squash, so the chmod succeeds from the root init container (contrary to what I expected from the `consume` chown failure).

Masking a failure here would surface later as a confusing permission error inside `document_exporter` instead of failing fast at the init container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)