### PR TITLE
csi-nfs: spread NFS across the bond with nconnect

### DIFF
--- a/k8s/platform/storage/csi-nfs/values.yaml
+++ b/k8s/platform/storage/csi-nfs/values.yaml
@@ -19,3 +19,16 @@ storageClass:
   mountOptions:
     - nfsvers=3
     - nolock
+    # One NFS mount is one TCP connection, and LACP hashes a flow onto a single
+    # physical link -- so beelink01/beelink02's 2Gbps bond0 delivered exactly the
+    # same 106 MiB/s as master02's single 1GbE. Measured 2026-09-03: sequential
+    # read 106 MiB/s on beelink01 and 104 MiB/s on master02, both ~89% of one
+    # 1GbE link, while the bond members carried a 7:1 traffic split.
+    #
+    # nconnect opens 4 TCP connections per mount so the hash can spread them
+    # across both bond members. Jumbo frames were the other option and are ruled
+    # out by Tailscale's MTU.
+    - nconnect=4
+    # Cuts atime write-back on a share that holds backups and versitygw object
+    # data -- nothing here reads atime.
+    - noatime


### PR DESCRIPTION
## What

Adds `nconnect=4` and `noatime` to the `unifi-nas` StorageClass mount options.

## Why

Sequential NFS throughput has been pinned to a single 1GbE link for years. Measured 2026-09-03 with an 8 GiB O_DIRECT working set:

| target | seq read | seq write |
| --- | --- | --- |
| `unifi-nas` @ beelink01 | 106 MiB/s | 28 MiB/s |
| `unifi-nas` @ master02 | 104 MiB/s | 32 MiB/s |

Both are ~89% of one 1GbE link — **even though `beelink01` has a 2 Gbps `bond0`** and `master02` only has a single 1GbE `eno1`. Identical throughput on a 2x link and a 1x link is the tell.

Confirmed from node-exporter: `beelink01`'s bond members carried a sustained 7:1 traffic split (`enp170s0` 0.83 MB/s vs `enp171s0` 5.69 MB/s). One NFS mount is one TCP connection, and LACP hashes a flow onto a single physical link, so the second NIC sits idle for NFS.

The 2023 dbench run against the *old QNAP* hit the same 108–112 MiB/s. Two NAS generations, one ceiling — this is the network path, not the UNAS.

`nconnect=4` opens four TCP connections per mount so the hash can spread them across both bond members. Jumbo frames were the other lever and are ruled out by Tailscale's MTU.

## Deployment note

**`StorageClass.mountOptions` is immutable.** A plain Helm upgrade will fail with a field-immutable error. The live class must be deleted so Helm recreates it:

```bash
kubectl delete sc unifi-nas
flux -n platform-storage reconcile helmrelease csi-nfs --with-source
```

Existing PVs are unaffected — they carry their own `mountOptions` baked in at provisioning time, so bound volumes keep working and `reclaimPolicy: Delete` still functions. They keep the *old* options until recreated, so only newly provisioned volumes get `nconnect`.

## Verification

Re-running the storage benchmark against `unifi-nas` after rollout; expect sequential read to move off the ~106 MiB/s ceiling toward ~2 Gbps on the bonded nodes. `master02` (single 1GbE) should be roughly unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)