### PR TITLE
observability: manage prometheus-operator CRDs with a HelmRelease

### DIFF
--- a/k8s/apps/monitoring/manifests/prometheusOperator/0alertmanagerConfigCustomResourceDefinition.yaml
+++ b/k8s/apps/monitoring/manifests/prometheusOperator/0alertmanagerConfigCustomResourceDefinition.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.16.4
     operator.prometheus.io/version: 0.77.1
   name: alertmanagerconfigs.monitoring.coreos.com

--- a/k8s/apps/monitoring/manifests/prometheusOperator/0alertmanagerCustomResourceDefinition.yaml
+++ b/k8s/apps/monitoring/manifests/prometheusOperator/0alertmanagerCustomResourceDefinition.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.16.4
     operator.prometheus.io/version: 0.77.1
   name: alertmanagers.monitoring.coreos.com

--- a/k8s/apps/monitoring/manifests/prometheusOperator/0podmonitorCustomResourceDefinition.yaml
+++ b/k8s/apps/monitoring/manifests/prometheusOperator/0podmonitorCustomResourceDefinition.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.16.4
     operator.prometheus.io/version: 0.77.1
   name: podmonitors.monitoring.coreos.com

--- a/k8s/apps/monitoring/manifests/prometheusOperator/0probeCustomResourceDefinition.yaml
+++ b/k8s/apps/monitoring/manifests/prometheusOperator/0probeCustomResourceDefinition.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.16.4
     operator.prometheus.io/version: 0.77.1
   name: probes.monitoring.coreos.com

--- a/k8s/apps/monitoring/manifests/prometheusOperator/0prometheusCustomResourceDefinition.yaml
+++ b/k8s/apps/monitoring/manifests/prometheusOperator/0prometheusCustomResourceDefinition.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.16.4
     operator.prometheus.io/version: 0.77.1
   name: prometheuses.monitoring.coreos.com

--- a/k8s/apps/monitoring/manifests/prometheusOperator/0prometheusagentCustomResourceDefinition.yaml
+++ b/k8s/apps/monitoring/manifests/prometheusOperator/0prometheusagentCustomResourceDefinition.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.16.4
     operator.prometheus.io/version: 0.77.1
   name: prometheusagents.monitoring.coreos.com

--- a/k8s/apps/monitoring/manifests/prometheusOperator/0prometheusruleCustomResourceDefinition.yaml
+++ b/k8s/apps/monitoring/manifests/prometheusOperator/0prometheusruleCustomResourceDefinition.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.16.4
     operator.prometheus.io/version: 0.77.1
   name: prometheusrules.monitoring.coreos.com

--- a/k8s/apps/monitoring/manifests/prometheusOperator/0scrapeconfigCustomResourceDefinition.yaml
+++ b/k8s/apps/monitoring/manifests/prometheusOperator/0scrapeconfigCustomResourceDefinition.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.16.4
     operator.prometheus.io/version: 0.77.1
   name: scrapeconfigs.monitoring.coreos.com

--- a/k8s/apps/monitoring/manifests/prometheusOperator/0servicemonitorCustomResourceDefinition.yaml
+++ b/k8s/apps/monitoring/manifests/prometheusOperator/0servicemonitorCustomResourceDefinition.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.16.4
     operator.prometheus.io/version: 0.77.1
   name: servicemonitors.monitoring.coreos.com

--- a/k8s/apps/monitoring/manifests/prometheusOperator/0thanosrulerCustomResourceDefinition.yaml
+++ b/k8s/apps/monitoring/manifests/prometheusOperator/0thanosrulerCustomResourceDefinition.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     controller-gen.kubebuilder.io/version: v0.16.4
     operator.prometheus.io/version: 0.77.1
   name: thanosrulers.monitoring.coreos.com

--- a/k8s/bootstrap/crds-prometheus-operator.yaml
+++ b/k8s/bootstrap/crds-prometheus-operator.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prometheus-operator-crds
+  namespace: flux-system
+spec:
+  interval: 15m0s
+  path: ./k8s/platform/observability/prometheus-operator-crds
+  # NOTE: Prevent cascading deletion of every ServiceMonitor, PodMonitor and
+  # PrometheusRule in the cluster.
+  prune: false
+  wait: true
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: ankhmorpork

--- a/k8s/bootstrap/group-platform.yaml
+++ b/k8s/bootstrap/group-platform.yaml
@@ -7,6 +7,8 @@ spec:
   interval: 15m0s
   path: ./k8s/flux/platform
   prune: false
+  dependsOn:
+  - name: prometheus-operator-crds
   sourceRef:
     kind: GitRepository
     name: ankhmorpork

--- a/k8s/bootstrap/kustomization.yaml
+++ b/k8s/bootstrap/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 namespace: flux-system
 resources:
   - github-repo.yaml
+  - crds-prometheus-operator.yaml
   - group-platform.yaml
   - group-apps.yaml

--- a/k8s/platform/observability/prometheus-operator-crds/kustomization.yaml
+++ b/k8s/platform/observability/prometheus-operator-crds/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: platform-observability
+resources:
+  - namespace.yaml
+  - repository.yaml
+  - release.yaml

--- a/k8s/platform/observability/prometheus-operator-crds/namespace.yaml
+++ b/k8s/platform/observability/prometheus-operator-crds/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: platform-observability

--- a/k8s/platform/observability/prometheus-operator-crds/release.yaml
+++ b/k8s/platform/observability/prometheus-operator-crds/release.yaml
@@ -1,0 +1,26 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: prometheus-operator-crds
+spec:
+  chart:
+    spec:
+      chart: prometheus-operator-crds
+      version: "31.0.1"
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-community
+      interval: 5m
+  interval: 5m
+  timeout: 10m
+  install:
+    timeout: 10m
+    # CreateReplace, not Create: Create would leave the older schemas in place.
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    timeout: 10m
+    crds: CreateReplace
+    remediation:
+      retries: 3

--- a/k8s/platform/observability/prometheus-operator-crds/repository.yaml
+++ b/k8s/platform/observability/prometheus-operator-crds/repository.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: prometheus-community
+spec:
+  interval: 5m
+  url: https://prometheus-community.github.io/helm-charts


### PR DESCRIPTION
Replaces the 10 CRDs vendored at operator v0.77.1 with the `prometheus-operator-crds` chart, so Renovate carries the schemas forward.

Its Kustomization sits in `k8s/bootstrap/` because nearly every component ships a ServiceMonitor or PrometheusRule; the platform group `dependsOn` it, and apps already depends on platform.

**Merge this alone and confirm the chart CRDs are live before merging #1190.** This commit stamps `kustomize.toolkit.fluxcd.io/prune: disabled` on the vendored files; the follow-up deletes them. Flux reads that annotation off the *live* object, so if both land in one merge the prune takes the CRDs and every ServiceMonitor, PodMonitor and PrometheusRule with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)