### PR TITLE
Revert mended-drum to backblaze

### DIFF
--- a/apps/mended-drum/db/values.yaml
+++ b/apps/mended-drum/db/values.yaml
@@ -18,8 +18,6 @@ backup:
   objectStore:
     retentionPolicy: 30d
     pathSuffix: mended-drum
-    bucketPrefix: s3://cnpg/postgres
-    endpointURL: http://versitygw.cnpg-system.svc.cluster.local:7070
 
 externalSecrets:
   admin:


### PR DESCRIPTION
Repointing the chart's ObjectStore left a store *named* `backblaze` writing to versity — misleading, and a one-time cutover with no overlap.

Replacing that with a second ObjectStore per cluster so both destinations can run side by side during the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)