### PR TITLE
atuin, paperless: move postgres onto bookworm

### DIFF
--- a/k8s/apps/atuin/postgres/values.yaml
+++ b/k8s/apps/atuin/postgres/values.yaml
@@ -8,7 +8,7 @@ owner: atuin
 
 cluster:
   instances: 2
-  imageName: ghcr.io/cloudnative-pg/postgresql:16.11
+  imageName: ghcr.io/cloudnative-pg/postgresql:16.15-standard-bookworm
   storage:
     size: 7Gi
   resources:

--- a/k8s/apps/paperless/manifests/postgres/values.yaml
+++ b/k8s/apps/paperless/manifests/postgres/values.yaml
@@ -2,7 +2,7 @@ database: paperless
 owner: paperless
 
 cluster:
-  imageName: ghcr.io/cloudnative-pg/postgresql:15.2
+  imageName: ghcr.io/cloudnative-pg/postgresql:15.19-standard-bookworm
   instances: 3
   primaryUpdateMethod: switchover
   storage:


### PR DESCRIPTION
Step one of two. atuin 16.11 → 16.15-standard-bookworm, paperless 15.2 → 15.19-standard-bookworm. Same major each, so a restart rather than a `pg_upgrade`.

paperless is the oldest in the fleet — 15.2 shipped Feb 2023, ~17 patch releases behind. Its `primaryUpdateMethod: switchover` is fine here since only the image changes.