### PR TITLE
paperless: drop the ineffective fsGroup

### DIFF
--- a/apps/paperless/manifests/backups/cronjob.yaml
+++ b/apps/paperless/manifests/backups/cronjob.yaml
@@ -19,13 +19,6 @@ spec:
             app.kubernetes.io/component: backup
             app.kubernetes.io/name: paperless
         spec:
-          # Let the kubelet own the volume instead of chmod-ing it. Only takes
-          # effect if the nfs CSIDriver declares fsGroupPolicy: File -- with the
-          # default ReadWriteOnceWithFSType it is skipped on an RWX volume with
-          # no fsType. The chmod below stays until that is confirmed.
-          securityContext:
-            fsGroup: 1000
-            fsGroupChangePolicy: OnRootMismatch
           affinity:
             podAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
@@ -38,8 +31,10 @@ spec:
             - command:
                 - sh
                 - -c
-                # csi-nfs creates the subdir 0755 owned by uid 977; the export
-                # runs as 1000 and cannot write without this.
+                # csi-nfs creates the subdir 0755 owned by uid 977 and the
+                # export runs as 1000. fsGroup cannot fix it: this NAS refuses
+                # chown, so the kubelet's ownership change is dropped. It does
+                # allow chmod, which is enough for the client-side access check.
                 - chmod 0777 /export
               image: busybox
               name: permissions


### PR DESCRIPTION
Tested #1083 rather than assuming. The CSIDriver **does** declare `fsGroupPolicy: File`, so the mechanism is available — but the volume came back:

```
DIR mode=777 uid=977 gid=988      # unchanged, not gid 1000
```

**This NAS refuses `chown` while allowing `chmod`.** Paperless' own init container has been reporting exactly that for a while:

```
chown: changing ownership of '/usr/src/paperless/consume': Operation not permitted
```

The kubelet's fsGroup chown hits the same `EPERM` and is silently dropped, so the group never becomes 1000. `fsGroupPolicy` was never the deciding factor.

The chmod is what actually works — it satisfies the NFS client's local access check, which is what blocks uid 1000 against a 0755 directory owned by 977. Comment records the finding so nobody retries fsGroup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)