### PR TITLE
immich: postgres 16 -> 17, third attempt

### DIFF
--- a/apps/photos/db/values.yaml
+++ b/apps/photos/db/values.yaml
@@ -3,7 +3,7 @@ owner: immich
 
 cluster:
   instances: 3
-  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:16.9-0.4.2
+  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:17.5-0.4.3
   primaryUpdateMethod: switchover
   storage:
     size: 20Gi


### PR DESCRIPTION
Found the real blocker, and it was never in the `immich` database.

`pg_upgrade_dump_5.log` pointed at **database oid 5 = `postgres`**, which held a stale, empty copy of `geodata_places` — left by an early immich run that connected to the default database before `DB_DATABASE_NAME` was set. That copy still carried the old `earthCoord` generated column of type `public.earth`, which `pg_restore` couldn't resolve.

Dropped the empty table (0 rows) plus the `cube` and `earthdistance` extensions that only existed to support it. `template1` was already clean, and the `immich` database is untouched — 13,612 + 6,239 embeddings, 224,210 geodata rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)