### PR TITLE
prowlarr: alert on losing most indexers, not on losing one

### DIFF
--- a/k8s/apps/vod-arr/prowlarr/prometheusRule.yaml
+++ b/k8s/apps/vod-arr/prowlarr/prometheusRule.yaml
@@ -37,7 +37,33 @@ spec:
               Arr Application prowlarr is having issues with {{ $labels.source }} health check - {{ $labels.message }}.
               For more infromation check {{ $labels.wikiurl }}.
             summary: prowlarr is unhealthy
-          expr: max_over_time(prowlarr_system_health_issues{job="prowlarr",source!="UpdateCheck",source!="IndexerLongTermStatusCheck"}[1h]) == 1
+          # IndexerStatusCheck joins the exclusions. It reports only "some
+          # indexer is unavailable", which for a set of public trackers is close
+          # to a steady state: across 40h of history the count sat at two or
+          # three of nine and never once reached zero. Three of those were dead
+          # entries, since removed, but a single tracker going down for the two
+          # hours this alert waits is ordinary and not actionable.
+          # IndexerLongTermStatusCheck was already excluded for the same reason;
+          # prowlarrIndexersUnavailable below covers the case that is not
+          # ordinary.
+          expr: max_over_time(prowlarr_system_health_issues{job="prowlarr",source!="UpdateCheck",source!="IndexerLongTermStatusCheck",source!="IndexerStatusCheck"}[1h]) == 1
+          for: 2h
+          labels:
+            severity: warning
+        # What actually matters is whether prowlarr can still find anything, so
+        # alert on the share of indexers that are down rather than on any single
+        # one. Stated as a proportion so adding indexers does not quietly move
+        # the threshold, but written as a multiplication: sum/total goes NaN
+        # when the denominator is absent or zero, which would leave the alert
+        # unfireable exactly when prowlarr has lost every indexer. Fires when
+        # more than half are down.
+        - alert: prowlarrIndexersUnavailable
+          annotations:
+            description: |
+              {{ $value }} of prowlarr's indexers are unavailable, more than half of them, so searches are running against a small fraction of its sources.
+              Individual public trackers fail routinely; this means most of them are failing at once.
+            summary: Most of prowlarr's indexers are unavailable
+          expr: sum(prowlarr_indexer_unavailable) * 2 > scalar(max(prowlarr_indexer_total))
           for: 2h
           labels:
             severity: warning


### PR DESCRIPTION
Recurrence fix for #1167. Removing the three dead entries already cleared the health check — `prowlarr_indexer_total` 9 → 7, `prowlarr_indexer_unavailable` 3 → 0, health issues 0 active — and the alert self-resolves once its 1h `max_over_time` lookback rolls past.

`IndexerStatusCheck` only reports "some indexer is unavailable", which across public trackers is near steady state: 40h of history sat at 2–3 of 9 and **never reached zero**. Three were dead entries, now gone, but a working tracker down for the 2h this alert waits is ordinary and actionable by nobody. It joins `UpdateCheck` and `IndexerLongTermStatusCheck` in the exclusions.

Replaced with the condition that matters — more than half unavailable:

```
sum(prowlarr_indexer_unavailable) * 2 > scalar(max(prowlarr_indexer_total))
```

A multiplication, not `sum/total`: pint's `promql/nan` flagged that the division goes NaN when the denominator is absent or zero, which would leave the alert unfireable in precisely the case it exists for — prowlarr having lost every indexer. Good catch by the linter that Phase 2 put in.

Left `sonarr`/`radarr` alone: both have `IndexerLongTermStatusCheck` active but already excluded, and for them a failing indexer means a broken connection to prowlarr, which is a different and genuinely actionable thing.