### PR TITLE
cnpg: give the WAL archive alert time to self-heal

### DIFF
--- a/k8s/apps/ai-gateway/db/release.yaml
+++ b/k8s/apps/ai-gateway/db/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.9.0"
+      version: "0.10.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/atuin/postgres/release.yaml
+++ b/k8s/apps/atuin/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.9.0"
+      version: "0.10.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/grafana/postgres/release.yaml
+++ b/k8s/apps/grafana/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.9.0"
+      version: "0.10.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/mealie/db/release.yaml
+++ b/k8s/apps/mealie/db/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.9.0"
+      version: "0.10.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/mended-drum/db/release.yaml
+++ b/k8s/apps/mended-drum/db/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.9.0"
+      version: "0.10.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/paperless/manifests/postgres/release.yaml
+++ b/k8s/apps/paperless/manifests/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.9.0"
+      version: "0.10.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/photos/db/release.yaml
+++ b/k8s/apps/photos/db/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.9.0"
+      version: "0.10.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/pocket-id/postgres/release.yaml
+++ b/k8s/apps/pocket-id/postgres/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.9.0"
+      version: "0.10.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/vod-arr/prowlarrdb/release.yaml
+++ b/k8s/apps/vod-arr/prowlarrdb/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.9.0"
+      version: "0.10.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/vod-arr/radarrdb/release.yaml
+++ b/k8s/apps/vod-arr/radarrdb/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.9.0"
+      version: "0.10.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts

--- a/k8s/apps/vod-arr/sonarrdb/release.yaml
+++ b/k8s/apps/vod-arr/sonarrdb/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cnpg-database
-      version: "0.9.0"
+      version: "0.10.0"
       sourceRef:
         kind: HelmRepository
         name: thaum-charts


### PR DESCRIPTION
Consumes thaum-xyz/helm-charts#12. All 11 releases to `cnpg-database` 0.10.0.

`CNPGLastFailedArchiveTime` goes to `for: 15m` and a new `CNPGWALArchiveBacklog` covers the case the first one can no longer catch quickly.

Closes #1258, closes #1259, closes #1260 — all three resolved on their own at 18:10 UTC on 2026-09-03, 40 seconds after firing. The cause was the storage benchmark campaign, not CNPG: fio against the `unifi-nas` export starved the `cnpg-system` versitygw gateway every cluster archives WAL through.

| | |
|---|---|
| gateway latency during the runs | ~1ms → 22s – 3m53s |
| primaries that failed an archive | 4 — pocket-id, vod-arr sonarr + prowlarr, paperless |
| failures each | exactly 1 |
| peak `archive_status/ready` | 1 segment |
| WAL segments lost | none — every one landed on retry |

All 11 move together rather than through Renovate for the same reason 0.9.0 did: an alert the whole fleet shares is either patient everywhere or nowhere, and the campaign has another day or two to run.

Checked before pushing:

- `make validate` — 120 targets render cleanly, no deprecated Flux APIs
- `pint lint` against live Prometheus — 97 entries, only the pre-existing `LonghornNodeDown` dead-code warning
- rendered each release with `helm template` against the local chart and queried the new expression against live Prometheus — one series per release, all `0`, so it matches the `jobLabel` scheme rather than silently matching nothing

`flux-build` could not prove this one: it resolves the chart from `oci://ghcr.io/thaum-xyz/helm-charts`, and 0.10.0 does not exist there until helm-charts#12 merges and `publish-charts` runs. **Merge that first** — this branch cannot reconcile before it.

Unrelated to this PR but part of the same incident: the three versitygw pods still hold pre-`nconnect` mounts (`relatime`, no `nconnect`), because the mounts predate f43367da. They need a `scale 0` / `scale 1` to remount across the bond.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
