### PR TITLE
observability: stop three jobs scraping each other's metrics

### DIFF
--- a/k8s/platform/observability/kube-prometheus-stack/values.yaml
+++ b/k8s/platform/observability/kube-prometheus-stack/values.yaml
@@ -47,6 +47,39 @@ kubeEtcd:
     - 192.168.50.31
     - 192.168.50.32
     - 192.168.50.35
+  serviceMonitor:
+    # k3s runs apiserver, scheduler, controller-manager and kubelet in one
+    # process behind a single merged registry, so scraping the etcd port also
+    # returns everyone else's metrics: 3812 of the 5746 series on this job were
+    # not etcd_* at all. Keep only what this job actually owns. `up` and the
+    # scrape_* series are added after metric relabeling, so the 11 etcd alerts
+    # that key off up{job="kube-etcd"} are unaffected.
+    metricRelabelings:
+      - action: keep
+        sourceLabels: [__name__]
+        regex: etcd_.*
+
+kubelet:
+  serviceMonitor:
+    metricRelabelings:
+      # Chart default, repeated because setting this key replaces it wholesale.
+      - action: drop
+        sourceLabels: [__name__, le]
+        regex: (csi_operations|storage_operation_duration)_seconds_bucket;(0.25|2.5|15|25|120|600)(\.0)?
+      # The same merged registry means the kubelet port re-exports the entire
+      # apiserver metric set -- 165441 series, exactly the count on
+      # job="apiserver". Worse than redundant: the apiserver ServiceMonitor
+      # drops histogram buckets for cardinality and this one does not, so any
+      # query spanning both jobs takes its numerator and denominator from
+      # different populations. That is what made the apiserver latency SLOs
+      # read 51% against a 99% target (#1247).
+      #
+      # Checked before dropping: of the 180 rule selectors that do not pin a
+      # job, the only bucket ones need le 0.1 and 1.0, and both survive on
+      # job="apiserver" with identical series counts.
+      - action: drop
+        sourceLabels: [__name__]
+        regex: apiserver_.*
 
 nodeExporter:
   operatingSystems:


### PR DESCRIPTION
k3s serves one merged registry, so each component's port returns everyone else's metrics:

| job | series | foreign |
|---|---|---|
| `kube-etcd` | 5 746 | 3 812 not `etcd_*` (66%) |
| `kubelet` | 282 985 | 165 441 `apiserver_*` (58%) |
| `apiserver` | 165 441 | — |

`kubelet` carries **exactly** the same 165 441 `apiserver_*` series as `apiserver`.

Not just waste: the apiserver ServiceMonitor drops histogram buckets for cardinality and the kubelet one doesn't, so any query spanning both takes numerator and denominator from different populations. That's what made the apiserver latency SLOs read 51% against a 99% target and page four criticals for two days (#1247).

**Checked before dropping.** 180 of the 265 rule selectors touching `apiserver_*` don't pin a job. Of those, the only bucket-based ones need `le` 0.1 and 1.0 — both survive the apiserver job's drop list, with identical series counts on both jobs:

```
le=0.1  apiserver_request_sli_duration_seconds_bucket  apiserver=1399  kubelet=1399
le=1.0  apiserver_request_duration_seconds_bucket      apiserver=2015  kubelet=2015
```

**Not dropping the kube-etcd ServiceMonitor**, which was the simpler-looking option: `etcd_server_has_leader`, `etcd_mvcc_db_total_size_in_bytes` and the disk-commit histograms exist on no other job (what `kubelet`/`apiserver` carry is the apiserver's etcd *client* metrics), and 11 etcd alerts read them. They'd have gone quiet rather than missing.

`kubelet.serviceMonitor.metricRelabelings` replaces the chart default wholesale, so the `csi_operations` bucket drop is repeated verbatim; cAdvisor's 8 and probes are untouched.

Expected: ~169k series shed, ~a quarter of what these three jobs carry. Worth landing before Phase 8 sizes retention, or the disk gets sized for duplicate data.

Post-merge check: `up{job="kube-etcd"}` must survive the `keep` — synthetic `up`/`scrape_*` series are added after metric relabeling, so it should, and the 11 etcd alerts depend on it.