### PR TITLE
*: name every values ConfigMap values-<releaseName>, and check for clashes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,4 +34,9 @@ jobs:
         with:
           go-version: '${{ env.golang-version }}'
       - run: go install github.com/mikefarah/yq/v4@${{ env.yq-version }}
+      # Both scripts shell out to kustomize. Without it validate-flux-paths.sh
+      # silently skipped every directory that has a kustomization.yaml, which is
+      # all of k8s/bootstrap.
+      - run: go install sigs.k8s.io/kustomize/kustomize/v5@${{ env.kustomize-version }}
       - run: ./hack/validate-flux-paths.sh
+      - run: ./hack/validate-configmap-ownership.sh

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ validate:  ## Render every kustomization and validate it against schemas
 validate-flux:  ## Check that Flux Kustomization paths exist
 	./hack/validate-flux-paths.sh
 
+.PHONY: validate-configmaps
+validate-configmaps:  ## Check no two Kustomizations render the same ConfigMap
+	./hack/validate-configmap-ownership.sh
+
 .PHONY: prometheusrules
 prometheusrules:  ## Validate prometheus rules
 	./hack/unpack-prometheus-rules.sh

--- a/hack/validate-configmap-ownership.py
+++ b/hack/validate-configmap-ownership.py
@@ -1,0 +1,25 @@
+import subprocess, pathlib, json, collections, sys
+paths = subprocess.run(["bash","-c",
+  "git ls-files 'k8s/flux/*' 'k8s/bootstrap/*' | xargs -I{} yq -r 'select(.kind==\"Kustomization\") | .spec.path' {} 2>/dev/null | sed 's|^\\./||' | sort -u"],
+  capture_output=True, text=True).stdout.split()
+owner = collections.defaultdict(set)
+for d in paths:
+    if not pathlib.Path(d).is_dir(): continue
+    out = subprocess.run(["kustomize","build",d], capture_output=True, text=True).stdout
+    if not out.strip(): continue
+    js = subprocess.run(["yq","ea","-o=json",'[.]',"-"], input=out, capture_output=True, text=True).stdout
+    try: docs = json.loads(js)
+    except Exception: continue
+    for o in docs:
+        if not isinstance(o, dict) or o.get("kind") != "ConfigMap": continue
+        md = o.get("metadata") or {}
+        owner[(md.get("namespace"), md.get("name"))].add(d)
+clashes = {k: v for k, v in owner.items() if len(v) > 1}
+print(f"  distinct ConfigMaps across all Kustomizations: {len(owner)}")
+if clashes:
+    print("  CLAIMED BY MORE THAN ONE KUSTOMIZATION:")
+    for (ns, n), ds in sorted(clashes.items()):
+        print(f"    {ns}/{n}")
+        for d in sorted(ds): print(f"        {d}")
+    sys.exit(1)
+print("  no ConfigMap is produced by two Kustomizations")

--- a/hack/validate-configmap-ownership.sh
+++ b/hack/validate-configmap-ownership.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Fails if two Flux Kustomizations render a ConfigMap with the same
+# namespace/name. Each renders fine alone, so `kustomize build` and kubeconform
+# both pass; the conflict only appears once they are applied together, where
+# whichever reconciles last silently wins.
+#
+# This bit once: alloy and kube-prometheus-stack both generated a ConfigMap
+# called "values" after alloy moved into platform-observability, and the
+# kube-prometheus-stack HelmRelease spent a day being handed alloy's config.
+
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)"
+exec python3 hack/validate-configmap-ownership.py

--- a/k8s/apps/ai-gateway/app/kustomization.yaml
+++ b/k8s/apps/ai-gateway/app/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - credentials.yaml
   - ingress-cloudflare.yaml
 configMapGenerator:
-  - name: values
+  - name: values-litellm
     files:
       - values.yaml=values.yaml
 # Stable ConfigMap name: helm-controller tracks values through

--- a/k8s/apps/ai-gateway/app/release.yaml
+++ b/k8s/apps/ai-gateway/app/release.yaml
@@ -21,7 +21,7 @@ spec:
       retries: 3
   valuesFrom:
     - kind: ConfigMap
-      name: values
+      name: values-litellm
   # The litellm chart has no ingress.labels, and homer-operator selects
   # Ingresses by label.
   postRenderers:

--- a/k8s/apps/ai-gateway/db/kustomization.yaml
+++ b/k8s/apps/ai-gateway/db/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - repository.yaml
   - release.yaml
 configMapGenerator:
-  - name: postgres-values
+  - name: values-postgres
     files:
       - values.yaml=values.yaml
 # Stable ConfigMap name: helm-controller tracks values through

--- a/k8s/apps/ai-gateway/db/release.yaml
+++ b/k8s/apps/ai-gateway/db/release.yaml
@@ -31,4 +31,4 @@ spec:
     mode: warn
   valuesFrom:
     - kind: ConfigMap
-      name: postgres-values
+      name: values-postgres

--- a/k8s/apps/atuin/app/kustomization.yaml
+++ b/k8s/apps/atuin/app/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - secrets.yaml
   - ingress-cloudflare.yaml
 configMapGenerator:
-  - name: values
+  - name: values-atuin
     files:
       - values.yaml=values.yaml
 # Stable ConfigMap name: helm-controller tracks values through

--- a/k8s/apps/atuin/app/release.yaml
+++ b/k8s/apps/atuin/app/release.yaml
@@ -28,7 +28,7 @@ spec:
     crds: CreateReplace
   valuesFrom:
     - kind: ConfigMap
-      name: values
+      name: values-atuin
   postRenderers:
     - kustomize:
         patches:

--- a/k8s/apps/atuin/postgres/kustomization.yaml
+++ b/k8s/apps/atuin/postgres/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - repository.yaml
   - release.yaml
 configMapGenerator:
-  - name: postgres-values
+  - name: values-postgres
     files:
       - values.yaml=values.yaml
 # Stable ConfigMap name: helm-controller tracks values through

--- a/k8s/apps/atuin/postgres/release.yaml
+++ b/k8s/apps/atuin/postgres/release.yaml
@@ -31,4 +31,4 @@ spec:
     mode: warn
   valuesFrom:
     - kind: ConfigMap
-      name: postgres-values
+      name: values-postgres

--- a/k8s/apps/changedetection/app/kustomization.yaml
+++ b/k8s/apps/changedetection/app/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - repository.yaml
   - release.yaml
 configMapGenerator:
-  - name: values
+  - name: values-changedetection
     files:
       - values.yaml=values.yaml
 # Stable ConfigMap name: helm-controller tracks values through

--- a/k8s/apps/changedetection/app/release.yaml
+++ b/k8s/apps/changedetection/app/release.yaml
@@ -28,7 +28,7 @@ spec:
     crds: CreateReplace
   valuesFrom:
     - kind: ConfigMap
-      name: values
+      name: values-changedetection
   postRenderers:
     - kustomize:
         patches:

--- a/k8s/apps/datalake-logs/kustomization.yaml
+++ b/k8s/apps/datalake-logs/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
   - grafana-datasource-cm.yaml
   - versity/
 configMapGenerator:
-  - name: values
+  - name: values-loki
     files:
       - values.yaml=values.yaml
 # Stable name so valuesFrom can reference it directly; no nameReference rewrite needed.

--- a/k8s/apps/datalake-logs/release.yaml
+++ b/k8s/apps/datalake-logs/release.yaml
@@ -28,4 +28,4 @@ spec:
     crds: CreateReplace
   valuesFrom:
     - kind: ConfigMap
-      name: values
+      name: values-loki

--- a/k8s/apps/datalake-logs/versity/kustomization.yaml
+++ b/k8s/apps/datalake-logs/versity/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
   - job.yaml
 # Not "values": the parent already generates a ConfigMap by that name here.
 configMapGenerator:
-  - name: versity-values
+  - name: values-versitygw
     files:
       - values.yaml=values.yaml
 generatorOptions:

--- a/k8s/apps/datalake-logs/versity/release.yaml
+++ b/k8s/apps/datalake-logs/versity/release.yaml
@@ -21,4 +21,4 @@ spec:
       retries: 3
   valuesFrom:
     - kind: ConfigMap
-      name: versity-values
+      name: values-versitygw

--- a/k8s/apps/grafana/grafana/kustomization.yaml
+++ b/k8s/apps/grafana/grafana/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
   - oidc-secret.yaml
   - ingress-cloudflare.yaml
 configMapGenerator:
-  - name: values
+  - name: values-grafana
     files:
       - values.yaml=values.yaml
 # Stable ConfigMap name: helm-controller tracks values through

--- a/k8s/apps/grafana/grafana/release.yaml
+++ b/k8s/apps/grafana/grafana/release.yaml
@@ -28,4 +28,4 @@ spec:
     crds: CreateReplace
   valuesFrom:
     - kind: ConfigMap
-      name: values
+      name: values-grafana

--- a/k8s/apps/grafana/postgres/kustomization.yaml
+++ b/k8s/apps/grafana/postgres/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - repository.yaml
   - release.yaml
 configMapGenerator:
-  - name: postgres-values
+  - name: values-postgres
     files:
       - values.yaml=values.yaml
 # Stable ConfigMap name: helm-controller tracks values through

--- a/k8s/apps/grafana/postgres/release.yaml
+++ b/k8s/apps/grafana/postgres/release.yaml
@@ -31,4 +31,4 @@ spec:
     mode: warn
   valuesFrom:
     - kind: ConfigMap
-      name: postgres-values
+      name: values-postgres

--- a/k8s/apps/mealie/db/kustomization.yaml
+++ b/k8s/apps/mealie/db/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - repository.yaml
   - release.yaml
 configMapGenerator:
-  - name: postgres-values
+  - name: values-postgres
     files:
       - values.yaml=values.yaml
 # Stable ConfigMap name: helm-controller tracks values through

--- a/k8s/apps/mealie/db/release.yaml
+++ b/k8s/apps/mealie/db/release.yaml
@@ -31,4 +31,4 @@ spec:
     mode: warn
   valuesFrom:
     - kind: ConfigMap
-      name: postgres-values
+      name: values-postgres

--- a/k8s/apps/mended-drum/db/kustomization.yaml
+++ b/k8s/apps/mended-drum/db/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - repository.yaml
   - release.yaml
 configMapGenerator:
-  - name: postgres-values
+  - name: values-postgres
     files:
       - values.yaml=values.yaml
 # Stable ConfigMap name: helm-controller tracks values through

--- a/k8s/apps/mended-drum/db/release.yaml
+++ b/k8s/apps/mended-drum/db/release.yaml
@@ -31,4 +31,4 @@ spec:
     mode: warn
   valuesFrom:
     - kind: ConfigMap
-      name: postgres-values
+      name: values-postgres

--- a/k8s/apps/paperless/manifests/postgres/kustomization.yaml
+++ b/k8s/apps/paperless/manifests/postgres/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - repository.yaml
   - release.yaml
 configMapGenerator:
-  - name: postgres-values
+  - name: values-postgres
     files:
       - values.yaml=values.yaml
 # Stable ConfigMap name: helm-controller tracks values through

--- a/k8s/apps/paperless/manifests/postgres/release.yaml
+++ b/k8s/apps/paperless/manifests/postgres/release.yaml
@@ -31,4 +31,4 @@ spec:
     mode: warn
   valuesFrom:
     - kind: ConfigMap
-      name: postgres-values
+      name: values-postgres

--- a/k8s/apps/photos/app/kustomization.yaml
+++ b/k8s/apps/photos/app/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
   - server-pdb.yaml
   - ingress-cloudflare.yaml
 configMapGenerator:
-  - name: values
+  - name: values-immich
     files:
       - values.yaml=values.yaml
 # Stable ConfigMap name: helm-controller tracks values through

--- a/k8s/apps/photos/app/release.yaml
+++ b/k8s/apps/photos/app/release.yaml
@@ -28,4 +28,4 @@ spec:
     mode: warn
   valuesFrom:
     - kind: ConfigMap
-      name: values
+      name: values-immich

--- a/k8s/apps/photos/db/kustomization.yaml
+++ b/k8s/apps/photos/db/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - repository.yaml
   - release.yaml
 configMapGenerator:
-  - name: postgres-values
+  - name: values-postgres
     files:
       - values.yaml=values.yaml
 generatorOptions:

--- a/k8s/apps/photos/db/release.yaml
+++ b/k8s/apps/photos/db/release.yaml
@@ -31,4 +31,4 @@ spec:
     mode: warn
   valuesFrom:
     - kind: ConfigMap
-      name: postgres-values
+      name: values-postgres

--- a/k8s/apps/pocket-id/app/kustomization.yaml
+++ b/k8s/apps/pocket-id/app/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
   - podmonitor.yaml
   - ingress-cloudflare.yaml
 configMapGenerator:
-  - name: values
+  - name: values-pocket-id
     files:
       - values.yaml=values.yaml
 # Stable ConfigMap name: helm-controller tracks values through

--- a/k8s/apps/pocket-id/app/release.yaml
+++ b/k8s/apps/pocket-id/app/release.yaml
@@ -28,7 +28,7 @@ spec:
     crds: CreateReplace
   valuesFrom:
     - kind: ConfigMap
-      name: values
+      name: values-pocket-id
     - kind: Secret
       name: pg-connection
       valuesKey: connectionString

--- a/k8s/apps/pocket-id/postgres/kustomization.yaml
+++ b/k8s/apps/pocket-id/postgres/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - repository.yaml
   - release.yaml
 configMapGenerator:
-  - name: postgres-values
+  - name: values-postgres
     files:
       - values.yaml=values.yaml
 # Stable ConfigMap name: helm-controller tracks values through

--- a/k8s/apps/pocket-id/postgres/release.yaml
+++ b/k8s/apps/pocket-id/postgres/release.yaml
@@ -31,4 +31,4 @@ spec:
     mode: warn
   valuesFrom:
     - kind: ConfigMap
-      name: postgres-values
+      name: values-postgres

--- a/k8s/apps/stirling-pdf/kustomization.yaml
+++ b/k8s/apps/stirling-pdf/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
   - ingress-cloudflare.yaml
   - oidc-secret.yaml
 configMapGenerator:
-  - name: values
+  - name: values-stirling-pdf
     files:
       - values.yaml=values.yaml
 # Stable ConfigMap name: helm-controller tracks values through

--- a/k8s/apps/stirling-pdf/release.yaml
+++ b/k8s/apps/stirling-pdf/release.yaml
@@ -28,7 +28,7 @@ spec:
     crds: CreateReplace
   valuesFrom:
     - kind: ConfigMap
-      name: values
+      name: values-stirling-pdf
   postRenderers:
     - kustomize:
         patches:

--- a/k8s/apps/vod-arr/prowlarrdb/kustomization.yaml
+++ b/k8s/apps/vod-arr/prowlarrdb/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - release.yaml
 configMapGenerator:
-  - name: postgres-prowlarr-values
+  - name: values-postgres-prowlarr
     files:
       - values.yaml=values.yaml
 # Stable ConfigMap name: helm-controller tracks values through

--- a/k8s/apps/vod-arr/prowlarrdb/release.yaml
+++ b/k8s/apps/vod-arr/prowlarrdb/release.yaml
@@ -31,4 +31,4 @@ spec:
     mode: warn
   valuesFrom:
     - kind: ConfigMap
-      name: postgres-prowlarr-values
+      name: values-postgres-prowlarr

--- a/k8s/apps/vod-arr/radarrdb/kustomization.yaml
+++ b/k8s/apps/vod-arr/radarrdb/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - release.yaml
 configMapGenerator:
-  - name: postgres-radarr-values
+  - name: values-postgres-radarr
     files:
       - values.yaml=values.yaml
 # Stable ConfigMap name: helm-controller tracks values through

--- a/k8s/apps/vod-arr/radarrdb/release.yaml
+++ b/k8s/apps/vod-arr/radarrdb/release.yaml
@@ -31,4 +31,4 @@ spec:
     mode: warn
   valuesFrom:
     - kind: ConfigMap
-      name: postgres-radarr-values
+      name: values-postgres-radarr

--- a/k8s/apps/vod-arr/sonarrdb/kustomization.yaml
+++ b/k8s/apps/vod-arr/sonarrdb/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - release.yaml
 configMapGenerator:
-  - name: postgres-sonarr-values
+  - name: values-postgres-sonarr
     files:
       - values.yaml=values.yaml
 # Stable ConfigMap name: helm-controller tracks values through

--- a/k8s/apps/vod-arr/sonarrdb/release.yaml
+++ b/k8s/apps/vod-arr/sonarrdb/release.yaml
@@ -31,4 +31,4 @@ spec:
     mode: warn
   valuesFrom:
     - kind: ConfigMap
-      name: postgres-sonarr-values
+      name: values-postgres-sonarr

--- a/k8s/platform/cluster/descheduler/kustomization.yaml
+++ b/k8s/platform/cluster/descheduler/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - namespace.yaml
   - release.yaml
 configMapGenerator:
-  - name: values
+  - name: values-descheduler
     files:
       - values.yaml=values.yaml
 # Stable name so valuesFrom can reference it directly; no nameReference rewrite needed.

--- a/k8s/platform/cluster/descheduler/release.yaml
+++ b/k8s/platform/cluster/descheduler/release.yaml
@@ -28,4 +28,4 @@ spec:
     crds: CreateReplace
   valuesFrom:
     - kind: ConfigMap
-      name: values
+      name: values-descheduler

--- a/k8s/platform/cluster/flux-system/controllers/kustomization.yaml
+++ b/k8s/platform/cluster/flux-system/controllers/kustomization.yaml
@@ -10,6 +10,6 @@ resources:
 generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:
-  - name: values
+  - name: values-flux2
     files:
       - values.yaml=values.yaml

--- a/k8s/platform/cluster/flux-system/controllers/release.yaml
+++ b/k8s/platform/cluster/flux-system/controllers/release.yaml
@@ -28,4 +28,4 @@ spec:
     crds: CreateReplace
   valuesFrom:
     - kind: ConfigMap
-      name: values
+      name: values-flux2

--- a/k8s/platform/cluster/node-feature-discovery/kustomization.yaml
+++ b/k8s/platform/cluster/node-feature-discovery/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - namespace.yaml
   - release.yaml
 configMapGenerator:
-  - name: values
+  - name: values-nfd
     files:
       - values.yaml=values.yaml
 # Stable name so valuesFrom can reference it directly; no nameReference rewrite needed.

--- a/k8s/platform/cluster/node-feature-discovery/release.yaml
+++ b/k8s/platform/cluster/node-feature-discovery/release.yaml
@@ -28,4 +28,4 @@ spec:
     crds: CreateReplace
   valuesFrom:
     - kind: ConfigMap
-      name: values
+      name: values-nfd

--- a/k8s/platform/cluster/node-problem-detector/kustomization.yaml
+++ b/k8s/platform/cluster/node-problem-detector/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - namespace.yaml
   - release.yaml
 configMapGenerator:
-  - name: values
+  - name: values-node-problem-detector
     files:
       - values.yaml=values.yaml
 # Stable name so valuesFrom can reference it directly; no nameReference rewrite needed.

--- a/k8s/platform/cluster/node-problem-detector/release.yaml
+++ b/k8s/platform/cluster/node-problem-detector/release.yaml
@@ -29,4 +29,4 @@ spec:
     crds: CreateReplace
   valuesFrom:
     - kind: ConfigMap
-      name: values
+      name: values-node-problem-detector

--- a/k8s/platform/cluster/system-kured/kustomization.yaml
+++ b/k8s/platform/cluster/system-kured/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - release.yaml
   - prometheus-rules.yaml
 configMapGenerator:
-  - name: values
+  - name: values-kured
     files:
       - values.yaml=values.yaml
 # Stable ConfigMap name: helm-controller tracks values through

--- a/k8s/platform/cluster/system-kured/release.yaml
+++ b/k8s/platform/cluster/system-kured/release.yaml
@@ -28,4 +28,4 @@ spec:
     crds: CreateReplace
   valuesFrom:
     - kind: ConfigMap
-      name: values
+      name: values-kured

--- a/k8s/platform/network/cilium/kustomization.yaml
+++ b/k8s/platform/network/cilium/kustomization.yaml
@@ -8,6 +8,6 @@ resources:
 generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:
-  - name: values
+  - name: values-cilium
     files:
       - values.yaml=values.yaml

--- a/k8s/platform/network/cilium/release.yaml
+++ b/k8s/platform/network/cilium/release.yaml
@@ -28,4 +28,4 @@ spec:
     crds: CreateReplace
   valuesFrom:
     - kind: ConfigMap
-      name: values
+      name: values-cilium

--- a/k8s/platform/network/cloudflared/kustomization.yaml
+++ b/k8s/platform/network/cloudflared/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - release.yaml
   - credentials.yaml
 configMapGenerator:
-  - name: values
+  - name: values-cloudflared
     files:
       - values.yaml=values.yaml
 # Stable ConfigMap name: helm-controller tracks values through

--- a/k8s/platform/network/cloudflared/release.yaml
+++ b/k8s/platform/network/cloudflared/release.yaml
@@ -29,6 +29,6 @@ spec:
     crds: CreateReplace
   valuesFrom:
     - kind: ConfigMap
-      name: values
+      name: values-cloudflared
     - kind: Secret
       name: credentials

--- a/k8s/platform/network/external-dns/kustomization.yaml
+++ b/k8s/platform/network/external-dns/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - release.yaml
   - unifi-credentials.yaml
 configMapGenerator:
-  - name: values
+  - name: values-external-dns
     files:
       - values.yaml=values.yaml
 # Stable ConfigMap name: helm-controller tracks values through

--- a/k8s/platform/network/external-dns/release.yaml
+++ b/k8s/platform/network/external-dns/release.yaml
@@ -28,4 +28,4 @@ spec:
     crds: CreateReplace
   valuesFrom:
     - kind: ConfigMap
-      name: values
+      name: values-external-dns

--- a/k8s/platform/security/external-secrets/controllers/kustomization.yaml
+++ b/k8s/platform/security/external-secrets/controllers/kustomization.yaml
@@ -7,6 +7,6 @@ resources:
 generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:
-  - name: values
+  - name: values-external-secrets
     files:
       - values.yaml=values.yaml

--- a/k8s/platform/security/external-secrets/controllers/release.yaml
+++ b/k8s/platform/security/external-secrets/controllers/release.yaml
@@ -29,4 +29,4 @@ spec:
     crds: CreateReplace
   valuesFrom:
     - kind: ConfigMap
-      name: values
+      name: values-external-secrets

--- a/k8s/platform/storage/cnpg-system/barman/kustomization.yaml
+++ b/k8s/platform/storage/cnpg-system/barman/kustomization.yaml
@@ -4,7 +4,7 @@ namespace: cnpg-system
 resources:
   - release.yaml
 configMapGenerator:
-  - name: barman-values
+  - name: values-barman
     files:
       - values.yaml=values.yaml
 generatorOptions:

--- a/k8s/platform/storage/cnpg-system/barman/release.yaml
+++ b/k8s/platform/storage/cnpg-system/barman/release.yaml
@@ -29,4 +29,4 @@ spec:
     crds: CreateReplace
   valuesFrom:
     - kind: ConfigMap
-      name: barman-values
+      name: values-barman

--- a/k8s/platform/storage/cnpg-system/operator/kustomization.yaml
+++ b/k8s/platform/storage/cnpg-system/operator/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
   - configmap-dashboard.yaml
   - prometheusrule.yaml
 configMapGenerator:
-  - name: values
+  - name: values-cnpg
     files:
       - values.yaml=values.yaml
 # Stable name so valuesFrom can reference it directly; no nameReference rewrite needed.

--- a/k8s/platform/storage/cnpg-system/operator/release.yaml
+++ b/k8s/platform/storage/cnpg-system/operator/release.yaml
@@ -29,4 +29,4 @@ spec:
     crds: CreateReplace
   valuesFrom:
     - kind: ConfigMap
-      name: values
+      name: values-cnpg

--- a/k8s/platform/storage/cnpg-system/versity/kustomization.yaml
+++ b/k8s/platform/storage/cnpg-system/versity/kustomization.yaml
@@ -10,6 +10,6 @@ resources:
 generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:
-  - name: versity-values
+  - name: values-versitygw
     files:
       - values.yaml=values.yaml

--- a/k8s/platform/storage/cnpg-system/versity/release.yaml
+++ b/k8s/platform/storage/cnpg-system/versity/release.yaml
@@ -21,4 +21,4 @@ spec:
       retries: 3
   valuesFrom:
     - kind: ConfigMap
-      name: versity-values
+      name: values-versitygw

--- a/k8s/platform/storage/csi-nfs/kustomization.yaml
+++ b/k8s/platform/storage/csi-nfs/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - release.yaml
   - mutatingpolicy.yaml
 configMapGenerator:
-  - name: values
+  - name: values-csi-nfs
     files:
       - values.yaml=values.yaml
 # Stable name so valuesFrom can reference it directly; no nameReference rewrite needed.

--- a/k8s/platform/storage/csi-nfs/release.yaml
+++ b/k8s/platform/storage/csi-nfs/release.yaml
@@ -29,4 +29,4 @@ spec:
     crds: CreateReplace
   valuesFrom:
     - kind: ConfigMap
-      name: values
+      name: values-csi-nfs

--- a/k8s/platform/storage/longhorn-system/kustomization.yaml
+++ b/k8s/platform/storage/longhorn-system/kustomization.yaml
@@ -13,6 +13,6 @@ resources:
 generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:
-  - name: values
+  - name: values-longhorn
     files:
       - values.yaml=values.yaml

--- a/k8s/platform/storage/longhorn-system/release.yaml
+++ b/k8s/platform/storage/longhorn-system/release.yaml
@@ -29,4 +29,4 @@ spec:
     crds: CreateReplace
   valuesFrom:
     - kind: ConfigMap
-      name: values
+      name: values-longhorn

--- a/k8s/platform/storage/longhorn-system/versity/kustomization.yaml
+++ b/k8s/platform/storage/longhorn-system/versity/kustomization.yaml
@@ -14,7 +14,7 @@ configMapGenerator:
   # Not "values": base/longhorn-system already generates a ConfigMap by that
   # name in this namespace. It is hashed today and so does not collide, but it
   # would the moment its kustomizeconfig.yaml is dropped.
-  - name: versity-values
+  - name: values-versitygw
     files:
       - values.yaml=values.yaml
 generatorOptions:

--- a/k8s/platform/storage/longhorn-system/versity/release.yaml
+++ b/k8s/platform/storage/longhorn-system/versity/release.yaml
@@ -21,4 +21,4 @@ spec:
       retries: 3
   valuesFrom:
     - kind: ConfigMap
-      name: versity-values
+      name: values-versitygw

--- a/k8s/platform/storage/topolvm-system/diskprep/kustomization.yaml
+++ b/k8s/platform/storage/topolvm-system/diskprep/kustomization.yaml
@@ -7,6 +7,6 @@ resources:
 generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:
-  - name: values
+  - name: values-diskprep
     files:
       - values.yaml=values.yaml

--- a/k8s/platform/storage/topolvm-system/diskprep/release.yaml
+++ b/k8s/platform/storage/topolvm-system/diskprep/release.yaml
@@ -29,4 +29,4 @@ spec:
     crds: CreateReplace
   valuesFrom:
     - kind: ConfigMap
-      name: values
+      name: values-diskprep

--- a/k8s/platform/storage/topolvm-system/topolvm/kustomization.yaml
+++ b/k8s/platform/storage/topolvm-system/topolvm/kustomization.yaml
@@ -8,6 +8,6 @@ resources:
 generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:
-  - name: values
+  - name: values-topolvm
     files:
       - values.yaml=values.yaml

--- a/k8s/platform/storage/topolvm-system/topolvm/release.yaml
+++ b/k8s/platform/storage/topolvm-system/topolvm/release.yaml
@@ -29,4 +29,4 @@ spec:
     crds: CreateReplace
   valuesFrom:
     - kind: ConfigMap
-      name: values
+      name: values-topolvm


### PR DESCRIPTION
Follow-up to the alloy / kube-prometheus-stack collision — fixing the class rather than the instance.

**37 components** generated a ConfigMap called `values` or `<something>-values`. Harmless until two share a namespace, at which point both Kustomizations own one object and whichever reconciles last wins.

All renamed to `values-<releaseName>`, matching cert-manager, kyverno, homer-operator, linstor-cluster and piraeus-operator. Verified no two components in a namespace land on the same name, and that all **51** ConfigMap-kind `valuesFrom` references still resolve inside their own render.

Left alone: traefik's `values-common` (deliberately shared by the `public` and `private` releases) and the two generators that are not helm values at all (`alloy-config`, `recyclarr-config`).

**New check.** `kustomize build` and kubeconform both pass on a collision, because each component renders correctly alone — only applying them together shows it. `hack/validate-configmap-ownership.sh` renders every Flux Kustomization and fails if one ConfigMap is claimed by two. Wired into CI and `make validate-configmaps`.

**Also**: the `flux-paths` job never installed kustomize, which both scripts need. `validate-flux-paths.sh` has therefore been silently skipping every directory with a `kustomization.yaml` — all of `k8s/bootstrap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)