### PR TITLE
Set Longhorn component resource requests

### DIFF
--- a/k8s/platform/storage/longhorn-system/release.yaml
+++ b/k8s/platform/storage/longhorn-system/release.yaml
@@ -30,3 +30,42 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: values
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              group: apps
+              version: v1
+              kind: Deployment
+              name: longhorn-driver-deployer
+            patch: |-
+              - op: add
+                path: /spec/template/spec/containers/0/resources
+                value:
+                  requests:
+                    cpu: 10m
+                    memory: 32Mi
+          - target:
+              group: apps
+              version: v1
+              kind: Deployment
+              name: longhorn-ui
+            patch: |-
+              - op: add
+                path: /spec/template/spec/containers/0/resources
+                value:
+                  requests:
+                    cpu: 10m
+                    memory: 32Mi
+          - target:
+              group: apps
+              version: v1
+              kind: DaemonSet
+              name: longhorn-manager
+            patch: |-
+              - op: add
+                path: /spec/template/spec/containers/1/resources
+                value:
+                  requests:
+                    cpu: 10m
+                    memory: 32Mi

--- a/k8s/platform/storage/longhorn-system/values.yaml
+++ b/k8s/platform/storage/longhorn-system/values.yaml
@@ -11,6 +11,8 @@ defaultSettings:
   snapshotDataIntegrity: "fast-check"
   upgradeChecker: false
   concurrentAutomaticEngineUpgradePerNodeLimit: "3"
+  systemManagedCSIComponentsResourceLimits: >-
+    {"csi-attacher":{"requests":{"cpu":"10m","memory":"80Mi"}},"csi-provisioner":{"requests":{"cpu":"10m","memory":"80Mi"}},"csi-resizer":{"requests":{"cpu":"10m","memory":"80Mi"}},"csi-snapshotter":{"requests":{"cpu":"10m","memory":"80Mi"}},"longhorn-csi-plugin":{"requests":{"cpu":"10m","memory":"96Mi"}},"node-driver-registrar":{"requests":{"cpu":"10m","memory":"32Mi"}},"longhorn-liveness-probe":{"requests":{"cpu":"10m","memory":"32Mi"}}}
 
 # Keep the live default target reproducible. The credentials Secret is generated
 # alongside the in-cluster Versity gateway and contains both the gateway and
@@ -25,6 +27,10 @@ longhornUI:
 
 longhornManager:
   priorityClass: "system-node-critical"
+  resources:
+    requests:
+      cpu: 110m
+      memory: 656Mi
 
 longhornDriver:
   priorityClass: "system-node-critical"


### PR DESCRIPTION
## Summary
- set requests for Longhorn manager and system-managed CSI components from observed usage
- set requests for the UI, driver deployer, and manager image pre-pull sidecar through Helm post-render patches
- keep this storage-specific work separate from the general workload resources PR for independent investigation and review

## Requested resources
- manager: `110m` CPU / `656Mi` memory
- CSI sidecars: `10m` CPU / `80Mi` memory
- CSI plugin: `10m` CPU / `96Mi` memory
- registrar, liveness probe, UI, driver deployer, and pre-pull sidecar: `10m` CPU / `32Mi` memory

## Scope note
Longhorn creates engine-image, instance-manager, and share-manager workloads dynamically. The chart/default-setting interfaces do not provide equivalent accurate per-component request knobs for those workloads, so this PR deliberately leaves them unchanged.

## Validation
- `make validate` (92 targets)
- `make validate-flux` (39 live paths)
- Longhorn 1.12.1 Helm render and post-render patches were validated while preparing the original resource changes
