### PR TITLE
dlna: pin minidlna's node, UUID and cache

### DIFF
--- a/k8s/apps/dlna-local/cache-pvc.yaml
+++ b/k8s/apps/dlna-local/cache-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cache
+  namespace: dlna-local
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: piraeus-r2

--- a/k8s/apps/dlna-local/deployment.yaml
+++ b/k8s/apps/dlna-local/deployment.yaml
@@ -18,12 +18,12 @@ spec:
       # using hotNetwork for SSDP multicast discovery.
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      # Pinned: SSDP only reaches the TV from a node with a VLAN20 sub-interface.
       affinity:
         nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              preference:
-                matchExpressions:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
                   - key: dlna-preferred
                     operator: In
                     values:
@@ -35,6 +35,8 @@ spec:
           env:
             - name: TZ
               value: Europe/Warsaw
+            - name: MINIDLNA_UUID
+              value: "4d696e69-444c-164e-9d41-7a2f67810b11"
             - name: MINIDLNA_FRIENDLY_NAME
               value: "UNAS DLNA Server"
             - name: MINIDLNA_MEDIA_DIR
@@ -74,7 +76,8 @@ spec:
               memory: 64Mi
       volumes:
         - name: cache
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: cache
         - name: photos
           persistentVolumeClaim:
             claimName: photos

--- a/k8s/apps/dlna-local/pdb.yaml
+++ b/k8s/apps/dlna-local/pdb.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: dlna-local
 spec:
   maxUnavailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
   selector:
     matchLabels:
       app: minidlna


### PR DESCRIPTION
- Node affinity `preferred` → `required`: SSDP only reaches the TV from a node
  with a VLAN20 sub-interface, so landing elsewhere silently breaks discovery.
- Pin `MINIDLNA_UUID` to the value it already advertises. minidlna derives the
  UUID from the bound NIC's MAC, so moving nodes made the TV see a new server.
- Cache moves from `emptyDir` to a 2Gi `piraeus-r2` PVC — the DB was rebuilt on
  every restart, re-scanning the NFS share (9 min / 2078 files).
- PDB gains `unhealthyPodEvictionPolicy: AlwaysAllow`, required by the
  `validate-pdb-drain-safety` policy.

Label the second node `dlna-preferred=true` once its VLAN20 interface exists.