### PR TITLE
prometheus: stop ExporterTargetDown firing on every CNPG primary

### DIFF
--- a/k8s/apps/datalake-metrics/prometheus/prometheusrule-scrape-health.yaml
+++ b/k8s/apps/datalake-metrics/prometheus/prometheusrule-scrape-health.yaml
@@ -16,7 +16,9 @@ spec:
           annotations:
             description: Exporter {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) reported its target being down. This results in lack of ability to scrape metrics from the main service.
             summary: Service monitored by exporter is Down
-          expr: '{__name__=~".*_up",__name__!="node_network_up",__name__!="node_supervisord_up"} == 0'
+          # cnpg_pg_replication_is_wal_receiver_up is 0 on every primary by
+          # definition -- only replicas run a WAL receiver.
+          expr: '{__name__=~".*_up",__name__!="node_network_up",__name__!="node_supervisord_up",__name__!="cnpg_pg_replication_is_wal_receiver_up"} == 0'
           for: 5m
           labels:
             severity: warning


### PR DESCRIPTION
Ten firing alerts are all `cnpg_pg_replication_is_wal_receiver_up == 0`, one per postgres primary. Only replicas run a WAL receiver, so it is 0 on a primary by definition and the alert can never clear.

Excluded the same way `node_network_up` and `node_supervisord_up` already are. Predates this migration — the rule used to live in a group named `testing.rules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)