### PR TITLE
grafana, pocket-id: follow the chart's postgres image

### DIFF
--- a/k8s/apps/grafana/postgres/values.yaml
+++ b/k8s/apps/grafana/postgres/values.yaml
@@ -2,7 +2,6 @@ database: grafana
 owner: grafana
 
 cluster:
-  imageName: ghcr.io/cloudnative-pg/postgresql:17.5
   instances: 2
   storage:
     size: 15Gi

--- a/k8s/apps/pocket-id/postgres/values.yaml
+++ b/k8s/apps/pocket-id/postgres/values.yaml
@@ -2,7 +2,6 @@ database: pocketid
 owner: pocketid
 
 cluster:
-  imageName: ghcr.io/cloudnative-pg/postgresql:17.5
   instances: 3
   storage:
     size: 9Gi


### PR DESCRIPTION
Drops both pins so they take the chart default, 17.11-standard-bookworm. Both already run 17, so it is a patch bump plus a base change — no `pg_upgrade`.

Checked before doing it: every database in the fleet is `collate=C`, which compares by byte order and is glibc-independent, so the bullseye→bookworm move needs no `REINDEX`. Verified on mealie in #1138 — 17.11 on pgdg12, app serving normally.