### PR TITLE
Right-size Cilium BPF map memory

### DIFF
--- a/k8s/platform/network/cilium/values.yaml
+++ b/k8s/platform/network/cilium/values.yaml
@@ -10,7 +10,13 @@ bpf:
   datapathMode: netkit
   distributedLRU:
     enabled: true
-  mapDynamicSizeRatio: 0.08
+  # Keep this explicit while distributedLRU is enabled. Cilium's 0.0025 default
+  # would be too small here: size for at most 50% map pressure using
+  #   peak = max(max_over_time(cilium_bpf_map_pressure[30d]))
+  #   ratio >= current ratio * peak / 0.50
+  # On 2026-08-20: 0.08 * 0.0542 / 0.50 = 0.0087, rounded up to 0.01.
+  # Recalculate when the 30-day peak crosses 0.50 or cluster traffic changes.
+  mapDynamicSizeRatio: 0.01
 bpfClockProbe: true
 enableIPv4BIGTCP: true
 enableIPv4Masquerade: true


### PR DESCRIPTION
## Summary

- reduce bpf.mapDynamicSizeRatio from 0.08 to 0.01
- keep the override explicit because distributed LRU still requires dynamic map sizing and the 0.0025 default is too small for observed traffic
- document the Prometheus-based sizing formula directly beside the value

## Evidence

The cilium-agent process RSS is only 260-330 MiB. The apparent 2.5-4.9 GiB working set is almost entirely cgroup-charged kernel vmalloc used by BPF maps:

- 32 GiB node: about 2.36 GiB BPF map virtual memory
- 64 GiB nodes: about 4.72 GiB BPF map virtual memory
- 30-day maximum cilium_bpf_map_pressure at ratio 0.08: 0.0542

Sizing for at most 50% pressure gives 0.08 * 0.0542 / 0.50 = 0.0087, rounded up to 0.01. Returning to the 0.0025 default would project the observed peak above 1.0; 0.01 projects it around 0.43 and cuts map reservation by roughly eight times.

## Rollout note

This changes BPF map capacities. The Cilium DaemonSet will roll and maps whose capacity changes may be recreated, so existing CT/NAT state can be lost during each agent restart. Keep the rollout isolated and verify node networking plus cilium_bpf_map_pressure after reconciliation.

## Validation

- make validate-flux (39 paths)
- make validate (92 targets)
- kustomize and full flux-build before/after render
- rendered object set unchanged
- kubectl diff contains only the intended Helm value and comment change