### PR TITLE
piraeus: own the roaming volume size policy

### DIFF
--- a/k8s/flux/platform/piraeus-datastore.yaml
+++ b/k8s/flux/platform/piraeus-datastore.yaml
@@ -9,6 +9,9 @@ spec:
   prune: false
   dependsOn:
     - name: topolvm
+    # The roaming size policy ships with this component, so the Kyverno CRDs
+    # have to exist before it applies. Same reason csi-nfs depends on kyverno.
+    - name: kyverno
   sourceRef:
     kind: GitRepository
     name: ankhmorpork

--- a/k8s/platform/security/kyverno/policies/kustomization.yaml
+++ b/k8s/platform/security/kyverno/policies/kustomization.yaml
@@ -5,4 +5,3 @@ resources:
   - validate-pdb-drain-safety.yaml
   - validate-helm-chart-version.yaml
   - validate-ingress-contract.yaml
-  - validate-roaming-volume-size.yaml

--- a/k8s/platform/storage/piraeus-datastore/kustomization.yaml
+++ b/k8s/platform/storage/piraeus-datastore/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: platform-storage
 resources:
   - namespace.yaml
+  - validatingpolicy.yaml
   - operator/
   - cluster/
   - gui/

--- a/k8s/platform/storage/piraeus-datastore/validatingpolicy.yaml
+++ b/k8s/platform/storage/piraeus-datastore/validatingpolicy.yaml
@@ -1,6 +1,14 @@
 apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
+  # Lives with piraeus rather than with kyverno because it exists purely to
+  # describe how this storage class behaves: the cap is a recovery-time budget
+  # for the roaming class, not a general admission rule. It belongs beside the
+  # class it constrains, and moves or dies with it.
+  #
+  # Cluster-scoped. Kustomize cannot know that for a CRD kind and stamps the
+  # component namespace on the rendered output; the API server ignores the field
+  # for cluster-scoped resources.
   name: validate-roaming-volume-size
 spec:
   evaluation:


### PR DESCRIPTION
## Why

`validate-roaming-volume-size` has nothing to do with Kyverno beyond being implemented in it. The 32 GiB cap is a **recovery-time budget for one storage class**: a Pod on `piraeus-r2-roaming` that moves attaches diskless for the 5-minute `auto-diskful` delay, then resyncs a replica over the node network — and 32 GiB is about five more minutes at the ~111 MiB/s that link actually sustains (measured 2026-09-05, corroborating the policy's original "1Gb/s" estimate).

That's a property of the class, so it belongs beside the class and should move or die with it. This is the reasoning `csi-nfs` already records for `mutate-nfs-pvc-alert-exclusion`, which lives with that provisioner for exactly the same reason.

## Changes

- `k8s/platform/security/kyverno/policies/validate-roaming-volume-size.yaml` → `k8s/platform/storage/piraeus-datastore/validatingpolicy.yaml`
- Removed from the kyverno policies kustomization, added to piraeus's
- `piraeus-datastore` gains `dependsOn: kyverno` for the CRDs, matching `csi-nfs`
- Header comment records why it lives here, and that kustomize stamps a namespace on this cluster-scoped kind which the API server ignores

Rendered object is unchanged apart from that namespace stamp: same `matchConditions`, same expression, still `Deny`. `make validate` passes.

## Rollout note

The object moves between two Flux Kustomizations, and pruning is inventory-based, so **reconcile `piraeus-datastore` before `kyverno`**:

```bash
flux -n flux-system reconcile kustomization piraeus-datastore
flux -n flux-system reconcile kustomization kyverno
kubectl get validatingpolicy validate-roaming-volume-size   # must still exist
```

Applying piraeus first means the object is re-labelled to its new owner before kyverno drops it from its inventory. The reverse order would briefly leave the cap unenforced — harmless today since nothing is creating roaming PVCs, but worth doing in the right order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)