### PR TITLE
vod-arr: let recyclarr's git work on the NFS config volume

### DIFF
--- a/k8s/apps/vod-arr/recyclarr/cronjob.yaml
+++ b/k8s/apps/vod-arr/recyclarr/cronjob.yaml
@@ -28,6 +28,17 @@ spec:
               env:
                 - name: TZ
                   value: Europe/Berlin
+                # The NFS export maps /config to uid 977 while this runs as 1000,
+                # and git refuses to touch a repo it does not own ("detected
+                # dubious ownership"), which fails the whole sync. fsGroup cannot
+                # fix it: NFS ignores it. Set via GIT_CONFIG_* rather than a
+                # global config file so nothing has to be written to $HOME.
+                - name: GIT_CONFIG_COUNT
+                  value: "1"
+                - name: GIT_CONFIG_KEY_0
+                  value: safe.directory
+                - name: GIT_CONFIG_VALUE_0
+                  value: "*"
                 - name: SONARR_API_KEY
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
The NFS PVC broke every recyclarr run with `detected dubious ownership` — the
export maps `/config` to uid 977 while the container runs as 1000, and git
refuses to operate on a repo it doesn't own. `fsGroup` can't fix it because NFS
ignores it (writes themselves work; only git objects).

Fixed with `GIT_CONFIG_COUNT/KEY/VALUE` so no `$HOME` write is needed.

Verified on a clean volume: sync completes, everything reports up to date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)