### PR TITLE
postgres: take cnpg-database 0.6.0 and let it own the backup target

### DIFF
--- a/k8s/apps/ai-gateway/db/release.yaml
+++ b/k8s/apps/ai-gateway/db/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.5.0"
+      version: "0.6.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/ai-gateway/db/values.yaml
+++ b/k8s/apps/ai-gateway/db/values.yaml
@@ -17,9 +17,6 @@ cluster:
 backup:
   schedule: "0 30 23 * * *"
   objectStore:
-    name: versity
-    bucketPrefix: s3://cnpg/postgres
-    endpointURL: http://versitygw.cnpg-system.svc.cluster.local:7070
     retentionPolicy: 30d
     pathSuffix: ai-gateway
 

--- a/k8s/apps/atuin/postgres/release.yaml
+++ b/k8s/apps/atuin/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.5.0"
+      version: "0.6.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/atuin/postgres/values.yaml
+++ b/k8s/apps/atuin/postgres/values.yaml
@@ -23,9 +23,6 @@ cluster:
 backup:
   schedule: "0 17 23 * * *"
   objectStore:
-    name: versity
-    bucketPrefix: s3://cnpg/postgres
-    endpointURL: http://versitygw.cnpg-system.svc.cluster.local:7070
     retentionPolicy: 14d
     pathSuffix: atuin
 

--- a/k8s/apps/grafana/postgres/release.yaml
+++ b/k8s/apps/grafana/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.5.0"
+      version: "0.6.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/grafana/postgres/values.yaml
+++ b/k8s/apps/grafana/postgres/values.yaml
@@ -16,9 +16,6 @@ cluster:
 backup:
   schedule: "0 17 23 * * *"
   objectStore:
-    name: versity
-    bucketPrefix: s3://cnpg/postgres
-    endpointURL: http://versitygw.cnpg-system.svc.cluster.local:7070
     # Shortest window in the fleet: a run of missed backups expires the base
     # backup within days rather than weeks.
     retentionPolicy: 3d

--- a/k8s/apps/mealie/db/release.yaml
+++ b/k8s/apps/mealie/db/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.5.0"
+      version: "0.6.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/mealie/db/values.yaml
+++ b/k8s/apps/mealie/db/values.yaml
@@ -16,9 +16,6 @@ cluster:
 backup:
   schedule: "0 17 23 * * *"
   objectStore:
-    name: versity
-    bucketPrefix: s3://cnpg/postgres
-    endpointURL: http://versitygw.cnpg-system.svc.cluster.local:7070
     retentionPolicy: 30d
     pathSuffix: mealie
 

--- a/k8s/apps/mended-drum/db/release.yaml
+++ b/k8s/apps/mended-drum/db/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.5.0"
+      version: "0.6.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/mended-drum/db/values.yaml
+++ b/k8s/apps/mended-drum/db/values.yaml
@@ -17,11 +17,8 @@ cluster:
 backup:
   schedule: "0 30 23 * * *"
   objectStore:
-    name: versity
     retentionPolicy: 30d
     pathSuffix: mended-drum
-    bucketPrefix: s3://cnpg/postgres
-    endpointURL: http://versitygw.cnpg-system.svc.cluster.local:7070
 
 externalSecrets:
   admin:

--- a/k8s/apps/multimedia/prowlarrdb/release.yaml
+++ b/k8s/apps/multimedia/prowlarrdb/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.5.0"
+      version: "0.6.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/multimedia/radarrdb/release.yaml
+++ b/k8s/apps/multimedia/radarrdb/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.5.0"
+      version: "0.6.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/multimedia/sonarrdb/release.yaml
+++ b/k8s/apps/multimedia/sonarrdb/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.5.0"
+      version: "0.6.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/paperless/manifests/postgres/release.yaml
+++ b/k8s/apps/paperless/manifests/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.5.0"
+      version: "0.6.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/paperless/manifests/postgres/values.yaml
+++ b/k8s/apps/paperless/manifests/postgres/values.yaml
@@ -17,9 +17,6 @@ cluster:
 backup:
   schedule: "0 36 22 * * *"
   objectStore:
-    name: versity
-    bucketPrefix: s3://cnpg/postgres
-    endpointURL: http://versitygw.cnpg-system.svc.cluster.local:7070
     retentionPolicy: 14d
     pathSuffix: paperless
 

--- a/k8s/apps/photos/db/release.yaml
+++ b/k8s/apps/photos/db/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.5.0"
+      version: "0.6.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/photos/db/values.yaml
+++ b/k8s/apps/photos/db/values.yaml
@@ -34,9 +34,6 @@ cluster:
 backup:
   schedule: "0 13 2 * * *"
   objectStore:
-    name: versity
-    bucketPrefix: s3://cnpg/postgres
-    endpointURL: http://versitygw.cnpg-system.svc.cluster.local:7070
     retentionPolicy: 14d
     pathSuffix: photos
 

--- a/k8s/apps/pocket-id/postgres/release.yaml
+++ b/k8s/apps/pocket-id/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.5.0"
+      version: "0.6.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/pocket-id/postgres/values.yaml
+++ b/k8s/apps/pocket-id/postgres/values.yaml
@@ -16,9 +16,6 @@ cluster:
 backup:
   schedule: "0 17 23 * * *"
   objectStore:
-    name: versity
-    bucketPrefix: s3://cnpg/postgres
-    endpointURL: http://versitygw.cnpg-system.svc.cluster.local:7070
     retentionPolicy: 30d
     # Not the namespace name.
     pathSuffix: pocketid


### PR DESCRIPTION
Chart 0.6.0 defaults to the versity gateway, so the per-cluster `name`/`bucketPrefix`/`endpointURL` were just repeating it — same pattern as the image pin. multimedia keeps explicit names since three clusters share that namespace.

Should be a no-op in the cluster: the rendered ObjectStore name and endpoint are identical.