### PR TITLE
karakeep: let meilisearch migrate its own database

### DIFF
--- a/k8s/apps/karakeep/search/deployment.yaml
+++ b/k8s/apps/karakeep/search/deployment.yaml
@@ -20,6 +20,12 @@ spec:
         - name: meilisearch
           image: getmeili/meilisearch:v1.52.0
           env:
+            # meilisearch refuses to start when its on-disk format predates the
+            # engine, so every image bump halts it until the data is migrated.
+            # The index is derived from karakeep and can be rebuilt, so migrate
+            # on start rather than hand-holding each Renovate bump.
+            - name: MEILI_UPGRADE_DB
+              value: "true"
             - name: MEILI_NO_ANALYTICS
               value: "true"
             # Was envFrom over the whole karakeep-secrets Secret, which handed


### PR DESCRIPTION
meilisearch refuses to start when its on-disk format predates the engine:

```
Your database version (1.51.0) is incompatible with your current engine version (1.52.0)
```

The v1.52.0 bump left it crash-looping for ~5h (66 restarts). Setting `MEILI_UPGRADE_DB` migrates on start. Left on permanently rather than as a one-shot: the index is derived from karakeep and rebuildable, and otherwise every Renovate bump halts it the same way.