### PR TITLE
immich: postgres follow-ups

### DIFF
--- a/apps/photos/db/values.yaml
+++ b/apps/photos/db/values.yaml
@@ -12,14 +12,24 @@ cluster:
     requests:
       cpu: 50m
       memory: 500Mi
+  # Bumping imageName to a release carrying a newer vchord leaves the extension
+  # behind at the old version. immich notices and tries to fix it itself, but
+  # postgres owns the extension so it cannot, and the workers crashloop with
+  # "must be owner of extension vchord". Follow an image bump with:
+  #   ALTER EXTENSION vchord UPDATE;
+  # run as postgres against the immich database.
   postgresql:
     shared_preload_libraries:
       - vchord.so
+    parameters:
+      search_path: '"$user", public'
   bootstrap:
     postInitApplicationSQL:
       - 'CREATE EXTENSION IF NOT EXISTS vchord CASCADE;'
-      - 'CREATE EXTENSION IF NOT EXISTS cube WITH SCHEMA pg_catalog;'
-      - 'CREATE EXTENSION IF NOT EXISTS earthdistance WITH SCHEMA pg_catalog;'
+      # public, not pg_catalog: immich resolves these as public.earth and
+      # public.ll_to_earth, and that is where the live cluster has them.
+      - 'CREATE EXTENSION IF NOT EXISTS cube WITH SCHEMA public;'
+      - 'CREATE EXTENSION IF NOT EXISTS earthdistance WITH SCHEMA public;'
 
 backup:
   schedule: "0 13 2 * * *"


### PR DESCRIPTION
Three loose ends from the postgres work.

**`search_path`** lands now that it isn't competing with an image change — CNPG rejects both in one step while `primaryUpdateMethod: switchover`. The inherited value still named the `vectors` schema, which no longer exists.

**Records the vchord ownership trap.** An image bump carrying a newer vchord leaves the extension behind; immich detects it, tries to self-update, and can't because `postgres` owns the extension — workers crashloop with `must be owner of extension vchord` until `ALTER EXTENSION vchord UPDATE` is run by hand. Inherent to CNPG (the extension ships a `.so`, so `CREATE EXTENSION` needs superuser), so it will recur on every such bump.

**Bootstrap creates cube and earthdistance in `public`** rather than `pg_catalog`, matching both the live cluster and how immich references them (`public.earth`, `public.ll_to_earth`). That mismatch is what left `pg_upgrade` unable to resolve the `earth` type — a rebuild today would have reintroduced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)