### PR TITLE
immich: back to 16.9 while the earthdistance blocker is fixed

### DIFF
--- a/apps/photos/db/values.yaml
+++ b/apps/photos/db/values.yaml
@@ -3,7 +3,7 @@ owner: immich
 
 cluster:
   instances: 3
-  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:17.5-0.4.3
+  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:16.9-0.4.2
   primaryUpdateMethod: switchover
   storage:
     size: 20Gi


### PR DESCRIPTION
`pg_upgrade` reached schema restore and failed:

```
pg_restore: error: could not execute query: ERROR: type "earth" does not exist
QUERY: SELECT cube(cube(cube(earth()*cos(radians($1))...))::earth
```

`geodata_places` has a generated column `earthCoord` of type `public.earth`, but the cluster bootstrapped earthdistance `WITH SCHEMA pg_catalog`, so the restore can't resolve the type.

Reverting to 16.9 to bring the cluster back while that's sorted. Data is untouched — `pg_upgrade --link` failed during restore into the *new* datadir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)