### PR TITLE
paperless: let fsGroup own the backup volume

### DIFF
--- a/apps/paperless/manifests/backups/cronjob.yaml
+++ b/apps/paperless/manifests/backups/cronjob.yaml
@@ -19,6 +19,13 @@ spec:
             app.kubernetes.io/component: backup
             app.kubernetes.io/name: paperless
         spec:
+          # Let the kubelet own the volume instead of chmod-ing it. Only takes
+          # effect if the nfs CSIDriver declares fsGroupPolicy: File -- with the
+          # default ReadWriteOnceWithFSType it is skipped on an RWX volume with
+          # no fsType. The chmod below stays until that is confirmed.
+          securityContext:
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
           affinity:
             podAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
csi-nfs provisions the subdirectory as `mode=755 uid=977 gid=988`, so the exporter running as uid 1000 cannot write without help. `fsGroup` is the platform mechanism for that, rather than a chmod init container.

Whether it actually applies depends on the nfs CSIDriver's `fsGroupPolicy`:

| policy | effect here |
|---|---|
| `File` | works |
| `ReadWriteOnceWithFSType` (k8s default) | **skipped** — RWX volume, and NFS PVs declare no fsType |
| `None` | skipped |

So this is deliberately belt-and-braces: **the chmod stays** until that is confirmed, and a wrong guess can't break the nightly export.

Verify with:

```bash
kubectl get csidriver nfs.csi.k8s.io -o jsonpath='{.spec.fsGroupPolicy}'
```

and by checking whether the export directory comes back owned by **gid 1000**. If it does, fsGroup fired and the chmod can be removed in a follow-up. If not, revert this and consider `mountPermissions` on the storage class instead.

`OnRootMismatch` keeps the recursive ownership walk from touching all 811 files on every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)