### PR TITLE
radarr, sonarr: move postgres onto bookworm

### DIFF
--- a/k8s/apps/multimedia/radarrdb/values.yaml
+++ b/k8s/apps/multimedia/radarrdb/values.yaml
@@ -2,7 +2,7 @@ database: radarr
 owner: radarr
 
 cluster:
-  imageName: ghcr.io/cloudnative-pg/postgresql:16.1
+  imageName: ghcr.io/cloudnative-pg/postgresql:16.15-standard-bookworm
   instances: 2
   storage:
     size: 10Gi

--- a/k8s/apps/multimedia/sonarrdb/values.yaml
+++ b/k8s/apps/multimedia/sonarrdb/values.yaml
@@ -2,7 +2,7 @@ database: sonarr
 owner: sonarr
 
 cluster:
-  imageName: ghcr.io/cloudnative-pg/postgresql:16.1
+  imageName: ghcr.io/cloudnative-pg/postgresql:16.15-standard-bookworm
   instances: 2
   storage:
     size: 10Gi


### PR DESCRIPTION
Step one of two, following the path proven on prowlarr in #1140/#1141. Same major, so a restart rather than a `pg_upgrade`. Base moves first because `pg_upgrade` mounts the old binaries into the new container.