### PR TITLE
observability: qualify the probe prober URLs

### DIFF
--- a/k8s/platform/observability/blackbox-exporter/probes/probe-avs.yaml
+++ b/k8s/platform/observability/blackbox-exporter/probes/probe-avs.yaml
@@ -11,7 +11,7 @@ spec:
   interval: 30s
   module: http_2xx
   prober:
-    url: blackbox-exporter:19115
+    url: blackbox-exporter.platform-observability.svc:19115
   scrapeTimeout: 30s
   targets:
     staticConfig:

--- a/k8s/platform/observability/blackbox-exporter/probes/probe-ingress.yaml
+++ b/k8s/platform/observability/blackbox-exporter/probes/probe-ingress.yaml
@@ -11,7 +11,7 @@ spec:
   interval: 30s
   module: http_2xx
   prober:
-    url: blackbox-exporter:19115
+    url: blackbox-exporter.platform-observability.svc:19115
   scrapeTimeout: 30s
   targets:
     ingress:

--- a/k8s/platform/observability/blackbox-exporter/probes/probe-thaum.yaml
+++ b/k8s/platform/observability/blackbox-exporter/probes/probe-thaum.yaml
@@ -11,7 +11,7 @@ spec:
   interval: 30s
   module: http_2xx
   prober:
-    url: blackbox-exporter:19115
+    url: blackbox-exporter.platform-observability.svc:19115
   scrapeTimeout: 30s
   targets:
     staticConfig:

--- a/k8s/platform/observability/uptimerobot/probe.yaml
+++ b/k8s/platform/observability/uptimerobot/probe.yaml
@@ -17,7 +17,7 @@ spec:
         - url
       targetLabel: instance
   prober:
-    url: uptimerobot:7979
+    url: uptimerobot.platform-observability.svc:7979
   targets:
     staticConfig:
       static:


### PR DESCRIPTION
All 14 probe targets are down: `lookup blackbox-exporter on 10.43.0.10:53: no such host`.

The prober URL is dialled by Prometheus, not from the Probe object's namespace, so shortening it when the probes moved next to the exporter was wrong — Prometheus is in `datalake-metrics`, the exporters are in `platform-observability`. My mistake in #1190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)