### PR TITLE
radarr, sonarr: major-upgrade postgres to the chart default

### DIFF
--- a/k8s/apps/multimedia/radarrdb/values.yaml
+++ b/k8s/apps/multimedia/radarrdb/values.yaml
@@ -2,7 +2,6 @@ database: radarr
 owner: radarr
 
 cluster:
-  imageName: ghcr.io/cloudnative-pg/postgresql:16.15-standard-bookworm
   instances: 2
   storage:
     size: 10Gi

--- a/k8s/apps/multimedia/sonarrdb/values.yaml
+++ b/k8s/apps/multimedia/sonarrdb/values.yaml
@@ -2,7 +2,6 @@ database: sonarr
 owner: sonarr
 
 cluster:
-  imageName: ghcr.io/cloudnative-pg/postgresql:16.15-standard-bookworm
   instances: 2
   storage:
     size: 10Gi


### PR DESCRIPTION
Step two of two — 16.15 → 17.11 with the bookworm base held constant so `pg_upgrade` finds the binaries it mounts. Backups `radarr-pre-pg17` and `sonarr-pre-pg17` both confirmed `completed` first.

Dropping the pin is what adopts the chart default.