### PR TITLE
immich: postgres 16 -> 17 on VectorChord

### DIFF
--- a/apps/photos/app/values.yaml
+++ b/apps/photos/app/values.yaml
@@ -22,6 +22,9 @@ controllers:
                 name: postgres-user
                 key: password
           DB_DATABASE_NAME: "immich"
+          # Auto-detection would pick it anyway, but be explicit now that the
+          # cluster carries both vchord and vector.
+          DB_VECTOR_EXTENSION: "vectorchord"
           IMMICH_MACHINE_LEARNING_URL: '{{ printf "http://%s-machine-learning:3003" .Release.Name }}'
 
 immich:

--- a/apps/photos/db/values.yaml
+++ b/apps/photos/db/values.yaml
@@ -3,7 +3,7 @@ owner: immich
 
 cluster:
   instances: 3
-  imageName: ghcr.io/tensorchord/cloudnative-pgvecto.rs:16-v0.2.1
+  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:17.5-0.4.3
   primaryUpdateMethod: switchover
   storage:
     size: 20Gi
@@ -14,14 +14,14 @@ cluster:
       memory: 500Mi
   postgresql:
     shared_preload_libraries:
-      - vectors.so
+      - vchord.so
+    parameters:
+      search_path: '"$user", public'
   bootstrap:
     postInitApplicationSQL:
-      - 'ALTER SYSTEM SET search_path TO "immich", public, vectors;'
-      - 'CREATE EXTENSION IF NOT EXISTS "vectors";'
+      - 'CREATE EXTENSION IF NOT EXISTS vchord CASCADE;'
       - 'CREATE EXTENSION IF NOT EXISTS cube WITH SCHEMA pg_catalog;'
       - 'CREATE EXTENSION IF NOT EXISTS earthdistance WITH SCHEMA pg_catalog;'
-      - 'ALTER SCHEMA vectors OWNER TO immich;'
 
 backup:
   schedule: "0 13 2 * * *"


### PR DESCRIPTION
Swaps `cloudnative-pgvecto.rs` for `cloudnative-vectorchord` — same publisher, same CNPG-compatible family, nothing extra to maintain. immich v3 drops pgvecto.rs and **refuses to start** without `vchord`.

VectorChord is not available as an ImageVolume extension image (the CNPG community set is pgaudit/pgrouting/pgvector/postgis/timescaledb/wal2json), and `cloudnative-vectorchord` has no PG18 tags — so the bundled operand image is the route, and PG18 waits.

**pgvecto.rs was removed from the live database first**, following immich's documented manual migration:

```sql
DROP INDEX clip_index; DROP INDEX face_index;
ALTER TABLE smart_search ALTER COLUMN embedding SET DATA TYPE real[];
ALTER TABLE face_search  ALTER COLUMN embedding SET DATA TYPE real[];
DROP EXTENSION vectors; DROP SCHEMA vectors CASCADE;
```

`real[]` is a builtin type, so `pg_upgrade` has no missing library to resolve **and all 19,851 embeddings survive** — 13,612 smart_search + 6,239 face_search, all 512-dim. No ML re-run needed. They convert back to `vector(512)` once `vchord` exists.

`search_path` moves into the cluster spec: CNPG keeps `postgresql.auto.conf` read-only, so the bootstrap `ALTER SYSTEM` can't be revised afterwards.

Backup `immich-pre-pg17` taken and completed beforehand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)