### PR TITLE
cnpg: take the chart's PodMonitors over the operator's

### DIFF
--- a/k8s/apps/ai-gateway/db/release.yaml
+++ b/k8s/apps/ai-gateway/db/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.8.0"
+      version: "0.9.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/atuin/postgres/release.yaml
+++ b/k8s/apps/atuin/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.8.0"
+      version: "0.9.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/grafana/postgres/release.yaml
+++ b/k8s/apps/grafana/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.8.0"
+      version: "0.9.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/mealie/db/release.yaml
+++ b/k8s/apps/mealie/db/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.8.0"
+      version: "0.9.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/mended-drum/db/release.yaml
+++ b/k8s/apps/mended-drum/db/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.8.0"
+      version: "0.9.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/paperless/manifests/postgres/release.yaml
+++ b/k8s/apps/paperless/manifests/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.8.0"
+      version: "0.9.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/photos/db/release.yaml
+++ b/k8s/apps/photos/db/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.8.0"
+      version: "0.9.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/pocket-id/postgres/release.yaml
+++ b/k8s/apps/pocket-id/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.8.0"
+      version: "0.9.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/vod-arr/prowlarrdb/release.yaml
+++ b/k8s/apps/vod-arr/prowlarrdb/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.8.0"
+      version: "0.9.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/vod-arr/radarrdb/release.yaml
+++ b/k8s/apps/vod-arr/radarrdb/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.8.0"
+      version: "0.9.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/vod-arr/sonarrdb/release.yaml
+++ b/k8s/apps/vod-arr/sonarrdb/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.8.0"
+      version: "0.9.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts


### PR DESCRIPTION
Consumes thaum-xyz/helm-charts#11. All 11 releases to `cnpg-database` 0.9.0.

The chart now renders the PodMonitors and sets the deprecated `spec.monitoring.enablePodMonitor: false` on both `Cluster` and `Pooler`, so the admission webhook stops warning on every apply.

`job` moves from `<namespace>/<cluster>` to the cluster name pinned by `jobLabel`, with `namespace` as a second matcher on every alert:

```
cnpg_backends_max_tx_duration_seconds{job="postgres", namespace="paperless"} > 300
```

Both sides move in the same chart version, which is why all 11 go together rather than via Renovate — piecemeal upgrades would leave some alerts on one scheme and some on the other for days.

Rendered every release against the published chart before pushing:

| | |
|---|---|
| all 11 | own `*-metrics` PodMonitor, `jobLabel: cnpg.io/cluster` |
| paperless | second PodMonitor `pooler-metrics`, `jobLabel: cnpg.io/poolerName` |
| all 11 | pass the new guard against both owners creating a PodMonitor |

Expect brief duplicate series during rollout as the operator removes its PodMonitor and the chart's takes over — the old `job="<ns>/<cluster>"` series go stale after 5 minutes.