### PR TITLE
atuin, paperless: major-upgrade postgres to the chart default

### DIFF
--- a/k8s/apps/atuin/postgres/values.yaml
+++ b/k8s/apps/atuin/postgres/values.yaml
@@ -8,7 +8,6 @@ owner: atuin
 
 cluster:
   instances: 2
-  imageName: ghcr.io/cloudnative-pg/postgresql:16.15-standard-bookworm
   storage:
     size: 7Gi
   resources:

--- a/k8s/apps/paperless/manifests/postgres/values.yaml
+++ b/k8s/apps/paperless/manifests/postgres/values.yaml
@@ -2,7 +2,6 @@ database: paperless
 owner: paperless
 
 cluster:
-  imageName: ghcr.io/cloudnative-pg/postgresql:15.19-standard-bookworm
   instances: 3
   primaryUpdateMethod: switchover
   storage:


### PR DESCRIPTION
Step two of two, bookworm base held constant. atuin 16.15 → 17.11, paperless 15.19 → 17.11 (`pg_upgrade` spans two majors in one hop, which it supports). Backups `atuin-pre-pg17` and `paperless-pre-pg17` confirmed `completed` first.

Completes the migration: every cluster that can follow the chart now does. ai-gateway and mended-drum stay pinned on 18 (no downgrade path), photos on its VectorChord build.