### PR TITLE
Preserve Longhorn backup and Renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -92,7 +92,7 @@
       "automerge": true
     },
     {
-      "description": "Bare metal: its own group, deliberately never automerged. Sharing a groupName with base/** put these in the same PR, which inherited automerge and defeated the point.",
+      "description": "Bare metal: its own group, deliberately never automerged.",
       "addLabels": [
         "dependencies/hosting"
       ],
@@ -102,13 +102,16 @@
       ]
     },
     {
-      "description": "core/ bootstraps the cluster (cert-manager, external-secrets, flux2). Soaked and labelled, deliberately not automerged: a bad flux2 or cert-manager bump takes everything else with it.",
+      "description": "Cluster bootstrap controllers are soaked and deliberately not automerged: a bad flux2, cert-manager, or external-secrets bump takes everything else with it.",
       "addLabels": [
         "dependencies/core"
       ],
       "groupName": "core infrastructure",
       "matchFileNames": [
-        "core/**"
+        "k8s/bootstrap/**",
+        "k8s/platform/cluster/flux-system/**",
+        "k8s/platform/security/cert-manager/**",
+        "k8s/platform/security/external-secrets/**"
       ],
       "minimumReleaseAge": "10 days"
     },
@@ -119,7 +122,10 @@
       ],
       "groupName": "hosting infrastructure",
       "matchFileNames": [
-        "base/**"
+        "k8s/platform/**",
+        "!k8s/platform/cluster/flux-system/**",
+        "!k8s/platform/security/cert-manager/**",
+        "!k8s/platform/security/external-secrets/**"
       ],
       "minimumReleaseAge": "10 days",
       "automerge": true
@@ -131,7 +137,7 @@
       ],
       "groupName": "applications",
       "matchFileNames": [
-        "apps/**"
+        "k8s/apps/**"
       ],
       "minimumReleaseAge": "20 days",
       "automerge": true
@@ -152,9 +158,7 @@
   ],
   "kubernetes": {
     "managerFilePatterns": [
-      "base/**",
-      "apps/**",
-      "core/**"
+      "k8s/**"
     ]
   },
   "flux": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # Working in this repo
 
-Flux-managed k3s homelab. `core/` bootstraps the cluster, `base/` is infrastructure,
-`apps/` is workloads. Every component has a Flux Kustomization in
-`base/flux-apps/<name>.yaml`.
+Flux-managed k3s homelab. `k8s/bootstrap/` creates the umbrella Flux resources,
+`k8s/platform/` contains infrastructure, and `k8s/apps/` contains workloads.
+Component Flux Kustomizations live in `k8s/flux/platform/` and `k8s/flux/apps/`.
 
 Changing anything Flux applies: see the `flux-app-change` skill in
 `.claude/skills/`. It covers proving the render, the traps that have bitten, and
@@ -28,11 +28,9 @@ but cannot see inside a HelmRelease.
 
 ## Suspended components
 
-Roughly half the fleet is suspended, declared in git — leftovers from emergency
-work in Dec 2025 when nodes failed and reconciliation was stopped to allow manual
-edits. Some were *already failing* before suspension, so **don't resume one
-without reading why it stopped**. `flux-apps` is the exception: never declare
-`suspend` on it, since it manages its own definition and would re-suspend itself.
+No Flux Kustomizations are currently declared suspended in Git. Check both the
+repository and live Flux state before changing suspension because live state can
+temporarily diverge during maintenance.
 
 ## Postgres (CloudNativePG)
 
@@ -50,5 +48,5 @@ backups, so anything built on it is worthless.
 
 ## Out of scope unless asked
 
-`apps/monitoring` — still hand-maintained kube-prometheus manifests with the
+`k8s/apps/monitoring` — still hand-maintained kube-prometheus manifests with the
 largest upgrade backlog in the repo. Excluded from routine upgrade work.

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Cluster is [k3s](https://k3s.io/) provisioned on bare-metal hosts with latest LT
 
 ### GitOps
 
-[Flux](https://github.com/fluxcd/flux2) watches `manifests/` subdirectories in `base` and `apps` top-level directories and makes changes based on YAML manifests.
+[Flux](https://github.com/fluxcd/flux2) bootstraps from `k8s/bootstrap/`, loads component definitions from `k8s/flux/platform/` and `k8s/flux/apps/`, and reconciles the manifests in `k8s/platform/` and `k8s/apps/`.
 
 ## 🌐 DNS
 

--- a/k8s/platform/storage/longhorn-system/kustomization.yaml
+++ b/k8s/platform/storage/longhorn-system/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - release.yaml
   - prometheusrule.yaml
   - sc-low-repl.yaml
+  - recurring-job-backup.yaml
   - middleware.yaml
   - oidc-secret.yaml
 generatorOptions:

--- a/k8s/platform/storage/longhorn-system/recurring-job-backup.yaml
+++ b/k8s/platform/storage/longhorn-system/recurring-job-backup.yaml
@@ -1,0 +1,16 @@
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  # Preserve the identity of the existing UI-created job so Flux adopts it
+  # instead of creating a second daily backup schedule.
+  name: c-gvgagj
+spec:
+  concurrency: 1
+  cron: "19 4 * * *"
+  groups:
+    - default
+  labels: {}
+  name: c-gvgagj
+  parameters: {}
+  retain: 3
+  task: backup

--- a/k8s/platform/storage/longhorn-system/values.yaml
+++ b/k8s/platform/storage/longhorn-system/values.yaml
@@ -9,9 +9,16 @@ persistence:
 defaultSettings:
   defaultDataPath: "/var/lib/rancher/longhorn"
   snapshotDataIntegrity: "fast-check"
-  #backupTarget: "nfs://192.168.40.10:/nfsshare/longhorn-backups"
   upgradeChecker: false
   concurrentAutomaticEngineUpgradePerNodeLimit: "3"
+
+# Keep the live default target reproducible. The credentials Secret is generated
+# alongside the in-cluster Versity gateway and contains both the gateway and
+# Longhorn key names.
+defaultBackupStore:
+  backupTarget: "s3://longhorn@us-east-1/"
+  backupTargetCredentialSecret: versitygw-credentials
+  pollInterval: 300
 
 longhornUI:
   replicas: 1

--- a/k8s/platform/storage/longhorn-system/versity/values.yaml
+++ b/k8s/platform/storage/longhorn-system/versity/values.yaml
@@ -1,10 +1,8 @@
 # Config reference: https://github.com/versity/versitygw/blob/main/chart/values.yaml
 #
 # An S3 gateway sitting next to its consumer, the way a cnpg-database sits next
-# to the app that needs postgres. This one exists to become Longhorn's backup
-# target: the current one is nfs://192.168.40.10/var/nfs/shared/longhornbackups,
-# which has been unavailable since 2025-02-11 and is why every Longhorn backup
-# errors. Wiring the BackupTarget CR to it is a separate step.
+# to the app that needs postgres. Longhorn's default backup target points here
+# through the defaultBackupStore values in the parent Longhorn release.
 
 # Pinned. The chart defaults to :latest.
 image:


### PR DESCRIPTION
## Summary

- declare the live Versity S3 backup target in Longhorn chart values
- adopt the existing daily Longhorn backup RecurringJob into Flux
- update Renovate path matching for the current k8s repository layout
- refresh repository guidance that still described the retired core/base/apps layout

## Operational cleanup

Removed 4,358 stale Longhorn Backup CRs whose state was Error and which referred to the retired NFS target. The 110 completed backups and both recurring jobs were preserved. This cleanup is an already-completed cluster operation and is not represented by a manifest deletion in this PR.

## Validation

- make validate-flux (39 paths)
- make validate (92 targets)
- jq empty .github/renovate.json
- git diff --cached --check
- full Flux render diff: only the expected Longhorn default-resource ConfigMap changes and RecurringJob addition
- kubectl diff: the live RecurringJob already matches, and only the intended backup target ConfigMap values differ