### PR TITLE
Add Kyverno admission and cleanup controllers

### DIFF
--- a/k8s/flux/platform/kyverno.yaml
+++ b/k8s/flux/platform/kyverno.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kyverno
+  namespace: flux-system
+spec:
+  interval: 15m0s
+  path: ./k8s/platform/security/kyverno
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: ankhmorpork

--- a/k8s/platform/security/kyverno/controllers/kustomization.yaml
+++ b/k8s/platform/security/kyverno/controllers/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kyverno
+resources:
+  - repository.yaml
+  - release.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+configMapGenerator:
+  - name: values
+    files:
+      - values.yaml=values.yaml

--- a/k8s/platform/security/kyverno/controllers/kustomization.yaml
+++ b/k8s/platform/security/kyverno/controllers/kustomization.yaml
@@ -1,12 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: kyverno
+namespace: platform-security
 resources:
   - repository.yaml
   - release.yaml
 generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:
-  - name: values
+  - name: values-kyverno
     files:
       - values.yaml=values.yaml

--- a/k8s/platform/security/kyverno/controllers/release.yaml
+++ b/k8s/platform/security/kyverno/controllers/release.yaml
@@ -10,7 +10,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: kyverno
-        namespace: kyverno
+        namespace: platform-security
       interval: 5m
   interval: 5m
   timeout: 10m
@@ -27,4 +27,4 @@ spec:
     crds: CreateReplace
   valuesFrom:
     - kind: ConfigMap
-      name: values
+      name: values-kyverno

--- a/k8s/platform/security/kyverno/controllers/release.yaml
+++ b/k8s/platform/security/kyverno/controllers/release.yaml
@@ -1,0 +1,30 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kyverno
+spec:
+  chart:
+    spec:
+      chart: kyverno
+      version: "3.9.0"
+      sourceRef:
+        kind: HelmRepository
+        name: kyverno
+        namespace: kyverno
+      interval: 5m
+  interval: 5m
+  timeout: 10m
+  install:
+    timeout: 10m
+    disableWait: false
+    crds: CreateReplace
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    timeout: 10m
+    disableWait: false
+    crds: CreateReplace
+  valuesFrom:
+    - kind: ConfigMap
+      name: values

--- a/k8s/platform/security/kyverno/controllers/repository.yaml
+++ b/k8s/platform/security/kyverno/controllers/repository.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: kyverno
+spec:
+  interval: 5m
+  url: https://kyverno.github.io/kyverno/

--- a/k8s/platform/security/kyverno/controllers/values.yaml
+++ b/k8s/platform/security/kyverno/controllers/values.yaml
@@ -1,0 +1,80 @@
+# Config reference: https://github.com/kyverno/kyverno/blob/main/charts/kyverno/values.yaml
+
+# Admission reports require the reports controller. Enforcement still happens
+# synchronously and is observable through controller metrics and events.
+features:
+  admissionReports:
+    enabled: false
+  aggregateReports:
+    enabled: false
+  policyReports:
+    enabled: false
+  validatingAdmissionPolicyReports:
+    enabled: false
+  backgroundScan:
+    enabled: false
+
+admissionController:
+  # Admission is on the API write path, so keep one replica on each of the
+  # cluster's three control-plane nodes.
+  replicas: 3
+  priorityClassName: system-cluster-critical
+  podDisruptionBudget:
+    minAvailable: 2
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 1
+        preference:
+          matchExpressions:
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+  initContainer:
+    resources:
+      limits: null
+      requests:
+        cpu: 10m
+        memory: 64Mi
+  container:
+    resources:
+      limits: null
+      requests:
+        cpu: 100m
+        memory: 128Mi
+  serviceMonitor:
+    enabled: true
+
+# Generate rules and mutate-existing rules are not part of the initial use case.
+backgroundController:
+  enabled: false
+
+cleanupController:
+  enabled: true
+  replicas: 1
+  priorityClassName: system-cluster-critical
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 1
+        preference:
+          matchExpressions:
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+  resources:
+    limits: null
+    requests:
+      cpu: 100m
+      memory: 64Mi
+  serviceMonitor:
+    enabled: true
+
+# PolicyReport generation and background auditing can be added independently if
+# reports become useful; neither is needed for admission or cleanup enforcement.
+reportsController:
+  enabled: false

--- a/k8s/platform/security/kyverno/kustomization.yaml
+++ b/k8s/platform/security/kyverno/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: kyverno
+namespace: platform-security
 resources:
   - namespace.yaml
   - controllers/

--- a/k8s/platform/security/kyverno/kustomization.yaml
+++ b/k8s/platform/security/kyverno/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kyverno
+resources:
+  - namespace.yaml
+  - controllers/

--- a/k8s/platform/security/kyverno/namespace.yaml
+++ b/k8s/platform/security/kyverno/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kyverno

--- a/k8s/platform/security/kyverno/namespace.yaml
+++ b/k8s/platform/security/kyverno/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: kyverno
+  name: platform-security


### PR DESCRIPTION
## Summary

- add Kyverno 1.19.0 (Helm chart 3.9.0) under `k8s/platform/security/kyverno`
- run the admission controller with three replicas, control-plane preference, and a PDB requiring two replicas available
- run one cleanup controller for `DeletingPolicy`/cleanup use cases
- disable the optional background and reports controllers because generate, mutate-existing, background scanning, and PolicyReports are not currently required
- expose admission and cleanup metrics through ServiceMonitors
- set explicit upstream-based requests and remove chart-default resource limits

## Component selection

| Component | State | Reason |
| --- | --- | --- |
| Admission controller | 3 replicas | Required for synchronous validation and mutation; highly available because it is on the API write path |
| Cleanup controller | 1 replica | Required for scheduled deleting/cleanup policies and TTL cleanup |
| Background controller | Disabled | Only needed for generate and mutate-existing rules |
| Reports controller | Disabled | Only needed for PolicyReports and background audit results |
| Reports server / Grafana | Disabled | Not needed without reports; Prometheus already scrapes controller metrics |

Cleanup permissions remain least-privilege. A future deleting policy must add an aggregated ClusterRole granting the cleanup controller `get`, `list`, `watch`, and `delete` for its specific target resources; this PR deliberately does not grant wildcard delete access. New policies should prefer the current CEL-based `DeletingPolicy` APIs because legacy `CleanupPolicy` types are deprecated in Kyverno 1.19.

## Kubernetes compatibility caveat

The cluster runs Kubernetes 1.36.3. Kyverno 1.19 is the current supported Kyverno release, but upstream currently documents tested Kubernetes compatibility only through 1.35. The chart itself declares Kubernetes `>=1.25`, renders successfully with `--kube-version 1.36.3`, and every rendered object was accepted by this cluster API in server-side dry-run. Runtime behavior on 1.36 is nevertheless not yet covered by Kyverno upstream compatibility guarantees.

## Validation

- `make validate` (94 targets)
- `make validate-flux` (40 live paths)
- full `flux-build` render of the new Kyverno path
- Helm render of chart 3.9.0 with `--kube-version 1.36.3`
- kubeconform: 64 resources, 42 validated, 22 CRD-schema resources skipped, 0 invalid/errors
- live API server-side dry-run: 39 cluster-scoped and 25 namespaced resources accepted
- rendered workload audit confirms only admission and cleanup Deployments are present, with requests and no limits
