### PR TITLE
ups: export UPS telemetry over Modbus TCP

### DIFF
--- a/k8s/apps/ups/configuration.yaml
+++ b/k8s/apps/ups/configuration.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: ups-modbus
+  name: telegraf
+data:
+  # Register map is undocumented by PowerWalker and was derived against the
+  # front-panel LCD; see docs/ups/modbus-register-map.md.
+  # UFIXED rather than UINT16 so `scale` is actually applied.
+  telegraf.conf: |
+    [agent]
+      interval = "30s"
+      flush_interval = "30s"
+      omit_hostname = true
+
+    [[inputs.modbus]]
+      name = "vfi1500"
+      name_override = "ups"
+      slave_id = 1
+      timeout = "3s"
+      controller = "tcp://192.168.1.141:502"
+      configuration_type = "register"
+      holding_registers = [
+        { name="temperature_celsius",    byte_order="AB", data_type="UFIXED", scale=0.1, address=[128] },
+        { name="input_frequency_hertz",  byte_order="AB", data_type="UFIXED", scale=0.1, address=[129] },
+        { name="input_voltage_volts",    byte_order="AB", data_type="UFIXED", scale=0.1, address=[132] },
+        { name="output_frequency_hertz", byte_order="AB", data_type="UFIXED", scale=0.1, address=[144] },
+        { name="output_voltage_volts",   byte_order="AB", data_type="UFIXED", scale=0.1, address=[147] },
+        { name="output_current_amperes", byte_order="AB", data_type="UFIXED", scale=0.1, address=[153] },
+        { name="load_percent",           byte_order="AB", data_type="UFIXED", scale=1.0, address=[162] },
+        { name="runtime_minutes",        byte_order="AB", data_type="UFIXED", scale=1.0, address=[165] },
+        { name="battery_charge_percent", byte_order="AB", data_type="UFIXED", scale=1.0, address=[169] },
+        { name="battery_voltage_volts",  byte_order="AB", data_type="UFIXED", scale=0.1, address=[170] },
+        { name="bypass_voltage_volts",   byte_order="AB", data_type="UFIXED", scale=0.1, address=[176] },
+      ]
+
+    [[outputs.prometheus_client]]
+      listen = ":9273"
+      metric_version = 2
+      collectors_exclude = ["gocollector", "process"]

--- a/k8s/apps/ups/deployment.yaml
+++ b/k8s/apps/ups/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: ups-modbus
+  name: ups-modbus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: exporter
+      app.kubernetes.io/name: ups-modbus
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: exporter
+        app.kubernetes.io/name: ups-modbus
+    spec:
+      containers:
+        - name: telegraf
+          image: docker.io/library/telegraf:1.39.3-alpine
+          args:
+            - --config
+            - /etc/telegraf/telegraf.conf
+          ports:
+            - containerPort: 9273
+              name: metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+          resources:
+            limits:
+              cpu: 200m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 48Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /etc/telegraf/telegraf.conf
+              name: config
+              subPath: telegraf.conf
+            - mountPath: /tmp
+              name: tmp
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+      volumes:
+        - name: config
+          configMap:
+            name: telegraf
+        - name: tmp
+          emptyDir: {}

--- a/k8s/apps/ups/kustomization.yaml
+++ b/k8s/apps/ups/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ups
+resources:
+  - namespace.yaml
+  - configuration.yaml
+  - deployment.yaml
+  - podmonitor.yaml

--- a/k8s/apps/ups/namespace.yaml
+++ b/k8s/apps/ups/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ups

--- a/k8s/apps/ups/podmonitor.yaml
+++ b/k8s/apps/ups/podmonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: ups-modbus
+  name: ups-modbus
+spec:
+  podMetricsEndpoints:
+    - interval: 30s
+      port: metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: exporter
+      app.kubernetes.io/name: ups-modbus

--- a/k8s/flux/apps/ups.yaml
+++ b/k8s/flux/apps/ups.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ups
+  namespace: flux-system
+spec:
+  interval: 15m0s
+  path: ./k8s/apps/ups
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: ankhmorpork


### PR DESCRIPTION
Telegraf polls the PowerWalker VFI 1500 over Modbus TCP and exposes Prometheus
metrics in a new `ups` namespace. Register map is the one derived against the
front-panel LCD in #1130.

Replaces the `snmp-ups` + `upsd` + `nut_exporter` stack the old plan assumed —
SNMP never answers on this unit, Modbus does.

Picked Telegraf over `modbus_exporter`: the latter's only published image is an
unversioned amd64-only build from 2021, whereas `telegraf:1.39.3-alpine` is
current and multi-arch, which matters for the Talos/RPi plan.

`UFIXED` not `UINT16` so `scale` is actually applied. Prometheus selects all
PodMonitors cluster-wide, so no extra wiring.