### PR TITLE
pint: fix container start and the port clash with the sidecar

### DIFF
--- a/k8s/apps/datalake-metrics/pint/deployment.yaml
+++ b/k8s/apps/datalake-metrics/pint/deployment.yaml
@@ -65,6 +65,10 @@ spec:
               name: rules
         - name: pint
           image: ghcr.io/cloudflare/pint:0.87.0
+          # The image declares CMD and no ENTRYPOINT, so args on their own
+          # replace the binary path rather than appending to it.
+          command:
+            - /usr/local/bin/pint
           args:
             - --config=/etc/pint/pint.hcl
             - --log-level=warn
@@ -73,11 +77,13 @@ spec:
             - --min-severity=warning
             # Bounds pint_problem cardinality; pint_problems stays a true total.
             - --max-problems=50
+            - --listen=:8081
             - glob
             - /rules/*.yaml
           ports:
+            # 8080 is taken: k8s-sidecar serves its own endpoint there.
             - name: http
-              containerPort: 8080
+              containerPort: 8081
           livenessProbe:
             httpGet:
               path: /health


### PR DESCRIPTION
Rollout fixes for #1228. Both only visible once it ran.

**Container never started** — `exec: "--config=/etc/pint/pint.hcl": no such file or directory`. The image declares `CMD` with no `ENTRYPOINT`, so `args` replaced the command instead of appending, and the first flag was treated as the binary. `command` set explicitly.

**Port clash** — k8s-sidecar runs its own web server on 8080, the port pint had. While pint crashlooped the sidecar was answering the scrape with a 404 on `/metrics`; once pint started, one of them would have failed to bind. pint moves to 8081, and the PodMonitor selects by port name so it is unchanged.

The sidecar half was already working correctly: 79 files in `/rules`, matching the 79 keys in `prometheus-k8s-rulefiles-0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)