### PR TITLE
immich: back to 16.9 again

### DIFF
--- a/apps/photos/db/values.yaml
+++ b/apps/photos/db/values.yaml
@@ -3,7 +3,7 @@ owner: immich
 
 cluster:
   instances: 3
-  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:17.5-0.4.3
+  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:16.9-0.4.2
   primaryUpdateMethod: switchover
   storage:
     size: 20Gi


### PR DESCRIPTION
The blocker isn't in the `immich` database. `pg_upgrade_dump_5.log` shows the failure restoring `public.geodata_places` into **database oid 5** (postgres/template1), with cube and earthdistance objects created as loose objects rather than via `CREATE EXTENSION`.

So there's a stale copy of the table outside `immich`, still carrying the old `earthCoord` generated column. Recovering to 16.9 to investigate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)