### PR TITLE
prowlarr: major-upgrade postgres to the chart default

### DIFF
--- a/k8s/apps/multimedia/prowlarrdb/values.yaml
+++ b/k8s/apps/multimedia/prowlarrdb/values.yaml
@@ -2,7 +2,6 @@ database: prowlarr
 owner: prowlarr
 
 cluster:
-  imageName: ghcr.io/cloudnative-pg/postgresql:16.15-standard-bookworm
   instances: 2
   storage:
     size: 10Gi


### PR DESCRIPTION
Step two of two. 16.15 → 17.11 with the bookworm base held constant, so `pg_upgrade` finds the old binaries it mounts into the new container.

Offline upgrade — backup `prowlarr-pre-pg17` taken and confirmed `completed` first. Dropping the pin is what adopts the chart default.