### PR TITLE
vod-arr: fix recyclarr, pinned four majors behind

### DIFF
--- a/k8s/apps/vod-arr/recyclarr/config.yaml
+++ b/k8s/apps/vod-arr/recyclarr/config.yaml
@@ -1,22 +1,50 @@
 # TRaSH-guide quality profiles and custom formats, applied on a schedule so the
 # *arrs' release selection is declared here rather than clicked into a database
 # nobody can read back.
+#
+# Written in the shape `recyclarr config create -t <id>` renders, rather than the
+# `include: - template:` indirection this used to rely on. That mechanism still
+# exists in v8, but every template was renamed when config-templates dropped
+# includes.json for templates.json -- the old `sonarr-v4-*` / `radarr-*-movie`
+# names resolve to nothing. Regenerate with `-t web-1080p` (sonarr) and
+# `-t hd-bluray-web` (radarr) to diff against upstream, including the optional
+# custom formats left out here.
 sonarr:
-  main:
+  # Instance names are global across services in v8: two instances both called
+  # "main" are silently treated as duplicates and dropped, logged only at debug.
+  tv:
     base_url: http://sonarr:8989
     api_key: !env_var SONARR_API_KEY
-    replace_existing_custom_formats: true
-    include:
-      - template: sonarr-quality-definition-series
-      - template: sonarr-v4-quality-profile-web-1080p
-      - template: sonarr-v4-custom-formats-web-1080p
+
+    quality_definition:
+      type: series
+
+    quality_profiles:
+      - trash_id: 72dae194fc92bf828f32cde7744e51a1 # WEB-1080p
+        reset_unmatched_scores:
+          enabled: true
+
+    custom_format_groups:
+      add:
+        - trash_id: 158188097a58d7687dee647e04af0da3 # [Optional] Golden Rule HD
+        - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4 # [Optional] Language Profiles
+        - trash_id: 85fae4a2294965b75710ef2989c850eb # [Streaming Services] HD/UHD boost
+        - trash_id: 59c3af66780d08332fdc64e68297098f # [Unwanted] Unwanted Formats
 
 radarr:
-  main:
+  movies:
     base_url: http://radarr:7878
     api_key: !env_var RADARR_API_KEY
-    replace_existing_custom_formats: true
-    include:
-      - template: radarr-quality-definition-movie
-      - template: radarr-quality-profile-hd-bluray-web
-      - template: radarr-custom-formats-hd-bluray-web
+
+    quality_definition:
+      type: movie
+
+    quality_profiles:
+      - trash_id: d1d67249d3890e49bc12e275d989a7e9 # HD Bluray + WEB
+        reset_unmatched_scores:
+          enabled: true
+
+    custom_format_groups:
+      add:
+        - trash_id: f8bf8eab4617f12dfdbd16303d8da245 # [Optional] Golden Rule HD
+        - trash_id: a3ac6af01d78e4f21fcb75f601ac96df # [Unwanted] Unwanted Formats

--- a/k8s/apps/vod-arr/recyclarr/cronjob.yaml
+++ b/k8s/apps/vod-arr/recyclarr/cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: sync
     app.kubernetes.io/name: recyclarr
     app.kubernetes.io/part-of: recyclarr
-    app.kubernetes.io/version: 7.4.0
+    app.kubernetes.io/version: 8.7.1
   name: recyclarr
 spec:
   concurrencyPolicy: Forbid
@@ -40,7 +40,7 @@ spec:
                       key: apiKey
                       name: radarr-api-key
                       optional: true
-              image: ghcr.io/recyclarr/recyclarr:7.4.0
+              image: ghcr.io/recyclarr/recyclarr:8.7.1
               name: recyclarr
               resources:
                 limits:


### PR DESCRIPTION
The nightly job has never succeeded: `templates.json does not exist … includes.json`.

Three faults, all silent:
- image pinned to **7.4.0**; **8.7.1** is current (unsorted ghcr tag list mistaken for latest)
- every config template was renamed when config-templates dropped `includes.json`;
  rewritten in the shape `recyclarr config create -t` renders (`web-1080p`, `hd-bluray-web`)
- both instances were named `main` — v8 instance names are global, so it processed
  neither and exited 0, logging `Duplicate instances` only at debug level

Verified live: radarr 40 custom formats + "HD Bluray + WEB", sonarr 37 + "WEB-1080p".

🤖 Generated with [Claude Code](https://claude.com/claude-code)