### PR TITLE
mealie: follow the chart's postgres image

### DIFF
--- a/k8s/apps/ai-gateway/db/release.yaml
+++ b/k8s/apps/ai-gateway/db/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.4.0"
+      version: "0.5.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/atuin/postgres/release.yaml
+++ b/k8s/apps/atuin/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.4.0"
+      version: "0.5.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/grafana/postgres/release.yaml
+++ b/k8s/apps/grafana/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.4.0"
+      version: "0.5.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/mealie/db/release.yaml
+++ b/k8s/apps/mealie/db/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.4.0"
+      version: "0.5.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/mealie/db/values.yaml
+++ b/k8s/apps/mealie/db/values.yaml
@@ -2,7 +2,6 @@ database: mealie
 owner: mealie
 
 cluster:
-  imageName: ghcr.io/cloudnative-pg/postgresql:17.2
   instances: 3
   storage:
     size: 2Gi

--- a/k8s/apps/mended-drum/db/release.yaml
+++ b/k8s/apps/mended-drum/db/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.4.0"
+      version: "0.5.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/multimedia/prowlarrdb/release.yaml
+++ b/k8s/apps/multimedia/prowlarrdb/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.4.0"
+      version: "0.5.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/multimedia/radarrdb/release.yaml
+++ b/k8s/apps/multimedia/radarrdb/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.4.0"
+      version: "0.5.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/multimedia/sonarrdb/release.yaml
+++ b/k8s/apps/multimedia/sonarrdb/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.4.0"
+      version: "0.5.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/paperless/manifests/postgres/release.yaml
+++ b/k8s/apps/paperless/manifests/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.4.0"
+      version: "0.5.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/photos/db/release.yaml
+++ b/k8s/apps/photos/db/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.4.0"
+      version: "0.5.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/pocket-id/postgres/release.yaml
+++ b/k8s/apps/pocket-id/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.4.0"
+      version: "0.5.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts


### PR DESCRIPTION
Takes chart 0.5.0 across the fleet (a no-op while every cluster still pins) and drops mealie's pin so it follows the chart default of 17.11-standard-bookworm.

mealie is already on 17, so this is a patch bump plus a base change — no `pg_upgrade`. Because glibc differs between bullseye and bookworm, collation ordering changes and text indexes need a `REINDEX` afterwards; I'll do that and refresh the collation version once it's up.

Canary for taking the rest off their pins.