### PR TITLE
immich: step to VectorChord on PG16 first

### DIFF
--- a/apps/photos/db/values.yaml
+++ b/apps/photos/db/values.yaml
@@ -3,7 +3,7 @@ owner: immich
 
 cluster:
   instances: 3
-  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:17.5-0.4.3
+  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:16.9-0.4.2
   primaryUpdateMethod: switchover
   storage:
     size: 20Gi


### PR DESCRIPTION
`pg_upgrade` failed on an OS mismatch, not anything to do with extensions:

```
/controller/old/usr/lib/postgresql/16/bin/postgres: error while loading
shared libraries: libssl.so.1.1: cannot open shared object file
```

CNPG mounts the **old** binaries and runs them inside the **new** container, so both images must share an OS base. `cloudnative-pgvecto.rs:16-v0.2.1` is **bullseye** (libssl1.1); `cloudnative-vectorchord:17.5` is **bookworm** (libssl3).

`16.9-0.4.2` is bookworm at the *same major*, verified directly — so this is a rolling restart, not an upgrade. It recovers the cluster from the failed-upgrade state and lands it on the right base with `vchord.so` and `vector.so` present. 17.5 follows once healthy, with both sides bookworm.

Nothing was modified by the failed attempt — it died at the version check before touching data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)