### PR TITLE
longhorn: bring the BackupTarget into git

### DIFF
--- a/k8s/platform/storage/longhorn-system/versity/backuptarget.yaml
+++ b/k8s/platform/storage/longhorn-system/versity/backuptarget.yaml
@@ -1,0 +1,18 @@
+# Longhorn 1.8 dropped the backup-target Settings, so this CR is the only way to
+# point Longhorn at a store. It was created by hand when backups were unblocked
+# and had no owner, meaning nothing in git described what the backups depend on.
+#
+# The endpoint does not belong in backupTargetURL -- the validating webhook only
+# accepts storage-protocol schemes. It comes from AWS_ENDPOINTS inside
+# versitygw-credentials, and the region here must match the gateway's VGW_REGION.
+#
+# syncRequestedAt is deliberately absent: Longhorn writes it on every sync, so
+# declaring it would put Flux and Longhorn in a loop.
+apiVersion: longhorn.io/v1beta2
+kind: BackupTarget
+metadata:
+  name: default
+spec:
+  backupTargetURL: s3://longhorn@us-east-1/
+  credentialSecret: versitygw-credentials
+  pollInterval: 5m0s

--- a/k8s/platform/storage/longhorn-system/versity/kustomization.yaml
+++ b/k8s/platform/storage/longhorn-system/versity/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - credentials-generator.yaml
   - credentials-secret.yaml
   - job.yaml
+  - backuptarget.yaml
 configMapGenerator:
   # Not "values": base/longhorn-system already generates a ConfigMap by that
   # name in this namespace. It is hashed today and so does not collide, but it


### PR DESCRIPTION
The `default` BackupTarget was created by hand when backups were unblocked and had no owner labels, so nothing in git described the store all 111 Longhorn backups depend on.

`syncRequestedAt` is deliberately omitted — Longhorn rewrites it on every sync, so declaring it would put Flux and Longhorn in a write loop. Server dry-run shows a clean `configured`, so adoption is non-disruptive.