### PR TITLE
piraeus: raise DRBD activity log and replication buffers

### DIFF
--- a/k8s/platform/storage/piraeus-datastore/cluster/values.yaml
+++ b/k8s/platform/storage/piraeus-datastore/cluster/values.yaml
@@ -252,6 +252,19 @@ storageClasses:
       # Keep application I/O local to one of the two diskful replicas. The
       # affinity controller updates PV affinity if LINSTOR moves a replica.
       linstor.csi.linbit.com/allowRemoteVolumeAccess: "false"
+      # DRBD writes activity-log metadata synchronously whenever a write lands in
+      # an extent it is not already tracking. The default 1237 extents cover
+      # ~4.8GiB, so a random write workload over a larger volume thrashes the AL
+      # and pays a metadata write on nearly every miss. 6433 is the maximum and
+      # covers ~25GiB.
+      #
+      # Measured 2026-09-03 on beelink01/beelink02/master02, 8GiB working set:
+      # random write IOPS 3833/3751/7491 -> 11800/11500/24100 (3.1-3.2x), QD1
+      # write latency -35%/-34%/-46%, durable commits +19-28%. Reads unchanged,
+      # which is expected -- the activity log only gates writes. Neither option
+      # trades away durability.
+      property.linstor.csi.linbit.com/DrbdOptions/Disk/al-extents: "6433"
+      property.linstor.csi.linbit.com/DrbdOptions/Net/max-buffers: "8000"
   # Same two replicas, but Pods are not pinned to them: a Pod may schedule onto
   # any satellite node and attach diskless, and auto-diskful then converts that
   # attachment into a local replica and drops the surplus one. I/O is remote
@@ -267,6 +280,19 @@ storageClasses:
       linstor.csi.linbit.com/storagePool: temporary-topolvm
       linstor.csi.linbit.com/allowRemoteVolumeAccess: "true"
       property.linstor.csi.linbit.com/DrbdOptions/auto-diskful: "5"
+      # DRBD writes activity-log metadata synchronously whenever a write lands in
+      # an extent it is not already tracking. The default 1237 extents cover
+      # ~4.8GiB, so a random write workload over a larger volume thrashes the AL
+      # and pays a metadata write on nearly every miss. 6433 is the maximum and
+      # covers ~25GiB.
+      #
+      # Measured 2026-09-03 on beelink01/beelink02/master02, 8GiB working set:
+      # random write IOPS 3833/3751/7491 -> 11800/11500/24100 (3.1-3.2x), QD1
+      # write latency -35%/-34%/-46%, durable commits +19-28%. Reads unchanged,
+      # which is expected -- the activity log only gates writes. Neither option
+      # trades away durability.
+      property.linstor.csi.linbit.com/DrbdOptions/Disk/al-extents: "6433"
+      property.linstor.csi.linbit.com/DrbdOptions/Net/max-buffers: "8000"
 
 volumeSnapshotClasses:
   - name: piraeus


### PR DESCRIPTION
## What

Adds `al-extents=6433` and `max-buffers=8000` to **both** `piraeus-r2` and `piraeus-r2-roaming`.

## Why

Both classes were running every DRBD option at its default. The costly one is the activity log: DRBD writes AL metadata synchronously whenever a write lands in an extent it isn't tracking, and the default 1237 extents cover only ~4.8 GiB — so random writes over a larger volume thrash it.

Measured against an otherwise identical class (`piraeus-r2-tuned`), same run, same physical pools, 8 GiB working set:

| Measure | default | tuned | change |
| --- | --- | --- | --- |
| random write IOPS · beelink01 | 3 833 | 11 800 | **3.1×** |
| random write IOPS · beelink02 | 3 751 | 11 500 | **3.1×** |
| random write IOPS · master02 | 7 491 | 24 100 | **3.2×** |
| QD1 write latency · beelink01 | 4 709 µs | 3 061 µs | −35% |
| QD1 write latency · master02 | 3 310 µs | 1 794 µs | −46% |
| mixed write · master02 | 1 290 | 6 552 | 5.1× |
| durable commits/s | 100 / 96 / 115 | 126 / 123 / 137 | +19–28% |

Reads are unchanged on all three nodes — the expected shape, since the activity log only gates writes. Three nodes agreeing this closely rules out run-to-run noise.

Neither option trades away durability. `al-extents` only changes how much AL metadata churn DRBD does; `max-buffers` is in-flight replication buffer.

## Not included

The remaining ~3 ms QD1 write is the protocol C round trip, and it is dominated by **the peer's disk flush**, not the network — a bare NVMe flush measures 2.3–3.0 ms here. Getting below it means protocol B (peer acknowledges from memory), which is a real durability trade and deliberately left alone.

## Deployment note

`StorageClass.parameters` is immutable, so a plain Helm upgrade fails. Both classes get deleted and recreated:

```bash
kubectl delete sc piraeus-r2 piraeus-r2-roaming
flux -n platform-storage reconcile helmrelease linstor-cluster --with-source
```

Bound PVs are unaffected. Existing DRBD resources do **not** pick this up from the StorageClass — they are adjusted separately via `linstor resource-definition drbd-options`, applied as part of this rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)