### PR TITLE
dlna: let kured drain the node minidlna runs on

### DIFF
--- a/k8s/apps/dlna-local/pdb.yaml
+++ b/k8s/apps/dlna-local/pdb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: minidlna
   namespace: dlna-local
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: minidlna


### PR DESCRIPTION
`minAvailable: 1` against a single replica left 0 allowed disruptions, so the budget blocked draining beelink02 outright — kured reboots would stall silently on that node.