### PR TITLE
alerting: one destination per alert, and drop dead rules

### DIFF
--- a/k8s/apps/datalake-alerts/alertmanager/configmap-template.yaml
+++ b/k8s/apps/datalake-alerts/alertmanager/configmap-template.yaml
@@ -9,55 +9,9 @@ data:
 
     global:
       resolve_timeout: 5m
-      slack_api_url: {{ .slack_api_url }}  {{/* This is a reference to a secret stored in doppler */}}
       opsgenie_api_url: 'https://api.eu.opsgenie.com'
       opsgenie_api_key: {{ .opsgenie_api_key }}  {{/* This is a reference to a secret stored in doppler */}}
     receivers:
-    - name: 'slack'
-      slack_configs:
-      - channel: '#alerts'
-        send_resolved: true
-        title: |
-          {{ `{{- if eq .Status "firing" -}}` }}
-            Firing {{ `{{ .Alerts.Firing | len }}` }}
-          {{ `{{- else -}}` }}
-            Resolved {{ `{{ .Alerts.Resolved | len }}` }}
-          {{ `{{- end }}` }} - {{ `{{ .CommonAnnotations.summary }}` }}
-        text: >-
-          {{ `{{- if .CommonAnnotations.message }}` }}
-            {{ `{{ .CommonAnnotations.message }}` }}
-          {{ `{{- end }}` }}
-          {{ `{{- if .CommonAnnotations.description }}` }}
-            {{ `{{ .CommonAnnotations.description }}` }}
-          {{ `{{- end }}` }}
-        short_fields: true
-        fields:
-        - title: Alertname
-          value: '{{ `{{ .CommonLabels.alertname }}` }}'
-        - title: Severity
-          value: '{{ `{{ .CommonLabels.severity }}` }}'
-        - title: Job
-          value: '{{ `{{ .GroupLabels.job }}` }}'
-        actions:
-        - type: button
-          text: 'Runbook :green_book:'
-          url: '{{ `{{ .CommonAnnotations.runbook_url }}` }}'
-        - type: button
-          text: 'Query :mag:'
-          url: '{{ `{{ (index .Alerts 0).GeneratorURL }}` }}'
-        - type: button
-          text: 'Dashboard :grafana:'
-          url: '{{ `{{ .CommonAnnotations.dashboard_url }}` }}'
-        - type: button
-          text: 'Silence :no_bell:'
-          url: >-
-            {{ `{{ .ExternalURL }}` }}/#/silences/new?filter=%7B
-            {{ `{{- range .CommonLabels.SortedPairs -}}` }}
-                {{ `{{- if ne .Name "alertname" -}}` }}
-                    {{ `{{- .Name }}` }}%3D%22{{ `{{- reReplaceAll " +" "%20" .Value -}}` }}%22%2C%20
-                {{ `{{- end -}}` }}
-            {{ `{{- end -}}` }}
-            alertname%3D%22{{ `{{ reReplaceAll " +" "%20" .CommonLabels.alertname }}` }}%22%7D
     - name: 'opsgenie'
       opsgenie_configs:
         - message: "{{ `{{ .GroupLabels.alertname }}` }} - {{ `{{ .CommonAnnotations.summary }}` }}"
@@ -92,28 +46,6 @@ data:
           responders:
           - name: 'Main'
             type: team
-    - name: 'pushover-mac'
-      pushover_configs:
-      - send_resolved: false
-        user_key: {{ .pushover_user_key }}  {{/* This is a reference to a secret stored in doppler */}}
-        token: {{ .pushover_token }}  {{/* This is a reference to a secret stored in doppler */}}
-        retry: 10m
-        device: McAir
-        url: '{{ `{{ (index .Alerts 0).GeneratorURL }}` }}'
-        priority: '{{ `{{ if eq .Status "firing" }}` }}0{{ `{{ else }}` }}-1{{ `{{ end }}` }}'
-        title: |
-          {{ `{{- if .CommonAnnotations.summary -}}` }}
-            {{ `{{- .CommonAnnotations.summary -}}` }}
-          {{ `{{- else -}}` }}
-            {{ `{{- .CommonLabels.alertname -}}` }}
-          {{ `{{- end }}` }}
-        message: >-
-          {{ `{{- if .CommonAnnotations.message }}` }}
-            {{ `{{ .CommonAnnotations.message }}` }}
-          {{ `{{- end }}` }}
-          {{ `{{- if .CommonAnnotations.description }}` }}
-            {{ `{{ .CommonAnnotations.description }}` }}
-          {{ `{{- end }}` }}
     - name: 'healthchecks.io'
       webhook_configs:
         - send_resolved: false
@@ -125,12 +57,12 @@ data:
     - name: "null"
     route:
       group_by: ['alertname', 'namespace', 'job']
-      #group_by: ['alertname', 'instance', 'job']
-      #group_by: ['instance', 'job']
       group_wait: 30s
       group_interval: 5m
       repeat_interval: 12h
-      receiver: 'slack'
+      # Nothing should reach here: every alert carries a severity, and .pint.hcl
+      # fails CI on any value outside warning|critical|info|none.
+      receiver: "null"
       routes:
         - matchers:
           - "alertname = Watchdog"
@@ -143,15 +75,12 @@ data:
         - matchers:
           - "severity = critical"
           receiver: 'opsgenie'
-          continue: true
-        - matchers:
-          - "severity = warning"
-          receiver: 'pushover-mac'
-          continue: true
         - matchers:
           - "severity = warning"
           receiver: 'github'
-          continue: true
+        - matchers:
+          - "severity = info"
+          receiver: "null"
     inhibit_rules:
       - source_matchers:
         - "severity = critical"
@@ -163,16 +92,6 @@ data:
         target_matchers:
         - "severity = info"
         equal: ['namespace', 'alertname']
-      - source_matchers:
-        - "alertname = ProbeFailed"
-        target_matchers:
-        - "alertname = StatusCode"
-        equal: ['job', 'instance']
-      - source_matchers:
-        - "alertname = NodeDown"
-        target_matchers:
-        - "alertname = TargetDown"
-        equal: ['job', 'instance']
       - source_matchers:
         - "alertname = KubeNodeUnreachable"
         target_matchers:

--- a/k8s/apps/datalake-alerts/alertmanager/externalsecret.yaml
+++ b/k8s/apps/datalake-alerts/alertmanager/externalsecret.yaml
@@ -16,15 +16,6 @@ spec:
     - remoteRef:
         key: MONITORING_AM_OPSGENIE_API_KEY
       secretKey: opsgenie_api_key
-    - remoteRef:
-        key: MONITORING_AM_PUSHOVER_TOKEN
-      secretKey: pushover_token
-    - remoteRef:
-        key: MONITORING_AM_PUSHOVER_USER_KEY
-      secretKey: pushover_user_key
-    - remoteRef:
-        key: MONITORING_AM_SLACK_API_URL
-      secretKey: slack_api_url
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore

--- a/k8s/apps/datalake-metrics/prometheus/prometheusrule-scrape-health.yaml
+++ b/k8s/apps/datalake-metrics/prometheus/prometheusrule-scrape-health.yaml
@@ -18,7 +18,7 @@ spec:
             summary: Service monitored by exporter is Down
           # cnpg_pg_replication_is_wal_receiver_up is 0 on every primary by
           # definition -- only replicas run a WAL receiver.
-          expr: '{__name__=~".*_up",__name__!="node_network_up",__name__!="node_supervisord_up",__name__!="cnpg_pg_replication_is_wal_receiver_up"} == 0'
+          expr: '{__name__=~".*_up",__name__!="node_network_up",__name__!="cnpg_pg_replication_is_wal_receiver_up"} == 0'
           for: 5m
           labels:
             severity: warning

--- a/k8s/apps/paperless/manifests/app/prometheusRules.yaml
+++ b/k8s/apps/paperless/manifests/app/prometheusRules.yaml
@@ -14,7 +14,7 @@ spec:
           annotations:
             description: Paperless has been unhealthy for more than 5 minutes.
             summary: Paperless is unhealthy
-          expr: up{job="paperless"} == 0
+          expr: up{job="paperless/paperless"} == 0
           for: 5m
           labels:
             severity: critical

--- a/k8s/platform/observability/kube-prometheus-stack/prometheusrule-nodes.yaml
+++ b/k8s/platform/observability/kube-prometheus-stack/prometheusrule-nodes.yaml
@@ -9,18 +9,6 @@ spec:
   groups:
     - name: node-custom.rules
       rules:
-        - alert: PackagesAvailable
-          annotations:
-            description: '{{ $value }} packages are available for upgrade. Maybe it is time to upgrade?'
-            runbook_url: https://runbooks.thaum.xyz/runbooks/thaum-xyz/PackagesAvailable
-            summary: Packages are available for upgrade
-          expr: |
-            sum by (node,instance) (yum_upgrades_pending) > 200
-            or
-            sum by (node,instance) (apt_upgrades_pending) > 200
-          for: 48h
-          labels:
-            severity: info
         - alert: FilesystemReadOnly
           annotations:
             description: Filesystem went read-only on {{ $labels.instance }}. Check FS for possible corruption.

--- a/k8s/platform/observability/uptimerobot/prometheusrule.yaml
+++ b/k8s/platform/observability/uptimerobot/prometheusrule.yaml
@@ -13,7 +13,7 @@ spec:
           record: uptimerobot_monitor_normalized_status
         - alert: SiteExternallyDown
           annotations:
-            description: Synthetic monitoring reports site {{ $labels.instance }} not to be up for 15m.
+            description: Synthetic monitoring reports site {{ $labels.instance }} not to be up for 10m.
             runbook_url: https://runbooks.thaum.xyz/runbooks/thaum-xyz/SiteExternallyDown
             summary: Site is not available from external network
           expr: uptimerobot_monitor_status == 9

--- a/k8s/platform/storage/longhorn-system/prometheusrule.yaml
+++ b/k8s/platform/storage/longhorn-system/prometheusrule.yaml
@@ -94,7 +94,7 @@ spec:
       for: 5m
       labels:
         severity: warning
-    - alert: LonghornIntanceManagerCPUUsageWarning
+    - alert: LonghornInstanceManagerCPUUsageWarning
       annotations:
         description: Longhorn instance manager {{$labels.instance_manager}} on {{$labels.node}} has CPU Usage / CPU request is {{$value}}% for
           more than 5 minutes.


### PR DESCRIPTION
Phase 1 of the observability follow-on backlog.

**Routing** collapses from five overlapping routes (three with `continue: true`, everything falling through to Slack) to one terminal destination each: Watchdog→healthchecks.io, InfoInhibitor→null, critical→opsgenie, warning→github, info→null, root→null. The `slack` and `pushover-mac` receivers and their three Doppler keys go with it.

Root `null` is a deliberate silent drop, kept safe by `.pint.hcl`'s severity check running at `severity = "bug"`.

**Dead rules**, each confirmed by live query: `PackagesAvailable` (both metrics absent), `PaperlessUnhealthy` (wrong job label — PodMonitor labels it `paperless/paperless`), the `node_supervisord_up` exclusion, and two inhibit rules naming alerts that do not exist. Plus a description/`for:` mismatch and a typo.

Verified with `amtool check-config` against the rendered config.

**Manual follow-up:** point the healthchecks.io check's own escalation at your pager, so a missing Watchdog reaches you. Alertmanager cannot do that for itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)