### PR TITLE
immich: 2.7.0 -> 2.7.5

### DIFF
--- a/apps/photos/app/values.yaml
+++ b/apps/photos/app/values.yaml
@@ -6,7 +6,7 @@ controllers:
       main:
         image:
           repository: ghcr.io/immich-app/immich-server
-          tag: "v2.7.0"
+          tag: "v2.7.5"
         env:
           TZ: "Europe/Warsaw"
           LOG_LEVEL: "debug"


### PR DESCRIPTION
First step of the immich work. Patch releases only — nothing in 2.7.1 through 2.7.5 touches the database, extensions or config. Chart stays at 0.12.0, already the latest.

The root-level tag is shared by the server and machine-learning subcharts, so one bump moves both — confirmed by rendering:

```
ghcr.io/immich-app/immich-machine-learning:v2.7.5
ghcr.io/immich-app/immich-server:v2.7.5
```

Postgres 17, the extension mechanism move, and v3 follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)