### PR TITLE
Add drain-safe PDB validation

### DIFF
--- a/k8s/apps/ai-gateway/app/values.yaml
+++ b/k8s/apps/ai-gateway/app/values.yaml
@@ -82,7 +82,9 @@ extraEnvVars:
     value: "/ui"
 pdb:
   enabled: true
-  minAvailable: 1
+  # The chart does not yet expose unhealthyPodEvictionPolicy; the Kyverno PDB
+  # policy will keep warning about that remaining drain-safety gap.
+  maxUnavailable: 1
 affinity:
   podAntiAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:

--- a/k8s/apps/grafana/grafana/values.yaml
+++ b/k8s/apps/grafana/grafana/values.yaml
@@ -5,6 +5,7 @@ headlessService: true
 
 podDisruptionBudget:
   maxUnavailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
 
 # The chart renders the traefik route; ingress-cloudflare.yaml carries the same
 # host for outside access.

--- a/k8s/apps/homer/app/values.yaml
+++ b/k8s/apps/homer/app/values.yaml
@@ -9,3 +9,10 @@ resources:
   requests:
     cpu: 10m
     memory: 64Mi
+
+highAvailability:
+  podDisruptionBudget:
+    # The chart does not yet expose unhealthyPodEvictionPolicy; the Kyverno PDB
+    # policy will keep warning about that remaining drain-safety gap.
+    minAvailable: null
+    maxUnavailable: 1

--- a/k8s/apps/monitoring/manifests/prometheus/podDisruptionBudget.yaml
+++ b/k8s/apps/monitoring/manifests/prometheus/podDisruptionBudget.yaml
@@ -10,7 +10,8 @@ metadata:
   name: prometheus-k8s
   namespace: monitoring
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
   selector:
     matchLabels:
       app.kubernetes.io/component: prometheus

--- a/k8s/apps/photos/app/server-pdb.yaml
+++ b/k8s/apps/photos/app/server-pdb.yaml
@@ -6,7 +6,8 @@ metadata:
     app.kubernetes.io/name: server
   name: immich-server
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
   selector:
     matchLabels:
       app.kubernetes.io/instance: immich

--- a/k8s/platform/security/kyverno/controllers/values.yaml
+++ b/k8s/platform/security/kyverno/controllers/values.yaml
@@ -20,7 +20,9 @@ admissionController:
   replicas: 3
   priorityClassName: system-cluster-critical
   podDisruptionBudget:
-    minAvailable: 2
+    minAvailable: null
+    maxUnavailable: 1
+    unhealthyPodEvictionPolicy: AlwaysAllow
   tolerations:
     - key: node-role.kubernetes.io/control-plane
       operator: Exists

--- a/k8s/platform/security/kyverno/policies/kustomization.yaml
+++ b/k8s/platform/security/kyverno/policies/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - require-resource-requests.yaml
+  - validate-pdb-drain-safety.yaml
   - validate-helm-chart-version.yaml
   - validate-ingress-contract.yaml

--- a/k8s/platform/security/kyverno/policies/validate-pdb-drain-safety.yaml
+++ b/k8s/platform/security/kyverno/policies/validate-pdb-drain-safety.yaml
@@ -1,0 +1,61 @@
+apiVersion: policies.kyverno.io/v1
+kind: ValidatingPolicy
+metadata:
+  name: validate-pdb-drain-safety
+spec:
+  evaluation:
+    background:
+      enabled: false
+  failurePolicy: Fail
+  validationActions:
+    - Warn
+  matchConstraints:
+    namespaceSelector:
+      matchExpressions:
+        # Longhorn manages its own instance-manager and CSI PDBs.
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - longhorn-system
+    resourceRules:
+      - apiGroups:
+          - policy
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - poddisruptionbudgets
+  matchConditions:
+    # CNPG creates role-specific PDBs whose lifecycle and failover semantics are
+    # managed by the operator rather than by application owners.
+    - name: exclude-cnpg-managed-pdbs
+      expression: >-
+        !object.metadata.?ownerReferences.orValue([]).exists(
+          owner,
+          owner.kind == "Cluster" &&
+          owner.apiVersion.startsWith("postgresql.cnpg.io/")
+        )
+  validations:
+    - expression: has(object.spec.maxUnavailable)
+      message: >-
+        PodDisruptionBudgets must use maxUnavailable so the disruption allowance
+        follows changes to the workload replica count.
+    - expression: >-
+        !has(object.spec.maxUnavailable) ||
+        (string(object.spec.maxUnavailable) != "0" &&
+        string(object.spec.maxUnavailable) != "0%")
+      message: maxUnavailable must permit at least one voluntary disruption.
+    - expression: >-
+        object.spec.?unhealthyPodEvictionPolicy.orValue("") == "AlwaysAllow"
+      message: >-
+        unhealthyPodEvictionPolicy must be AlwaysAllow so an unhealthy Pod does
+        not indefinitely block a node drain.
+    - expression: >-
+        has(object.spec.selector) &&
+        (object.spec.selector.?matchLabels.orValue({}).size() > 0 ||
+        object.spec.selector.?matchExpressions.orValue([]).size() > 0)
+      message: >-
+        PodDisruptionBudget selectors must not be empty because policy/v1 empty
+        selectors match every Pod in the namespace.


### PR DESCRIPTION
## Summary

- add a warning-only `policies.kyverno.io/v1` `ValidatingPolicy` for drain-safe PodDisruptionBudgets
- require a non-zero `maxUnavailable`, `unhealthyPodEvictionPolicy: AlwaysAllow`, and a non-empty selector
- exclude CNPG-owned PDBs and the operator-managed Longhorn namespace
- migrate Immich, Prometheus, Grafana, Kyverno, LiteLLM, and Homer away from replica-sensitive `minAvailable` settings where applicable

## Rollout notes

- the policy starts with `validationActions: Warn`
- the current live evaluation skips all 15 CNPG/Longhorn-managed PDBs as intended
- after these manifest changes, five managed PDBs pass fully
- LiteLLM, Homer, and TopoLVM retain only the `AlwaysAllow` warning because their charts do not expose that PDB field; they are deliberately visible rather than exempted
- this prevents structurally zero-disruption PDB definitions but cannot guarantee a drain while another replica is already unavailable

## Validation

- server-side dry-run against the live Kyverno CRD
- live policy audit: 1 pass, 7 findings, 15 operator-managed skips before migration
- prospective managed-PDB audit: 5 pass, 2 expected chart-limitation findings
- safe PDB fixture: pass
- `maxUnavailable: 0` fixture: finding as expected
- empty selector fixture: finding as expected
- full Helm/Flux renders compared against pre-change object sets and specs
- `make validate` (96 targets)
- `make validate-flux` (41 Flux paths)