### PR TITLE
cnpg: add a versity gateway alongside the operator

### DIFF
--- a/base/cnpg-system/kustomization.yaml
+++ b/base/cnpg-system/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - namespace.yaml
   - operator/
   - barman/
+  - versity/

--- a/base/cnpg-system/versity/credentials-secret.yaml
+++ b/base/cnpg-system/versity/credentials-secret.yaml
@@ -1,0 +1,26 @@
+# Unlike the longhorn and datalake gateways, these credentials are not minted
+# in-cluster: eleven namespaces already read POSTGRES_S3_* from Doppler for
+# their postgres-backup secret. Making the gateway accept the same pair means
+# repointing a database is only an endpoint change.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: versitygw-credentials
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-auth-api
+  target:
+    name: versitygw-credentials
+    template:
+      data:
+        rootAccessKeyId: "{{ .accessKey }}"
+        rootSecretAccessKey: "{{ .secretKey }}"
+  data:
+    - remoteRef:
+        key: POSTGRES_S3_ACCESS_KEY
+      secretKey: accessKey
+    - remoteRef:
+        key: POSTGRES_S3_SECRET_KEY
+      secretKey: secretKey

--- a/base/cnpg-system/versity/job.yaml
+++ b/base/cnpg-system/versity/job.yaml
@@ -1,0 +1,33 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: bootstrap-bucket
+spec:
+  # barman-cloud will not create the bucket, and a missing one surfaces as a
+  # failed backup rather than anything naming the cause.
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: mc
+          image: minio/mc:latest
+          env:
+            - name: BUCKET_NAME
+              value: cnpg
+            - name: VGW_ENDPOINT
+              value: http://versitygw:7070
+            - name: ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: versitygw-credentials
+                  key: rootAccessKeyId
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: versitygw-credentials
+                  key: rootSecretAccessKey
+          command: ["/bin/sh", "-lc"]
+          args:
+            - |
+              mc alias set vgw "$VGW_ENDPOINT" "$ACCESS_KEY" "$SECRET_KEY" --api S3v4
+              mc mb --ignore-existing vgw/$BUCKET_NAME

--- a/base/cnpg-system/versity/kustomization.yaml
+++ b/base/cnpg-system/versity/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# The namespace is created and owned by base/cnpg-system.
+namespace: cnpg-system
+resources:
+  - repository.yaml
+  - release.yaml
+  - credentials-secret.yaml
+  - job.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+configMapGenerator:
+  - name: versity-values
+    files:
+      - values.yaml=values.yaml

--- a/base/cnpg-system/versity/release.yaml
+++ b/base/cnpg-system/versity/release.yaml
@@ -1,0 +1,24 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: versitygw
+spec:
+  chart:
+    spec:
+      chart: versitygw
+      version: "0.3.5"
+      sourceRef:
+        kind: HelmRepository
+        name: versity
+      interval: 15m
+  interval: 30m
+  timeout: 10m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: versity-values

--- a/base/cnpg-system/versity/repository.yaml
+++ b/base/cnpg-system/versity/repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: versity
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/versity/versitygw/charts

--- a/base/cnpg-system/versity/values.yaml
+++ b/base/cnpg-system/versity/values.yaml
@@ -1,0 +1,36 @@
+# Config reference: https://github.com/versity/versitygw/blob/main/chart/values.yaml
+#
+# Backup target for the fleet's postgres clusters, replacing Backblaze. Same
+# pattern as the longhorn and datalake gateways, but shared: eleven clusters
+# across eleven namespaces write here rather than one consumer next door.
+
+# Pinned. The chart defaults to :latest.
+image:
+  tag: "v1.7.0"
+
+auth:
+  existingSecret: versitygw-credentials
+
+gateway:
+  backend:
+    type: posix
+    args: "/mnt/data"
+    # Object metadata as ordinary files rather than xattrs, which is what lets
+    # this sit on an NFSv3 share.
+    sidecarDir: "/mnt/metadata"
+
+# Eleven clusters at 3d-30d retention. nfs.csi.k8s.io does not enforce the
+# request, so this is a label rather than a reservation.
+persistence:
+  enabled: true
+  create: true
+  size: 100Gi
+  storageClassName: unifi-nas
+  accessMode: ReadWriteMany
+
+resources:
+  limits:
+    memory: 1Gi
+  requests:
+    cpu: 50m
+    memory: 128Mi


### PR DESCRIPTION
Backup target for the fleet's postgres clusters, to replace Backblaze. Same shape as the longhorn and datalake gateways, but **shared** — eleven clusters across eleven namespaces write here, rather than one consumer next door.

**Root credentials come from Doppler**, not an in-cluster generator. Every namespace already reads `POSTGRES_S3_ACCESS_KEY` / `POSTGRES_S3_SECRET_KEY` for its `postgres-backup` secret, so making the gateway accept that same pair means repointing a database is only an `endpointURL` change — no cross-namespace credential distribution to solve.

Bucket `cnpg`, 100Gi on `unifi-nas`, posix backend with `sidecarDir` so metadata works over NFSv3.

**This only stands the gateway up.** Repointing the clusters follows separately, one at a time — each needs a fresh base backup before it has any recovery point in the new store, since the destination path changes.

Motivation: velero died because Backblaze rejects the `x-amz-tagging` header the AWS SDK sends, and barman-cloud writes to Backblaze through a similar path. Backups are completing today, but that's a latent dependency worth removing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)