### PR TITLE
datalake-alerts: prefix the alertmanager version with v

### DIFF
--- a/k8s/apps/datalake-alerts/alertmanager/alertmanager.yaml
+++ b/k8s/apps/datalake-alerts/alertmanager/alertmanager.yaml
@@ -45,5 +45,6 @@ spec:
     runAsNonRoot: true
     runAsUser: 1000
   serviceAccountName: alertmanager-main
-  # Image is derived from version.
-  version: 0.34.0
+  # Derived image tag. Unlike Prometheus, the operator uses this verbatim for
+  # alertmanager, so the v prefix is required.
+  version: v0.34.0


### PR DESCRIPTION
Rollout fix. The operator uses `spec.version` verbatim for alertmanager, so `0.34.0` produced a tag that does not exist and all three replicas were in ImagePullBackOff. Prometheus resolved `3.14.0` to `v3.14.0`, hence only alertmanager broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)