### PR TITLE
smartctl-exporter: match device-exclude against the label, not the path

### DIFF
--- a/k8s/platform/storage/smartctl-exporter/values.yaml
+++ b/k8s/platform/storage/smartctl-exporter/values.yaml
@@ -21,8 +21,12 @@ tolerations: &smartctlTolerations
 # that churn. NVMe is still found by scan.
 #
 # The cost: a newly fitted SATA disk stays unmonitored until it is named here.
+#
+# The pattern matches a bare device label, not a path: the exporter strips the
+# /dev/ prefix before filtering, so "^/dev/sd" silently matches nothing. The
+# chart's own values.yaml suggests "/dev/sr.*", which has the same problem.
 config:
-  device_exclude: "^/dev/sd"
+  device_exclude: "^sd"
 
 # The chart reads resources and tolerations per instance and does not fall back
 # to the base ones -- an instance that omits them renders `resources: null`.


### PR DESCRIPTION
`^/dev/sd` from #1243 excluded **nothing** — the cluster still scrapes all 8 Longhorn iSCSI volumes.

The exporter strips the `/dev/` prefix when building a device label (`buildDeviceLabel`: `/dev/sda` → `sda`) and filters on that label, so the pattern never matched. Its logs say `Found device name=sda`, which is the tell.

Verified on beelink01 before committing — with `^sd`:

```
Ignoring device name=sda ... sdl
Found device name=nvme0
Number of devices found count=1
```

The chart's own values.yaml documents `device_exclude: /dev/sr.*`, which has the same defect.