### PR TITLE
multimedia: back postgres up to versity

### DIFF
--- a/k8s/apps/multimedia/prowlarrdb/values.yaml
+++ b/k8s/apps/multimedia/prowlarrdb/values.yaml
@@ -19,7 +19,9 @@ backup:
   schedule: "0 7 3 * * *"
   objectStore:
     # Three clusters share this namespace, so each needs its own store.
-    name: backblaze-prowlarr
+    name: versity-prowlarr
+    bucketPrefix: s3://cnpg/postgres
+    endpointURL: http://versitygw.cnpg-system.svc.cluster.local:7070
     retentionPolicy: 7d
     pathSuffix: prowlarr
 

--- a/k8s/apps/multimedia/radarrdb/values.yaml
+++ b/k8s/apps/multimedia/radarrdb/values.yaml
@@ -23,7 +23,9 @@ backup:
   schedule: "0 17 3 * * *"
   objectStore:
     # Three clusters share this namespace, so each needs its own store.
-    name: backblaze-radarr
+    name: versity-radarr
+    bucketPrefix: s3://cnpg/postgres
+    endpointURL: http://versitygw.cnpg-system.svc.cluster.local:7070
     retentionPolicy: 14d
     pathSuffix: radarr
 

--- a/k8s/apps/multimedia/sonarrdb/values.yaml
+++ b/k8s/apps/multimedia/sonarrdb/values.yaml
@@ -19,7 +19,9 @@ backup:
   schedule: "0 27 3 * * *"
   objectStore:
     # Three clusters share this namespace, so each needs its own store.
-    name: backblaze-sonarr
+    name: versity-sonarr
+    bucketPrefix: s3://cnpg/postgres
+    endpointURL: http://versitygw.cnpg-system.svc.cluster.local:7070
     retentionPolicy: 7d
     pathSuffix: sonarr
 


### PR DESCRIPTION
Canary batch for finishing the versity cutover — three near-identical clusters whose backups matter least.

Stores are **renamed** (`backblaze-prowlarr` → `versity-prowlarr`) rather than repointed, so nothing keeps a backblaze name while writing elsewhere.

Credentials unchanged: versitygw holds the same access key the per-namespace `postgres-backup` secrets already carry (verified identical md5 across namespaces), which is why mended-drum has run on versity for 8 days without a credential change.

WAL archiving moves with it, so I'll verify both a base backup and WAL landing in the bucket before doing the remaining seven.