### PR TITLE
pocket-id: record the postgres volume as 9Gi

### DIFF
--- a/k8s/apps/pocket-id/postgres/values.yaml
+++ b/k8s/apps/pocket-id/postgres/values.yaml
@@ -4,7 +4,7 @@ owner: pocketid
 cluster:
   instances: 3
   storage:
-    size: 7Gi
+    size: 9Gi
   resources:
     limits:
       cpu: 400m


### PR DESCRIPTION
Resized in place when WAL filled the 7Gi volume, but git still said 7Gi — so the 0.3.0 bump tried to shrink it and CNPG's webhook refused:

```
spec.storage: Invalid value: "7Gi": can't shrink existing storage from 9Gi to 7Gi
```

Checked the other 10 clusters; only this one had drifted.