### PR TITLE
multimedia: patch prowlarr postgres to 16.15

### DIFF
--- a/k8s/apps/multimedia/prowlarrdb/values.yaml
+++ b/k8s/apps/multimedia/prowlarrdb/values.yaml
@@ -2,7 +2,7 @@ database: prowlarr
 owner: prowlarr
 
 cluster:
-  imageName: ghcr.io/cloudnative-pg/postgresql:16.1
+  imageName: ghcr.io/cloudnative-pg/postgresql:16.15-system-bullseye
   instances: 2
   storage:
     size: 10Gi


### PR DESCRIPTION
First phase-1 patch upgrade from the plan in #1136. Same major, same Debian base (bullseye), so no `pg_upgrade` and no collation change — CNPG rolls the replica then switches over.

Canary choice: prowlarr's downtime costs nothing, and its database has no extensions.