### PR TITLE
immich: postgres 16 -> 17

### DIFF
--- a/apps/photos/db/values.yaml
+++ b/apps/photos/db/values.yaml
@@ -3,7 +3,7 @@ owner: immich
 
 cluster:
   instances: 3
-  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:16.9-0.4.2
+  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:17.5-0.4.3
   primaryUpdateMethod: switchover
   storage:
     size: 20Gi


### PR DESCRIPTION
Retry of the major upgrade now that both sides are **bookworm**. The earlier attempt failed only because the old bullseye binaries couldn't run inside the new bookworm container.

VectorChord is already in place on 16.9: all **19,851 embeddings** converted back to `vector(512)`, and immich has rebuilt `clip_index` and `face_index` as `vchordrq`. So this step is purely the major version bump.

Backup `immich-pre-pg17-vchord` taken and completed beforehand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)