### PR TITLE
mended-drum: add versity as a second backup destination

### DIFF
--- a/apps/mended-drum/db/kustomization.yaml
+++ b/apps/mended-drum/db/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 resources:
   - repository.yaml
   - release.yaml
+  - versity-objectstore.yaml
+  - versity-scheduledbackup.yaml
 configMapGenerator:
   - name: postgres-values
     files:

--- a/apps/mended-drum/db/versity-objectstore.yaml
+++ b/apps/mended-drum/db/versity-objectstore.yaml
@@ -1,0 +1,22 @@
+# Second backup destination, running alongside backblaze during the migration.
+# Not chart-provisioned: cnpg-database renders a single ObjectStore from
+# backup.objectStore, and teaching it about a second one is not worth it for a
+# transitional state.
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: versity
+spec:
+  configuration:
+    destinationPath: s3://cnpg/postgres/mended-drum
+    endpointURL: http://versitygw.cnpg-system.svc.cluster.local:7070
+    s3Credentials:
+      accessKeyId:
+        name: postgres-backup
+        key: S3_ACCESS_KEY
+      secretAccessKey:
+        name: postgres-backup
+        key: S3_SECRET_KEY
+    wal:
+      compression: gzip
+  retentionPolicy: 30d

--- a/apps/mended-drum/db/versity-scheduledbackup.yaml
+++ b/apps/mended-drum/db/versity-scheduledbackup.yaml
@@ -1,0 +1,20 @@
+# Base backups only. WAL archiving stays on backblaze for now: CNPG rejects a
+# second plugin entry with isWALArchiver true -- "Cannot enable more than one
+# WAL archiver plugin" -- because postgres has a single archive_command.
+#
+# So until the archiver is switched, versity can restore to a backup time but
+# not to an arbitrary point; backblaze remains the complete copy.
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: postgres-versity
+spec:
+  schedule: "0 45 23 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: postgres
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+    parameters:
+      barmanObjectName: versity


### PR DESCRIPTION
Step 1 of the mended-drum migration. Base backups go to **both** backblaze and versity, so the move overlaps rather than cutting over.

- `backblaze` — unchanged, keeps WAL archiving, remains the complete copy
- `versity` — new ObjectStore + ScheduledBackup targeting it via `barmanObjectName`

Both are plain manifests rather than chart values: `cnpg-database` renders a single ObjectStore from `backup.objectStore`, and teaching it about a second isn't worth it for a transitional state.

Verified beforehand that a `Backup` can target a non-archiver store this way — a test backup completed. Also verified CNPG **rejects** two WAL archivers (`Cannot enable more than one WAL archiver plugin`), since postgres has a single `archive_command`. So versity supports restore-to-backup-time but not PITR until the archiver switches in step 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)