### PR TITLE
cnpg: exempt immich's nightly sweep from LongRunningTransaction

### DIFF
--- a/k8s/platform/storage/cnpg-system/operator/prometheusrule.yaml
+++ b/k8s/platform/storage/cnpg-system/operator/prometheusrule.yaml
@@ -6,12 +6,21 @@ spec:
   groups:
   - name: cnp-default.rules
     rules:
+    # immich is exempted up to an hour. Its IntegrityService sweep runs nightly
+    # at 03:00 local and holds one transaction open while it batches through
+    # ~42k untracked-file and ~42k missing-file checks; measured peaks of 1683s
+    # on 2026-09-02 and 1113s on 2026-09-03, climbing monotonically then
+    # committing. That is the job working, not a transaction stuck holding
+    # locks, and it grows with the library -- so a fixed 300s would keep filing
+    # an issue every night for as long as the library exists.
     - alert: LongRunningTransaction
       annotations:
         description: Pod {{ $labels.pod }} is taking more than 5 minutes (300 seconds) for a query.
         summary: A query is taking longer than 5 minutes.
       expr: |-
-        cnpg_backends_max_tx_duration_seconds > 300
+        cnpg_backends_max_tx_duration_seconds{datname!="immich"} > 300
+        or
+        cnpg_backends_max_tx_duration_seconds{datname="immich"} > 3600
       for: 1m
       labels:
         severity: warning


### PR DESCRIPTION
Closes #685 — investigated rather than closed as self-resolved.

It's recurring, not stale: the bridge refreshed the issue at 2026-09-03 01:21. Two nights of data (all the TSDB holds post-migration) show the same shape both times:

```
09-02  01:09 → 01:29   512s climbing to 1683s
09-03  01:09 → 01:19   482s climbing to 1113s
```

01:09 UTC = 03:09 local — Immich's `IntegrityService`, which holds one transaction open while batching through ~42k untracked-file and ~42k missing-file checks. The alert's own labels agree: `application_name=postgres.js`, `datname=immich`.

That's the job working, not a transaction sitting on locks, and it scales with the library — so 300s files an issue every night indefinitely. Exempting immich to 1h leaves 300s intact for the other 11 databases.

Verified against the recorded peak: old expression returns 1682s at `2026-09-02T01:29Z`, new one returns nothing.