### PR TITLE
vod-arr: open gluetun's inbound ports for qbittorrent

### DIFF
--- a/k8s/apps/vod-arr/qbittorrent/config.yaml
+++ b/k8s/apps/vod-arr/qbittorrent/config.yaml
@@ -11,8 +11,16 @@ data:
   # kubelet probes and Traefik arrive from these, and nothing else is allowed
   # off the tunnel.
   FIREWALL_OUTBOUND_SUBNETS: 10.42.0.0/16,10.43.0.0/16,192.168.50.0/24
-  # FIREWALL_INPUT_PORTS is deliberately absent: it opens the listener on the
-  # tunnel interface as well, publishing the WebUI to the VPN network.
+  # OUTBOUND_SUBNETS writes OUTPUT rules only -- the INPUT policy stays DROP, so
+  # without the ports below every inbound connection is dropped and the
+  # readiness probe times out instead of being refused, while Traefik, the *arrs
+  # and Prometheus all hang. 8080 is the WebUI, 9091 the exporter.
+  #
+  # These bind to the default-route interface, not the tunnel: gluetun passes
+  # them to SetAllowedPort with defaultRoute.NetInterface. The tunnel-side
+  # equivalent is FIREWALL_VPN_INPUT_PORTS, which stays unset -- that is the one
+  # that would publish a listener to the VPN network.
+  FIREWALL_INPUT_PORTS: 8080,9091
   DOT: "on"
   DNS_KEEP_NAMESERVER: "off"
   HTTP_CONTROL_SERVER_ADDRESS: :8000


### PR DESCRIPTION
`FIREWALL_OUTBOUND_SUBNETS` only writes OUTPUT rules — the INPUT policy stayed
DROP, so every inbound connection to the qbittorrent pod was dropped (418
packets). The readiness probe timed out instead of being refused, and the same
rule silently blocked traefik, the *arrs reaching the download client, and the
prometheus scrape.

`FIREWALL_INPUT_PORTS` binds to eth0, not the tunnel — `FIREWALL_VPN_INPUT_PORTS`
is the tunnel-side setting and stays unset. 6881 is deliberately omitted.

Verified live: 3/3 ready, WebUI 200 through the Service, 95 `qbittorrent_` series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)