### PR TITLE
piraeus: add roaming storage class

### DIFF
--- a/k8s/platform/security/kyverno/policies/kustomization.yaml
+++ b/k8s/platform/security/kyverno/policies/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - validate-pdb-drain-safety.yaml
   - validate-helm-chart-version.yaml
   - validate-ingress-contract.yaml
+  - validate-roaming-volume-size.yaml

--- a/k8s/platform/security/kyverno/policies/validate-roaming-volume-size.yaml
+++ b/k8s/platform/security/kyverno/policies/validate-roaming-volume-size.yaml
@@ -1,0 +1,42 @@
+apiVersion: policies.kyverno.io/v1
+kind: ValidatingPolicy
+metadata:
+  name: validate-roaming-volume-size
+spec:
+  evaluation:
+    background:
+      enabled: false
+  failurePolicy: Fail
+  validationActions:
+    - Deny
+  matchConstraints:
+    resourceRules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - persistentvolumeclaims
+  matchConditions:
+    - name: only-roaming-storage-class
+      expression: >-
+        object.spec.?storageClassName.orValue("") == "piraeus-r2-roaming"
+  variables:
+    - name: requested
+      expression: >-
+        quantity(object.spec.?resources.?requests.?storage.orValue("0"))
+  validations:
+    # A Pod that moves attaches diskless for the class's 5 minute auto-diskful
+    # delay, then resyncs a replica over the node network. rs-discard-granularity
+    # keeps unallocated blocks off the wire, but requested size is the only proxy
+    # admission has: a full 32Gi is about five more minutes at 1Gb/s.
+    - expression: >-
+        !variables.requested.isGreaterThan(quantity("32Gi"))
+      message: >-
+        PersistentVolumeClaims on piraeus-r2-roaming are limited to 32Gi, because
+        the volume is resynced across the node network every time its Pod moves
+        to a node without a replica. Use piraeus-r2 for larger volumes; it pins
+        the Pod to a replica instead.

--- a/k8s/platform/storage/piraeus-datastore/cluster/values.yaml
+++ b/k8s/platform/storage/piraeus-datastore/cluster/values.yaml
@@ -252,6 +252,21 @@ storageClasses:
       # Keep application I/O local to one of the two diskful replicas. The
       # affinity controller updates PV affinity if LINSTOR moves a replica.
       linstor.csi.linbit.com/allowRemoteVolumeAccess: "false"
+  # Same two replicas, but Pods are not pinned to them: a Pod may schedule onto
+  # any satellite node and attach diskless, and auto-diskful then converts that
+  # attachment into a local replica and drops the surplus one. I/O is remote
+  # until the conversion completes, hence the size cap enforced by the
+  # validate-roaming-volume-size policy.
+  - name: piraeus-r2-roaming
+    reclaimPolicy: Delete
+    allowVolumeExpansion: true
+    volumeBindingMode: WaitForFirstConsumer
+    parameters:
+      csi.storage.k8s.io/fstype: xfs
+      linstor.csi.linbit.com/autoPlace: "2"
+      linstor.csi.linbit.com/storagePool: temporary-topolvm
+      linstor.csi.linbit.com/allowRemoteVolumeAccess: "true"
+      property.linstor.csi.linbit.com/DrbdOptions/auto-diskful: "5"
 
 volumeSnapshotClasses:
   - name: piraeus


### PR DESCRIPTION
Adds `piraeus-r2-roaming`: same two replicas as `piraeus-r2`, but Pods are not pinned to the replica nodes. A Pod may schedule onto any satellite node and attach diskless; `DrbdOptions/auto-diskful: 5` then converts that attachment into a local replica and drops the surplus one, so the data follows the Pod.

I/O is remote until the conversion completes, so a Kyverno `ValidatingPolicy` caps PVCs on the class at 32Gi (CREATE and UPDATE, so expansion can't walk past it). `piraeus-r2` is unchanged — no StorageClass recreation needed.

Verified with `kyverno apply` (2Gi passes, 32Gi boundary passes, 45Gi denied, other classes skipped) plus both `hack/validate-*.sh` scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)