### PR TITLE
pyrra: point the apiserver read-latency SLOs at a bucket that exists

### DIFF
--- a/k8s/apps/datalake-metrics/pyrra/slo-apiserver-read-cluster-latency.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/slo-apiserver-read-cluster-latency.yaml
@@ -6,11 +6,18 @@ metadata:
     role: alert-rules
   name: apiserver-read-cluster-latency
 spec:
+  # le must name a bucket that survives kube-prometheus-stack's cardinality
+  # drop on the apiserver ServiceMonitor, which discards
+  # apiserver_request_duration_seconds_bucket for le 1.5 among others. k3s
+  # serves one merged registry, so the kubelet endpoint re-exports these same
+  # metrics without that drop: at le=1.5 the numerator had only job="kubelet"
+  # while the denominator had both jobs, and the SLO read 51% against a 99%
+  # target. 1.0 is kept on both jobs, and is the stricter objective anyway.
   description: ""
   indicator:
     latency:
       success:
-        metric: apiserver_request_duration_seconds_bucket{component="apiserver",scope=~"cluster|",verb=~"LIST|GET",le="1.5"}
+        metric: apiserver_request_duration_seconds_bucket{component="apiserver",scope=~"cluster|",verb=~"LIST|GET",le="1.0"}
       total:
         metric: apiserver_request_duration_seconds_count{component="apiserver",scope=~"cluster|",verb=~"LIST|GET"}
   target: "99"

--- a/k8s/apps/datalake-metrics/pyrra/slo-apiserver-read-namespace-latency.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/slo-apiserver-read-namespace-latency.yaml
@@ -6,11 +6,18 @@ metadata:
     role: alert-rules
   name: apiserver-read-namespace-latency
 spec:
+  # le must name a bucket that survives kube-prometheus-stack's cardinality
+  # drop on the apiserver ServiceMonitor, which discards
+  # apiserver_request_duration_seconds_bucket for le 1.5 among others. k3s
+  # serves one merged registry, so the kubelet endpoint re-exports these same
+  # metrics without that drop: at le=1.5 the numerator had only job="kubelet"
+  # while the denominator had both jobs, and the SLO read 51% against a 99%
+  # target. 1.0 is kept on both jobs, and is the stricter objective anyway.
   description: ""
   indicator:
     latency:
       success:
-        metric: apiserver_request_duration_seconds_bucket{component="apiserver",scope=~"namespace|",verb=~"LIST|GET",le="1.5"}
+        metric: apiserver_request_duration_seconds_bucket{component="apiserver",scope=~"namespace|",verb=~"LIST|GET",le="1.0"}
       total:
         metric: apiserver_request_duration_seconds_count{component="apiserver",scope=~"namespace|",verb=~"LIST|GET"}
   target: "99"


### PR DESCRIPTION
**4 critical `ErrorBudgetBurn` alerts have been paging since 2026-09-01 21:05** — the migration window. Neither SLO was measuring latency.

kube-prometheus-stack's apiserver ServiceMonitor drops `apiserver_request_duration_seconds_bucket` for a list of `le` values to control cardinality, and **1.5 is on that list**. k3s serves one merged registry, so the kubelet endpoint re-exports the same apiserver metrics *without* that drop:

```
_count  job="apiserver" 130   job="kubelet" 130
_bucket job="kubelet"   130   job="apiserver" MISSING
```

Numerator one job, denominator two → ratio 0.51 → "49% of reads over 1.5s" against a 99% target → maximum burn, continuously, for two days.

`apiserver-read-resource-latency` is the control: it asks for `le=0.1`, which survives on both jobs, and has never fired.

`le=1.0` is retained on both jobs and measures **100% over 5m / 1h / 6h / 1d**, so this silences the false page *and* tightens the objective from 1.5s to 1s.

Not fixed here: the kubelet and kube-etcd jobs both re-ingest metrics they don't own (the plan already flags kube-etcd at 66% foreign series). That's a cardinality problem worth its own change.