### PR TITLE
atuin: declare the database the cluster actually has

### DIFF
--- a/k8s/apps/atuin/postgres/values.yaml
+++ b/k8s/apps/atuin/postgres/values.yaml
@@ -1,9 +1,11 @@
-# No `database`, and bootstrap disabled below. The hand-written manifest declared
-# no bootstrap stanza -- it was dropped in c5c5ab63 when this cluster was
-# recovered from backup -- so what is live is CloudNativePG's own default,
-# initdb with database and owner "app". Rendering the chart's bootstrap would
-# rewrite that to "atuin" on an already-initialised cluster. `owner` is still
-# required: it supplies the username in the user ExternalSecret.
+# The cluster was recovered from backup with no bootstrap stanza, so CNPG
+# defaulted initdb to database and owner "app" -- neither of which exists here.
+# The monitoring queries target the declared app database, so all 61
+# cnpg_backends_* / cnpg_pg_* metric families failed with
+# `FATAL: database "app" does not exist`, leaving seven of the ten CNPG alerts
+# evaluating against nothing. Declaring the real names fixes that; initdb does
+# not re-run on initialised PGDATA.
+database: atuin
 owner: atuin
 
 cluster:
@@ -17,8 +19,6 @@ cluster:
     requests:
       cpu: 130m
       memory: 300Mi
-  bootstrap:
-    enabled: false
 
 backup:
   schedule: "0 17 23 * * *"


### PR DESCRIPTION
The Cluster spec claimed its app database was `app`. It's `atuin`, and no role or database named `app` exists. CNPG targets the *declared* name for its default monitoring queries, so all of them failed:

```
FATAL: database "app" does not exist (SQLSTATE 3D000)
Error collecting user query  query=pg_replication  targetDatabase=app
```

Cost: **61 of 89 metric families** — the entire `cnpg_backends_*` / `cnpg_pg_*` set — leaving **7 of the 10 CNPG alerts** evaluating against series that never existed. Indistinguishable from a healthy database. (The 3 backup alerts were fine; they read barman plugin metrics, present for all 11 clusters.)

Measured by port-forwarding both exporters: atuin 29 families, mealie 89.

The removed comment argued against declaring it, on the grounds that rendering bootstrap would rewrite an initialised cluster. `initdb` doesn't re-run on non-empty PGDATA, and the server-side diff is three lines:

```
-      database: app        +      database: atuin
-      owner: app           +      owner: atuin
                            +      secret: {name: postgres-user}
```

`encoding` and the C locale stay as CNPG defaulted them.

The secret reference is a credential no-op: `postgres-user` already has `username=atuin`, and its password hashes identically to the one in `atuin-secrets`/`dbUri` that the app connects with — so CNPG reconciling the role changes nothing.