### PR TITLE
pint: run the rules sidecar as a native kubernetes sidecar

### DIFF
--- a/k8s/apps/datalake-metrics/pint/deployment.yaml
+++ b/k8s/apps/datalake-metrics/pint/deployment.yaml
@@ -24,11 +24,13 @@ spec:
         app.kubernetes.io/version: 0.87.0
     spec:
       serviceAccountName: pint
-      containers:
+      initContainers:
         # Mirrors the operator's rulefile ConfigMaps into the shared volume. The
         # label selector matches however many shards exist, so nothing here has to
         # know or care how the operator splits them.
         - name: rules-sync
+          # Native sidecar: starts before pint and terminates after it.
+          restartPolicy: Always
           image: quay.io/kiwigrid/k8s-sidecar:2.10.3
           env:
             - name: METHOD
@@ -47,6 +49,18 @@ spec:
             # prefixing would only make pint's problem output harder to read.
             - name: UNIQUE_FILENAMES
               value: "false"
+          # Kubelet holds pint until this passes, which is what removes the
+          # race: previously pint ran its first check seconds before the sidecar
+          # wrote anything and failed with "no matching files", then sat blind
+          # until the next 10m interval.
+          startupProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - ls /rules/*.yaml >/dev/null 2>&1
+            periodSeconds: 2
+            failureThreshold: 60
           resources:
             requests:
               cpu: 10m
@@ -63,6 +77,7 @@ spec:
           volumeMounts:
             - mountPath: /rules
               name: rules
+      containers:
         - name: pint
           image: ghcr.io/cloudflare/pint:0.87.0
           # The image declares CMD and no ENTRYPOINT, so args on their own

--- a/k8s/apps/datalake-metrics/pint/prometheusrule.yaml
+++ b/k8s/apps/datalake-metrics/pint/prometheusrule.yaml
@@ -26,9 +26,9 @@ spec:
         # evaluate. The job label is pinned in the ServiceMonitor.
         - alert: PintNotReporting
           annotations:
-            description: pint_problems has been absent for 1h. Either pint is not running or it is not being scraped; either way nothing is checking the loaded rules against live data.
+            description: pint is not checking anything. Either it is absent or unscrapeable, or it is running but its last iteration checked zero rules; either way the loaded rules are unverified.
             summary: pint is not reporting
-          expr: absent(pint_problems{job="pint"})
+          expr: absent(pint_problems{job="pint"}) or max(pint_last_run_checks{job="pint"}) == 0
           for: 1h
           labels:
             severity: warning


### PR DESCRIPTION
Follow-up to #1229. Good suggestion — this is the right pattern.

pint ran its first check at container start + 1s; the sidecar wrote `/rules` 4s later. So every start logged `no matching files` and then sat blind until the next 10m interval. Confirmed live: `pint_check_iterations_total 1` with `pint_last_run_checks 0`, and no `pint_problems` series exported at all.

`rules-sync` moves to an `initContainer` with `restartPolicy: Always` — a [native sidecar](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/), stable since 1.33 and this cluster runs 1.36. It starts before the main container and terminates after it.

Ordering alone only guarantees the sidecar has *started*, not that it has synced, so a `startupProbe` waiting for at least one file in `/rules` is what actually closes the race — kubelet holds pint until it passes.

Also broadened `PintNotReporting` to cover `pint_last_run_checks == 0`. pint exports that even when a run checks nothing, which beats inferring the state from a missing `pint_problems` — and it is precisely the signal that would have named this bug on sight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)