### PR TITLE
immich: postgres 16 -> 17, second retry

### DIFF
--- a/apps/photos/db/values.yaml
+++ b/apps/photos/db/values.yaml
@@ -3,7 +3,7 @@ owner: immich
 
 cluster:
   instances: 3
-  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:16.9-0.4.2
+  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:17.5-0.4.3
   primaryUpdateMethod: switchover
   storage:
     size: 20Gi


### PR DESCRIPTION
The object that broke the schema restore is gone.

`geodata_places` had a generated column `earthCoord` of type `public.earth`, and `pg_restore` couldn't resolve the type mid-restore. immich has since migrated that away — the column no longer exists, and geo lookups now use a functional index over a `ll_to_earth_public` wrapper whose body is fully schema-qualified.

That migration ran when the database came back after the previous attempt, so the blocker cleared itself.

Backup `immich-pre-pg17-retry2` taken against the post-migration schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)