### PR TITLE
immich: 2.7.5 -> 3.1.0

### DIFF
--- a/apps/photos/app/values.yaml
+++ b/apps/photos/app/values.yaml
@@ -6,7 +6,7 @@ controllers:
       main:
         image:
           repository: ghcr.io/immich-app/immich-server
-          tag: "v2.7.5"
+          tag: "v3.1.0"
         env:
           TZ: "Europe/Warsaw"
           LOG_LEVEL: "debug"


### PR DESCRIPTION
v3 drops pgvecto.rs, which is already handled — the cluster runs **VectorChord 0.4.2** and **pgvector 0.8.0**, both inside immich's accepted ranges (`vchord >= 0.3 < 2.0`, `pgvector >= 0.7 < 0.9`), with embeddings converted and `clip_index`/`face_index` rebuilt as `vchordrq`.

Checked the breaking changes against this deployment:

- **removed env vars** — only `IMMICH_MACHINE_LEARNING_PING_TIMEOUT`, not set here
- **API v1 / endpoint changes** — affect third-party integrations, not the deployment
- **class-validator → zod**, **album owner → album_user** — internal refactors with migrations

v2.7.5 is the direct predecessor of v3.0.0 (the changelog is literally `v2.7.5...v3.0.0`), so there's no version gate to step through.

Backup `immich-pre-v3` taken and completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)