### PR TITLE
mended-drum: back up to versity instead of backblaze

### DIFF
--- a/apps/mended-drum/db/values.yaml
+++ b/apps/mended-drum/db/values.yaml
@@ -18,6 +18,8 @@ backup:
   objectStore:
     retentionPolicy: 30d
     pathSuffix: mended-drum
+    bucketPrefix: s3://cnpg/postgres
+    endpointURL: http://versitygw.cnpg-system.svc.cluster.local:7070
 
 externalSecrets:
   admin:


### PR DESCRIPTION
First cluster onto the in-cluster gateway.

Credentials are unchanged — the gateway's root pair is the same `POSTGRES_S3_*` from Doppler that `postgres-backup` already carries (hash-verified), so this is only an endpoint and bucket change.

Canary for the fleet: barman-cloud drives boto3 and the ObjectStore CRD has no path-style switch, so whether a custom endpoint addresses the bucket correctly gets settled here rather than across eleven clusters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)