### PR TITLE
paperless: grow paperless-data to 5Gi

### DIFF
--- a/k8s/apps/paperless/manifests/app/pvcData.yaml
+++ b/k8s/apps/paperless/manifests/app/pvcData.yaml
@@ -11,5 +11,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 2Gi
+      storage: 5Gi
   storageClassName: longhorn


### PR DESCRIPTION
`longhorn_volume_actual_size_bytes` counts snapshot history rather than occupancy, so one nightly backup snapshot (1885 MiB) sits at 95% of a 2 Gi volume while the filesystem holds 0.35 Gi. Alert left as-is; the volume gets headroom instead — ~38% after.

Longhorn 1.12.1 with `allowVolumeExpansion: true`, and these are standalone PVCs rather than StatefulSet templates, so it expands in place.

`paperless-media` stays at 2 Gi — same size, opposite shape (0.94 Gi real data, 128 MiB snapshot), so it isn't near this alert. Say if you want it too.