### PR TITLE
observability: fix values ConfigMap collision, make the PVC policy admission-only

### DIFF
--- a/k8s/apps/datalake-metrics/pyrra/kustomization.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/kustomization.yaml
@@ -22,7 +22,7 @@ resources:
   - slo-prometheus-sd-kubernetes-errors.yaml
 # Qualified so a future values generator in the parent cannot collide.
 configMapGenerator:
-  - name: pyrra-values
+  - name: values-pyrra
     files:
       - values.yaml=values.yaml
 generatorOptions:

--- a/k8s/apps/datalake-metrics/pyrra/release.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/release.yaml
@@ -25,4 +25,4 @@ spec:
       retries: 3
   valuesFrom:
     - kind: ConfigMap
-      name: pyrra-values
+      name: values-pyrra

--- a/k8s/platform/observability/alloy/kustomization.yaml
+++ b/k8s/platform/observability/alloy/kustomization.yaml
@@ -6,9 +6,11 @@ resources:
   - release.yaml
   - syslog-service.yaml
 configMapGenerator:
-  - name: values
+  - name: values-alloy
     files:
       - values.yaml=values.yaml
-# Stable name so valuesFrom can reference it directly; no nameReference rewrite needed.
+# Stable name so valuesFrom can reference it directly; no nameReference rewrite
+# needed. Qualified because every component in this namespace would otherwise
+# generate a ConfigMap called "values" and silently overwrite the others.
 generatorOptions:
   disableNameSuffixHash: true

--- a/k8s/platform/observability/alloy/release.yaml
+++ b/k8s/platform/observability/alloy/release.yaml
@@ -23,4 +23,4 @@ spec:
       retries: 3
   valuesFrom:
     - kind: ConfigMap
-      name: values
+      name: values-alloy

--- a/k8s/platform/observability/kube-prometheus-stack/kustomization.yaml
+++ b/k8s/platform/observability/kube-prometheus-stack/kustomization.yaml
@@ -7,9 +7,11 @@ resources:
   - prometheusrule-nodes.yaml
   - prometheusrule-workloads.yaml
 configMapGenerator:
-  - name: values
+  - name: values-kube-prometheus-stack
     files:
       - values.yaml=values.yaml
-# Stable name so valuesFrom can reference it directly; no nameReference rewrite needed.
+# Stable name so valuesFrom can reference it directly; no nameReference rewrite
+# needed. Qualified because every component in this namespace would otherwise
+# generate a ConfigMap called "values" and silently overwrite the others.
 generatorOptions:
   disableNameSuffixHash: true

--- a/k8s/platform/observability/kube-prometheus-stack/release.yaml
+++ b/k8s/platform/observability/kube-prometheus-stack/release.yaml
@@ -25,4 +25,4 @@ spec:
       retries: 3
   valuesFrom:
     - kind: ConfigMap
-      name: values
+      name: values-kube-prometheus-stack

--- a/k8s/platform/storage/csi-nfs/mutatingpolicy.yaml
+++ b/k8s/platform/storage/csi-nfs/mutatingpolicy.yaml
@@ -9,20 +9,23 @@ spec:
   # Lives with this provisioner rather than with kyverno because it exists purely
   # to describe how this driver provisions: subDir puts every claim in a
   # subdirectory of one share, so all of them report that share's fill level as
-  # their own. KubePersistentVolumeFillingUp
-  # then fires once per claim for a single filling disk. The mixin rule already
-  # ends with `unless ... kube_persistentvolumeclaim_labels
-  # {label_excluded_from_alerts="true"}`, so this label is the supported way out.
+  # their own. KubePersistentVolumeFillingUp then fires once per claim for a
+  # single filling disk. The mixin rule already ends with
+  # `unless ... kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"}`,
+  # so this label is the supported way out.
   #
   # A policy rather than manifest labels because the versitygw chart owns three of
   # these claims and does not expose PVC labels.
+  #
+  # Admission only. mutateExisting is implemented by kyverno's background
+  # controller, which is deliberately disabled in this cluster
+  # (k8s/platform/security/kyverno/controllers/values.yaml: "Generate rules and
+  # mutate-existing rules are not part of the initial use case"), so enabling it
+  # here only parks UpdateRequests in Pending forever. Claims that predate this
+  # policy were labelled once by hand.
   evaluation:
     background:
-      enabled: true
-    mutateExisting:
-      enabled: true
-    # Must be false for mutateExisting to act on background-controller requests.
-    skipBackgroundRequests: false
+      enabled: false
   failurePolicy: Fail
   matchConstraints:
     resourceRules:


### PR DESCRIPTION
### The important half: a ConfigMap collision I introduced

`alloy` and `kube-prometheus-stack` both generate a ConfigMap named `values` with `disableNameSuffixHash: true`, and since alloy moved into `platform-observability` in #1190 they do it **in the same namespace**. Two Flux Kustomizations owning one object: whichever reconciled last won, and the kube-prometheus-stack HelmRelease has been consuming alloy's river config.

It is **NotReady right now**, rolled back to v7 — which is why the kube-state-metrics label allowlist from #1236 never reached the deployment (that pod is 23h old).

Renamed to `values-alloy` / `values-kube-prometheus-stack`, matching the `values-<releaseName>` pattern already used by cert-manager, kyverno, homer-operator, linstor-cluster and piraeus-operator. `pyrra-values` → `values-pyrra` likewise.

Worth noting the collision is invisible to `kustomize build` and `kubeconform`: each component renders fine alone. Only applying them together shows it.

### The PVC policy is admission-only now

`mutateExisting` needs kyverno's background controller, which this cluster disables deliberately (*"Generate rules and mutate-existing rules are not part of the initial use case"*). It only parked UpdateRequests in `Pending`. The admission path works — verified by touching a PVC and watching the label appear — so the policy keeps CREATE/UPDATE and the three pre-existing claims were labelled by hand. All 8 `unifi-nas` PVCs now carry it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)