### PR TITLE
vod-arr: give the *arrs a backup volume on NFS

### DIFF
--- a/k8s/apps/vod-arr/bazarr/deployment.yaml
+++ b/k8s/apps/vod-arr/bazarr/deployment.yaml
@@ -59,6 +59,9 @@ spec:
           volumeMounts:
             - mountPath: /config
               name: config
+            - mountPath: /backup
+              name: backups
+              subPath: bazarr
             - mountPath: /media/tv
               name: tv
             - mountPath: /media/movies
@@ -74,6 +77,9 @@ spec:
         - name: config
           persistentVolumeClaim:
             claimName: bazarr-config
+        - name: backups
+          persistentVolumeClaim:
+            claimName: backups
         - name: tv
           persistentVolumeClaim:
             claimName: vod-tv

--- a/k8s/apps/vod-arr/prowlarr/statefulset.yaml
+++ b/k8s/apps/vod-arr/prowlarr/statefulset.yaml
@@ -63,6 +63,9 @@ spec:
           volumeMounts:
             - mountPath: /config
               name: config
+            - mountPath: /backup
+              name: backups
+              subPath: prowlarr
         - args:
             - prowlarr
           env:
@@ -186,6 +189,10 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prowlarr
+      volumes:
+        - name: backups
+          persistentVolumeClaim:
+            claimName: backups
   volumeClaimTemplates:
     - metadata:
         name: config

--- a/k8s/apps/vod-arr/radarr/statefulset.yaml
+++ b/k8s/apps/vod-arr/radarr/statefulset.yaml
@@ -63,6 +63,9 @@ spec:
           volumeMounts:
             - mountPath: /config
               name: config
+            - mountPath: /backup
+              name: backups
+              subPath: radarr
             - mountPath: /media/movies
               name: media
             - mountPath: /downloads
@@ -191,6 +194,9 @@ spec:
         runAsUser: 1000
       serviceAccountName: radarr
       volumes:
+        - name: backups
+          persistentVolumeClaim:
+            claimName: backups
         - name: media
           persistentVolumeClaim:
             claimName: vod-movies

--- a/k8s/apps/vod-arr/shared/kustomization.yaml
+++ b/k8s/apps/vod-arr/shared/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - pv-downloads.yaml
   - pv-movies.yaml
   - pv-tv.yaml
+  - pvc-backups.yaml
   - pvc-downloads.yaml
   - pvc-movies.yaml
   - pvc-tv.yaml

--- a/k8s/apps/vod-arr/shared/pvc-backups.yaml
+++ b/k8s/apps/vod-arr/shared/pvc-backups.yaml
@@ -1,0 +1,18 @@
+# The *arrs' own scheduled backups, kept off each app's config volume so they
+# survive it being wiped and are somewhere obvious when restoring. Same reasoning
+# and same storage class as plex's backups PVC. One claim for the namespace, with
+# each app mounted into its own subPath so the dated archives do not intermingle.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/component: backup
+    app.kubernetes.io/part-of: vod-arr
+  name: backups
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: unifi-nas

--- a/k8s/apps/vod-arr/sonarr/statefulset.yaml
+++ b/k8s/apps/vod-arr/sonarr/statefulset.yaml
@@ -63,6 +63,9 @@ spec:
           volumeMounts:
             - mountPath: /config
               name: config
+            - mountPath: /backup
+              name: backups
+              subPath: sonarr
             - mountPath: /media/tv
               name: media
             - mountPath: /downloads
@@ -191,6 +194,9 @@ spec:
         runAsUser: 1000
       serviceAccountName: sonarr
       volumes:
+        - name: backups
+          persistentVolumeClaim:
+            claimName: backups
         - name: media
           persistentVolumeClaim:
             claimName: vod-tv


### PR DESCRIPTION
All four apps run scheduled backups into their own config volume, so a config
wipe destroys the backups too — the one moment they matter. Same pattern and
storage class as plex's `backups` PVC.

One RWX claim for the namespace, each app mounted at `/backup` via its own
`subPath` so archives stay separated. `backupFolder` is set through each app's
API (it lives in their databases, not in git).

🤖 Generated with [Claude Code](https://claude.com/claude-code)