### PR TITLE
postgres: finish the versity cutover

### DIFF
--- a/k8s/apps/ai-gateway/db/values.yaml
+++ b/k8s/apps/ai-gateway/db/values.yaml
@@ -17,6 +17,9 @@ cluster:
 backup:
   schedule: "0 30 23 * * *"
   objectStore:
+    name: versity
+    bucketPrefix: s3://cnpg/postgres
+    endpointURL: http://versitygw.cnpg-system.svc.cluster.local:7070
     retentionPolicy: 30d
     pathSuffix: ai-gateway
 

--- a/k8s/apps/atuin/postgres/values.yaml
+++ b/k8s/apps/atuin/postgres/values.yaml
@@ -23,6 +23,9 @@ cluster:
 backup:
   schedule: "0 17 23 * * *"
   objectStore:
+    name: versity
+    bucketPrefix: s3://cnpg/postgres
+    endpointURL: http://versitygw.cnpg-system.svc.cluster.local:7070
     retentionPolicy: 14d
     pathSuffix: atuin
 

--- a/k8s/apps/grafana/postgres/values.yaml
+++ b/k8s/apps/grafana/postgres/values.yaml
@@ -16,6 +16,9 @@ cluster:
 backup:
   schedule: "0 17 23 * * *"
   objectStore:
+    name: versity
+    bucketPrefix: s3://cnpg/postgres
+    endpointURL: http://versitygw.cnpg-system.svc.cluster.local:7070
     # Shortest window in the fleet: a run of missed backups expires the base
     # backup within days rather than weeks.
     retentionPolicy: 3d

--- a/k8s/apps/mealie/db/values.yaml
+++ b/k8s/apps/mealie/db/values.yaml
@@ -16,6 +16,9 @@ cluster:
 backup:
   schedule: "0 17 23 * * *"
   objectStore:
+    name: versity
+    bucketPrefix: s3://cnpg/postgres
+    endpointURL: http://versitygw.cnpg-system.svc.cluster.local:7070
     retentionPolicy: 30d
     pathSuffix: mealie
 

--- a/k8s/apps/paperless/manifests/postgres/values.yaml
+++ b/k8s/apps/paperless/manifests/postgres/values.yaml
@@ -17,6 +17,9 @@ cluster:
 backup:
   schedule: "0 36 22 * * *"
   objectStore:
+    name: versity
+    bucketPrefix: s3://cnpg/postgres
+    endpointURL: http://versitygw.cnpg-system.svc.cluster.local:7070
     retentionPolicy: 14d
     pathSuffix: paperless
 

--- a/k8s/apps/photos/db/values.yaml
+++ b/k8s/apps/photos/db/values.yaml
@@ -34,6 +34,9 @@ cluster:
 backup:
   schedule: "0 13 2 * * *"
   objectStore:
+    name: versity
+    bucketPrefix: s3://cnpg/postgres
+    endpointURL: http://versitygw.cnpg-system.svc.cluster.local:7070
     retentionPolicy: 14d
     pathSuffix: photos
 

--- a/k8s/apps/pocket-id/postgres/values.yaml
+++ b/k8s/apps/pocket-id/postgres/values.yaml
@@ -16,6 +16,9 @@ cluster:
 backup:
   schedule: "0 17 23 * * *"
   objectStore:
+    name: versity
+    bucketPrefix: s3://cnpg/postgres
+    endpointURL: http://versitygw.cnpg-system.svc.cluster.local:7070
     retentionPolicy: 30d
     # Not the namespace name.
     pathSuffix: pocketid


### PR DESCRIPTION
The last seven clusters — ai-gateway, atuin, grafana, mealie, paperless, photos,
pocket-id — follow multimedia onto the in-cluster gateway.

Verified on the multimedia canary before doing these: the plugin used the versity
endpoint after cutover and backblaze only before it (checked timestamps, since
this exact test produced a false positive last time), WAL archiving reported 452
archived / 0 failed, and the base backup is on disk at
`/mnt/data/cnpg/postgres/prowlarr` (61.7M).

Credentials unchanged; versitygw holds the same access key the per-namespace
`postgres-backup` secrets carry.

The old backblaze ObjectStores survive the rename because the chart marks them
`helm.sh/resource-policy: keep` — they need a manual delete once these are proven.