### PR TITLE
postgres: take cnpg-database 0.3.0 for bounded WAL

### DIFF
--- a/k8s/apps/ai-gateway/db/release.yaml
+++ b/k8s/apps/ai-gateway/db/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.2.1"
+      version: "0.3.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/atuin/postgres/release.yaml
+++ b/k8s/apps/atuin/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.2.1"
+      version: "0.3.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/grafana/postgres/release.yaml
+++ b/k8s/apps/grafana/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.2.1"
+      version: "0.3.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/mealie/db/release.yaml
+++ b/k8s/apps/mealie/db/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.2.1"
+      version: "0.3.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/mended-drum/db/release.yaml
+++ b/k8s/apps/mended-drum/db/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.2.1"
+      version: "0.3.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/multimedia/prowlarrdb/release.yaml
+++ b/k8s/apps/multimedia/prowlarrdb/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.2.1"
+      version: "0.3.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/multimedia/radarrdb/release.yaml
+++ b/k8s/apps/multimedia/radarrdb/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.2.1"
+      version: "0.3.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/multimedia/sonarrdb/release.yaml
+++ b/k8s/apps/multimedia/sonarrdb/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.2.1"
+      version: "0.3.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/paperless/manifests/postgres/release.yaml
+++ b/k8s/apps/paperless/manifests/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.2.1"
+      version: "0.3.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/photos/db/release.yaml
+++ b/k8s/apps/photos/db/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.2.1"
+      version: "0.3.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/pocket-id/postgres/release.yaml
+++ b/k8s/apps/pocket-id/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.2.1"
+      version: "0.3.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts


### PR DESCRIPTION
Picks up the WAL defaults from thaum-xyz/helm-charts#5 across all 11 clusters.

Fixes what took pocket-id down: a rebooted replica's replication slot retained
WAL on the primary without limit (`max_slot_wal_keep_size: -1`) while WAL ran at
~3GB/day on a 13MB database.

All five settings are sighup/superuser context, so clusters reload without a
restart and no failover is expected.