### PR TITLE
github-receiver: bump to v0.3.1 and drop version labels

### DIFF
--- a/k8s/apps/datalake-alerts/alertmanager/alertmanager.yaml
+++ b/k8s/apps/datalake-alerts/alertmanager/alertmanager.yaml
@@ -6,7 +6,6 @@ metadata:
     app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.34.0
   name: main
 spec:
   affinity:
@@ -30,7 +29,6 @@ spec:
       app.kubernetes.io/instance: main
       app.kubernetes.io/name: alertmanager
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 0.34.0
   replicas: 3
   resources:
     limits:

--- a/k8s/apps/datalake-alerts/alertmanager/configmap-template.yaml
+++ b/k8s/apps/datalake-alerts/alertmanager/configmap-template.yaml
@@ -113,5 +113,4 @@ metadata:
     app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.34.0
   name: alertmanager-config-template

--- a/k8s/apps/datalake-alerts/alertmanager/externalsecret.yaml
+++ b/k8s/apps/datalake-alerts/alertmanager/externalsecret.yaml
@@ -6,7 +6,6 @@ metadata:
     app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.34.0
   name: alertmanager-main
 spec:
   data:

--- a/k8s/apps/datalake-alerts/alertmanager/ingress.yaml
+++ b/k8s/apps/datalake-alerts/alertmanager/ingress.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.34.0
   name: alertmanager
 spec:
   ingressClassName: private

--- a/k8s/apps/datalake-alerts/alertmanager/poddisruptionbudget.yaml
+++ b/k8s/apps/datalake-alerts/alertmanager/poddisruptionbudget.yaml
@@ -6,7 +6,6 @@ metadata:
     app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.34.0
   name: alertmanager-main
 spec:
   maxUnavailable: 1

--- a/k8s/apps/datalake-alerts/alertmanager/prometheusrule.yaml
+++ b/k8s/apps/datalake-alerts/alertmanager/prometheusrule.yaml
@@ -6,7 +6,6 @@ metadata:
     app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.34.0
     role: alert-rules
   name: alertmanager-main-rules
 spec:

--- a/k8s/apps/datalake-alerts/alertmanager/service.yaml
+++ b/k8s/apps/datalake-alerts/alertmanager/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.34.0
   name: alertmanager-main
 spec:
   ports:

--- a/k8s/apps/datalake-alerts/alertmanager/serviceaccount.yaml
+++ b/k8s/apps/datalake-alerts/alertmanager/serviceaccount.yaml
@@ -7,5 +7,4 @@ metadata:
     app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.34.0
   name: alertmanager-main

--- a/k8s/apps/datalake-alerts/alertmanager/servicemonitor.yaml
+++ b/k8s/apps/datalake-alerts/alertmanager/servicemonitor.yaml
@@ -6,7 +6,6 @@ metadata:
     app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.34.0
   name: alertmanager-main
 spec:
   endpoints:

--- a/k8s/apps/datalake-alerts/github-receiver/configmap.yaml
+++ b/k8s/apps/datalake-alerts/github-receiver/configmap.yaml
@@ -72,5 +72,4 @@ metadata:
   labels:
     app.kubernetes.io/component: alertmanager-webhook-receiver
     app.kubernetes.io/name: github-receiver
-    app.kubernetes.io/version: 0.3.1
   name: github-receiver-config

--- a/k8s/apps/datalake-alerts/github-receiver/configmap.yaml
+++ b/k8s/apps/datalake-alerts/github-receiver/configmap.yaml
@@ -72,5 +72,5 @@ metadata:
   labels:
     app.kubernetes.io/component: alertmanager-webhook-receiver
     app.kubernetes.io/name: github-receiver
-    app.kubernetes.io/version: 0.1.3
+    app.kubernetes.io/version: 0.3.1
   name: github-receiver-config

--- a/k8s/apps/datalake-alerts/github-receiver/deployment.yaml
+++ b/k8s/apps/datalake-alerts/github-receiver/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: alertmanager-webhook-receiver
     app.kubernetes.io/name: github-receiver
-    app.kubernetes.io/version: 0.1.3
+    app.kubernetes.io/version: 0.3.1
   name: github-receiver
 spec:
   replicas: 1
@@ -20,7 +20,7 @@ spec:
       labels:
         app.kubernetes.io/component: alertmanager-webhook-receiver
         app.kubernetes.io/name: github-receiver
-        app.kubernetes.io/version: 0.1.3
+        app.kubernetes.io/version: 0.3.1
     spec:
       automountServiceAccountToken: false
       containers:
@@ -33,7 +33,7 @@ spec:
           envFrom:
             - secretRef:
                 name: github-receiver-credentials
-          image: ghcr.io/pfnet-research/alertmanager-to-github:v0.1.3
+          image: ghcr.io/pfnet-research/alertmanager-to-github:v0.3.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/k8s/apps/datalake-alerts/github-receiver/deployment.yaml
+++ b/k8s/apps/datalake-alerts/github-receiver/deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: alertmanager-webhook-receiver
     app.kubernetes.io/name: github-receiver
-    app.kubernetes.io/version: 0.3.1
   name: github-receiver
 spec:
   replicas: 1
@@ -20,7 +19,6 @@ spec:
       labels:
         app.kubernetes.io/component: alertmanager-webhook-receiver
         app.kubernetes.io/name: github-receiver
-        app.kubernetes.io/version: 0.3.1
     spec:
       automountServiceAccountToken: false
       containers:

--- a/k8s/apps/datalake-alerts/github-receiver/externalsecret.yaml
+++ b/k8s/apps/datalake-alerts/github-receiver/externalsecret.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: alertmanager-webhook-receiver
     app.kubernetes.io/name: github-receiver
-    app.kubernetes.io/version: 0.3.1
   name: github-receiver-credentials
 spec:
   data:

--- a/k8s/apps/datalake-alerts/github-receiver/externalsecret.yaml
+++ b/k8s/apps/datalake-alerts/github-receiver/externalsecret.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: alertmanager-webhook-receiver
     app.kubernetes.io/name: github-receiver
-    app.kubernetes.io/version: 0.1.3
+    app.kubernetes.io/version: 0.3.1
   name: github-receiver-credentials
 spec:
   data:

--- a/k8s/apps/datalake-alerts/github-receiver/service.yaml
+++ b/k8s/apps/datalake-alerts/github-receiver/service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: alertmanager-webhook-receiver
     app.kubernetes.io/name: github-receiver
-    app.kubernetes.io/version: 0.1.3
+    app.kubernetes.io/version: 0.3.1
   name: github-receiver
 spec:
   clusterIP: None

--- a/k8s/apps/datalake-alerts/github-receiver/service.yaml
+++ b/k8s/apps/datalake-alerts/github-receiver/service.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: alertmanager-webhook-receiver
     app.kubernetes.io/name: github-receiver
-    app.kubernetes.io/version: 0.3.1
   name: github-receiver
 spec:
   clusterIP: None

--- a/k8s/apps/datalake-alerts/github-receiver/serviceaccount.yaml
+++ b/k8s/apps/datalake-alerts/github-receiver/serviceaccount.yaml
@@ -5,5 +5,5 @@ metadata:
   labels:
     app.kubernetes.io/component: alertmanager-webhook-receiver
     app.kubernetes.io/name: github-receiver
-    app.kubernetes.io/version: 0.1.3
+    app.kubernetes.io/version: 0.3.1
   name: github-receiver

--- a/k8s/apps/datalake-alerts/github-receiver/serviceaccount.yaml
+++ b/k8s/apps/datalake-alerts/github-receiver/serviceaccount.yaml
@@ -5,5 +5,4 @@ metadata:
   labels:
     app.kubernetes.io/component: alertmanager-webhook-receiver
     app.kubernetes.io/name: github-receiver
-    app.kubernetes.io/version: 0.3.1
   name: github-receiver

--- a/k8s/apps/datalake-alerts/github-receiver/servicemonitor.yaml
+++ b/k8s/apps/datalake-alerts/github-receiver/servicemonitor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: alertmanager-webhook-receiver
     app.kubernetes.io/name: github-receiver
-    app.kubernetes.io/version: 0.1.3
+    app.kubernetes.io/version: 0.3.1
   name: github-receiver
 spec:
   endpoints:

--- a/k8s/apps/datalake-alerts/github-receiver/servicemonitor.yaml
+++ b/k8s/apps/datalake-alerts/github-receiver/servicemonitor.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: alertmanager-webhook-receiver
     app.kubernetes.io/name: github-receiver
-    app.kubernetes.io/version: 0.3.1
   name: github-receiver
 spec:
   endpoints:

--- a/k8s/apps/datalake-metrics/pint/deployment.yaml
+++ b/k8s/apps/datalake-metrics/pint/deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: linter
     app.kubernetes.io/name: pint
-    app.kubernetes.io/version: 0.87.0
   name: pint
 spec:
   replicas: 1
@@ -21,7 +20,6 @@ spec:
       labels:
         app.kubernetes.io/component: linter
         app.kubernetes.io/name: pint
-        app.kubernetes.io/version: 0.87.0
     spec:
       serviceAccountName: pint
       initContainers:

--- a/k8s/apps/datalake-metrics/prometheus/clusterrole.yaml
+++ b/k8s/apps/datalake-metrics/prometheus/clusterrole.yaml
@@ -6,7 +6,6 @@ metadata:
     app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 3.14.0
   name: prometheus-k8s
 rules:
   - apiGroups:

--- a/k8s/apps/datalake-metrics/prometheus/clusterrolebinding.yaml
+++ b/k8s/apps/datalake-metrics/prometheus/clusterrolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
     app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 3.14.0
   name: prometheus-k8s
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/k8s/apps/datalake-metrics/prometheus/ingress.yaml
+++ b/k8s/apps/datalake-metrics/prometheus/ingress.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 3.14.0
   name: prometheus-k8s
 spec:
   ingressClassName: private

--- a/k8s/apps/datalake-metrics/prometheus/poddisruptionbudget.yaml
+++ b/k8s/apps/datalake-metrics/prometheus/poddisruptionbudget.yaml
@@ -6,7 +6,6 @@ metadata:
     app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 3.14.0
   name: prometheus-k8s
 spec:
   maxUnavailable: 1

--- a/k8s/apps/datalake-metrics/prometheus/prometheus.yaml
+++ b/k8s/apps/datalake-metrics/prometheus/prometheus.yaml
@@ -6,7 +6,6 @@ metadata:
     app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 3.14.0
   name: k8s
 spec:
   affinity:
@@ -49,7 +48,6 @@ spec:
       app.kubernetes.io/instance: k8s
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 3.14.0
   podMonitorNamespaceSelector: {}
   podMonitorSelector: {}
   probeNamespaceSelector: {}

--- a/k8s/apps/datalake-metrics/prometheus/prometheusrule.yaml
+++ b/k8s/apps/datalake-metrics/prometheus/prometheusrule.yaml
@@ -6,7 +6,6 @@ metadata:
     app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 3.14.0
     role: alert-rules
   name: prometheus-k8s-prometheus-rules
 spec:

--- a/k8s/apps/datalake-metrics/prometheus/role-config.yaml
+++ b/k8s/apps/datalake-metrics/prometheus/role-config.yaml
@@ -6,7 +6,6 @@ metadata:
     app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 3.14.0
   name: prometheus-k8s-config
 rules:
   - apiGroups:

--- a/k8s/apps/datalake-metrics/prometheus/rolebinding-config.yaml
+++ b/k8s/apps/datalake-metrics/prometheus/rolebinding-config.yaml
@@ -6,7 +6,6 @@ metadata:
     app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 3.14.0
   name: prometheus-k8s-config
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/k8s/apps/datalake-metrics/prometheus/service.yaml
+++ b/k8s/apps/datalake-metrics/prometheus/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 3.14.0
   name: prometheus-k8s
 spec:
   ports:

--- a/k8s/apps/datalake-metrics/prometheus/serviceaccount-token.yaml
+++ b/k8s/apps/datalake-metrics/prometheus/serviceaccount-token.yaml
@@ -8,6 +8,5 @@ metadata:
     app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 3.14.0
   name: prometheus-k8s-token
 type: kubernetes.io/service-account-token

--- a/k8s/apps/datalake-metrics/prometheus/serviceaccount.yaml
+++ b/k8s/apps/datalake-metrics/prometheus/serviceaccount.yaml
@@ -7,5 +7,4 @@ metadata:
     app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 3.14.0
   name: prometheus-k8s

--- a/k8s/apps/datalake-metrics/prometheus/servicemonitor.yaml
+++ b/k8s/apps/datalake-metrics/prometheus/servicemonitor.yaml
@@ -6,7 +6,6 @@ metadata:
     app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 3.14.0
   name: prometheus-k8s
 spec:
   endpoints:


### PR DESCRIPTION
Two changes.

**Bump alertmanager-to-github v0.1.3 → v0.3.1.** My earlier "abandoned since 2022" note was wrong — inferred from the pin rather than checked; upstream shipped v0.2.2 → v0.3.1. Every flag currently passed still exists, so this is a straight bump. Two new flags, neither set: `--reopen-window` (a recurring alert reopens its closed issue rather than filing a new one — interesting for the message-board model, but it changes triage behaviour) and `--no-previous-issue`.

**Drop `app.kubernetes.io/version` labels** across `datalake-metrics` and `datalake-alerts`, 28 files. Renovate bumps the image tag but not the label next to it, so the label starts lying on the first bump. Not hypothetical: the kube-prometheus manifests this stack replaced had `version: 2.47.1` beside a `v3.0.0` image, with every version label in the tree drifted.

No selector referenced the label — Service, PDB, ServiceMonitor and PodMonitor all select on component/instance/name/part-of — so nothing rebinds. `spec.version` on the Prometheus and Alertmanager CRs is untouched; the operator reads that to derive the image, so it is the version rather than a copy of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)