### PR TITLE
postgres: pin each cluster's current image

### DIFF
--- a/k8s/apps/ai-gateway/db/values.yaml
+++ b/k8s/apps/ai-gateway/db/values.yaml
@@ -2,6 +2,7 @@ database: litellm
 owner: litellm
 
 cluster:
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.1-system-trixie
   instances: 2
   storage:
     size: 2Gi

--- a/k8s/apps/grafana/postgres/values.yaml
+++ b/k8s/apps/grafana/postgres/values.yaml
@@ -2,6 +2,7 @@ database: grafana
 owner: grafana
 
 cluster:
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.5
   instances: 2
   storage:
     size: 15Gi

--- a/k8s/apps/mealie/db/values.yaml
+++ b/k8s/apps/mealie/db/values.yaml
@@ -2,6 +2,7 @@ database: mealie
 owner: mealie
 
 cluster:
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.2
   instances: 3
   storage:
     size: 2Gi

--- a/k8s/apps/mended-drum/db/values.yaml
+++ b/k8s/apps/mended-drum/db/values.yaml
@@ -2,6 +2,7 @@ database: drum
 owner: drum
 
 cluster:
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.1-system-trixie
   instances: 2
   storage:
     size: 1Gi

--- a/k8s/apps/multimedia/prowlarrdb/values.yaml
+++ b/k8s/apps/multimedia/prowlarrdb/values.yaml
@@ -2,6 +2,7 @@ database: prowlarr
 owner: prowlarr
 
 cluster:
+  imageName: ghcr.io/cloudnative-pg/postgresql:16.1
   instances: 2
   storage:
     size: 10Gi

--- a/k8s/apps/multimedia/radarrdb/values.yaml
+++ b/k8s/apps/multimedia/radarrdb/values.yaml
@@ -2,6 +2,7 @@ database: radarr
 owner: radarr
 
 cluster:
+  imageName: ghcr.io/cloudnative-pg/postgresql:16.1
   instances: 2
   storage:
     size: 10Gi

--- a/k8s/apps/multimedia/sonarrdb/values.yaml
+++ b/k8s/apps/multimedia/sonarrdb/values.yaml
@@ -2,6 +2,7 @@ database: sonarr
 owner: sonarr
 
 cluster:
+  imageName: ghcr.io/cloudnative-pg/postgresql:16.1
   instances: 2
   storage:
     size: 10Gi

--- a/k8s/apps/paperless/manifests/postgres/values.yaml
+++ b/k8s/apps/paperless/manifests/postgres/values.yaml
@@ -2,6 +2,7 @@ database: paperless
 owner: paperless
 
 cluster:
+  imageName: ghcr.io/cloudnative-pg/postgresql:15.2
   instances: 3
   primaryUpdateMethod: switchover
   storage:

--- a/k8s/apps/pocket-id/postgres/values.yaml
+++ b/k8s/apps/pocket-id/postgres/values.yaml
@@ -2,6 +2,7 @@ database: pocketid
 owner: pocketid
 
 cluster:
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.5
   instances: 3
   storage:
     size: 9Gi


### PR DESCRIPTION
Nine of eleven clusters never set `imageName`, so CNPG defaulted it at creation
and froze it into the spec. That is why the fleet spans **15.2 to 18.1** — nobody
picked those versions, they are just whatever the operator shipped that day.

This records the current image for each, changing nothing. It has to land
**before** the chart gets a default `imageName`, or all nine unpinned clusters
would move at once — including paperless 15 → 18, an offline `pg_upgrade`.