### PR TITLE
immich: split the search_path change out of the image bump

### DIFF
--- a/apps/photos/db/values.yaml
+++ b/apps/photos/db/values.yaml
@@ -15,8 +15,6 @@ cluster:
   postgresql:
     shared_preload_libraries:
       - vchord.so
-    parameters:
-      search_path: '"$user", public'
   bootstrap:
     postInitApplicationSQL:
       - 'CREATE EXTENSION IF NOT EXISTS vchord CASCADE;'


### PR DESCRIPTION
CNPG's webhook rejected #1086:

```
Can't change image name and configuration at the same time when
`primaryUpdateMethod` is set to `switchover`.
There are differences in PostgreSQL configuration parameters: {"search_path":...}
```

Same constraint the CNPG docs warn about for extension images — roll the image first, change configuration after. This drops `parameters.search_path` so the VectorChord/PG17 move can proceed; search_path follows in its own change.

The stale `vectors` entry in the inherited `search_path` is inert regardless — postgres ignores schemas that don't exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)