### PR TITLE
csi-nfs: exclude the static NFS claims too, and alert on the share itself

### DIFF
--- a/k8s/apps/dlna-local/pvc.yaml
+++ b/k8s/apps/dlna-local/pvc.yaml
@@ -1,6 +1,10 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  labels:
+    # NFS on the UNAS: this claim reports the whole share's fill level,
+    # not its own. NASVolumeFillingUp covers the share itself.
+    excluded_from_alerts: "true"
   name: photos
   namespace: dlna-local
 spec:

--- a/k8s/apps/paperless/manifests/app/pvcConsume.yaml
+++ b/k8s/apps/paperless/manifests/app/pvcConsume.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   labels:
+    # NFS on the UNAS: this claim reports the whole share's fill level,
+    # not its own. NASVolumeFillingUp covers the share itself.
+    excluded_from_alerts: "true"
     app.kubernetes.io/component: webservice
     app.kubernetes.io/name: paperless
   name: consume

--- a/k8s/apps/photos/app/library-old-pvc.yaml
+++ b/k8s/apps/photos/app/library-old-pvc.yaml
@@ -1,6 +1,10 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  labels:
+    # NFS on the UNAS: this claim reports the whole share's fill level,
+    # not its own. NASVolumeFillingUp covers the share itself.
+    excluded_from_alerts: "true"
   name: library-old
 spec:
   accessModes:

--- a/k8s/apps/photos/app/library-pvc.yaml
+++ b/k8s/apps/photos/app/library-pvc.yaml
@@ -1,6 +1,10 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  labels:
+    # NFS on the UNAS: this claim reports the whole share's fill level,
+    # not its own. NASVolumeFillingUp covers the share itself.
+    excluded_from_alerts: "true"
   name: immich-library
 spec:
   accessModes:

--- a/k8s/apps/plex/media/pvc-movies.yaml
+++ b/k8s/apps/plex/media/pvc-movies.yaml
@@ -1,6 +1,10 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  labels:
+    # NFS on the UNAS: this claim reports the whole share's fill level,
+    # not its own. NASVolumeFillingUp covers the share itself.
+    excluded_from_alerts: "true"
   name: plex-movies
 spec:
   accessModes:

--- a/k8s/apps/plex/media/pvc-tv.yaml
+++ b/k8s/apps/plex/media/pvc-tv.yaml
@@ -1,6 +1,10 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  labels:
+    # NFS on the UNAS: this claim reports the whole share's fill level,
+    # not its own. NASVolumeFillingUp covers the share itself.
+    excluded_from_alerts: "true"
   name: plex-tv
 spec:
   accessModes:

--- a/k8s/apps/vod-arr/shared/pvc-downloads.yaml
+++ b/k8s/apps/vod-arr/shared/pvc-downloads.yaml
@@ -1,6 +1,10 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  labels:
+    # NFS on the UNAS: this claim reports the whole share's fill level,
+    # not its own. NASVolumeFillingUp covers the share itself.
+    excluded_from_alerts: "true"
   name: vod-downloads
 spec:
   accessModes:

--- a/k8s/apps/vod-arr/shared/pvc-movies.yaml
+++ b/k8s/apps/vod-arr/shared/pvc-movies.yaml
@@ -1,6 +1,10 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  labels:
+    # NFS on the UNAS: this claim reports the whole share's fill level,
+    # not its own. NASVolumeFillingUp covers the share itself.
+    excluded_from_alerts: "true"
   name: vod-movies
 spec:
   accessModes:

--- a/k8s/apps/vod-arr/shared/pvc-tv.yaml
+++ b/k8s/apps/vod-arr/shared/pvc-tv.yaml
@@ -1,6 +1,10 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  labels:
+    # NFS on the UNAS: this claim reports the whole share's fill level,
+    # not its own. NASVolumeFillingUp covers the share itself.
+    excluded_from_alerts: "true"
   name: vod-tv
 spec:
   accessModes:

--- a/k8s/platform/storage/csi-nfs/kustomization.yaml
+++ b/k8s/platform/storage/csi-nfs/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - namespace.yaml
   - release.yaml
   - mutatingpolicy.yaml
+  - prometheusrule.yaml
 configMapGenerator:
   - name: values-csi-nfs
     files:

--- a/k8s/platform/storage/csi-nfs/prometheusrule.yaml
+++ b/k8s/platform/storage/csi-nfs/prometheusrule.yaml
@@ -1,0 +1,35 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/name: csi-nfs
+  name: csi-nfs
+spec:
+  groups:
+    - name: nfs.rules
+      rules:
+        # Every NFS claim is a directory on one btrfs volume, so each reports the
+        # whole share and KubePersistentVolumeFillingUp fires once per claim.
+        # Those claims carry excluded_from_alerts, which silences that -- and
+        # would leave the share itself unwatched. This is the one alert for it:
+        # the join collapses however many claims exist into a single series.
+        - alert: NASVolumeFillingUp
+          annotations:
+            description: The UNAS share behind every NFS PersistentVolume is {{ $value | humanizePercentage }} free. Individual claims cannot show this because they all report the share, not themselves.
+            summary: Shared NFS volume is filling up
+          expr: |
+            min(
+              kubelet_volume_stats_available_bytes{job="kubelet"}
+              * on (namespace, persistentvolumeclaim) group_left
+                kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"}
+            )
+            /
+            min(
+              kubelet_volume_stats_capacity_bytes{job="kubelet"}
+              * on (namespace, persistentvolumeclaim) group_left
+                kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"}
+            ) < 0.10
+          for: 1h
+          labels:
+            severity: warning


### PR DESCRIPTION
Verifying the previous PVC work end-to-end surfaced a gap.

The exclusion cut PVCs under 15% free from **15 → 9**, but the nine survivors report the same 13.2% — they are the media libraries and the paperless consume dir, static PVs on `storageClassName: manual`, all NFS to `192.168.40.10` under `/var/nfs/shared`. Same volume, so the policy's `unifi-nas` selector simply never matched them.

Labelled in git rather than widening the policy to `manual`: that class name says nothing about NFS, and a future non-NFS static PV should not be silently excluded.

**That would have left the share unwatched**, which is the thing actually worth alerting on — 15 claims were under 15% free precisely because the volume behind them is. `NASVolumeFillingUp` joins the excluded claims down to a single series and alerts once. Verified against live data: exactly one result, 13.2% free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)