### PR TITLE
flux: reconcile every HelmRelease every 5m

### DIFF
--- a/.claude/skills/app-deployment/SKILL.md
+++ b/.claude/skills/app-deployment/SKILL.md
@@ -154,11 +154,16 @@ so reconcile the source explicitly rather than assuming.
 `disableNameSuffixHash: true` gives the ConfigMap a stable name, a values change
 alters its *content* but not `valuesFrom.name` — so nothing in the HelmRelease
 spec changes and there is no event for helm-controller to act on. It notices via
-`status.lastAttemptedConfigDigest` only on its next interval. Intervals here are
-5m on 32 releases, 10m on one and **30m on fifteen**, so an unforced change can
-sit for half an hour looking like a failed deploy. The hash suffix would trigger
-it immediately, at the cost of a new ConfigMap name on every edit; stable names
-are the deliberate trade, and reconciling the release is the price.
+`status.lastAttemptedConfigDigest` only on its next interval. The hash suffix
+would trigger it immediately, at the cost of a new ConfigMap name on every edit;
+stable names are the deliberate trade, and reconciling the release is the price.
+
+**Keep `spec.interval` at 5m on every HelmRelease** — it is the ceiling on how
+long a values-only change can sit looking like a failed deploy, and the only
+automatic path to picking one up. A quiet chart is not a reason to raise it: the
+interval costs a Helm dry-run diff, not an upgrade. Fifteen releases sat at 30m
+and one at 10m until 2026-09-05. `spec.chart.spec.interval` is a different
+knob — that one polls the chart source and can stay high.
 
 ## Traps that have bitten
 

--- a/k8s/apps/ai-gateway/app/release.yaml
+++ b/k8s/apps/ai-gateway/app/release.yaml
@@ -11,7 +11,7 @@ spec:
         name: litellm
       version: "1.97.0"
       interval: 30m
-  interval: 10m
+  interval: 5m
   timeout: 15m
   install:
     remediation:

--- a/k8s/apps/ai-gateway/db/release.yaml
+++ b/k8s/apps/ai-gateway/db/release.yaml
@@ -14,7 +14,7 @@ spec:
         kind: HelmRepository
         name: thaum-charts
       interval: 5m
-  interval: 30m
+  interval: 5m
   timeout: 10m
   install:
     # Helm's waiter cannot judge a CNPG Cluster, and install remediation would

--- a/k8s/apps/atuin/postgres/release.yaml
+++ b/k8s/apps/atuin/postgres/release.yaml
@@ -14,7 +14,7 @@ spec:
         kind: HelmRepository
         name: thaum-charts
       interval: 5m
-  interval: 30m
+  interval: 5m
   timeout: 10m
   install:
     # Helm's waiter cannot judge a CNPG Cluster, and install remediation would

--- a/k8s/apps/datalake-logs/versity/release.yaml
+++ b/k8s/apps/datalake-logs/versity/release.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: versity
       interval: 15m
-  interval: 30m
+  interval: 5m
   timeout: 10m
   install:
     remediation:

--- a/k8s/apps/grafana/postgres/release.yaml
+++ b/k8s/apps/grafana/postgres/release.yaml
@@ -14,7 +14,7 @@ spec:
         kind: HelmRepository
         name: thaum-charts
       interval: 5m
-  interval: 30m
+  interval: 5m
   timeout: 10m
   install:
     # Helm's waiter cannot judge a CNPG Cluster, and install remediation would

--- a/k8s/apps/homer/app/release.yaml
+++ b/k8s/apps/homer/app/release.yaml
@@ -13,7 +13,7 @@ spec:
         name: homer-operator
         namespace: homer
       interval: 15m
-  interval: 30m
+  interval: 5m
   timeout: 10m
   install:
     crds: CreateReplace

--- a/k8s/apps/mealie/db/release.yaml
+++ b/k8s/apps/mealie/db/release.yaml
@@ -14,7 +14,7 @@ spec:
         kind: HelmRepository
         name: thaum-charts
       interval: 5m
-  interval: 30m
+  interval: 5m
   timeout: 10m
   install:
     # Helm's waiter cannot judge a CNPG Cluster, and install remediation would

--- a/k8s/apps/mended-drum/db/release.yaml
+++ b/k8s/apps/mended-drum/db/release.yaml
@@ -14,7 +14,7 @@ spec:
         kind: HelmRepository
         name: thaum-charts
       interval: 5m
-  interval: 30m
+  interval: 5m
   timeout: 10m
   install:
     # Helm's waiter cannot judge a CNPG Cluster, and install remediation would

--- a/k8s/apps/paperless/manifests/postgres/release.yaml
+++ b/k8s/apps/paperless/manifests/postgres/release.yaml
@@ -14,7 +14,7 @@ spec:
         kind: HelmRepository
         name: thaum-charts
       interval: 5m
-  interval: 30m
+  interval: 5m
   timeout: 10m
   install:
     # Helm's waiter cannot judge a CNPG Cluster, and install remediation would

--- a/k8s/apps/photos/db/release.yaml
+++ b/k8s/apps/photos/db/release.yaml
@@ -14,7 +14,7 @@ spec:
         kind: HelmRepository
         name: thaum-charts
       interval: 5m
-  interval: 30m
+  interval: 5m
   timeout: 10m
   install:
     # Helm's waiter cannot judge a CNPG Cluster, and install remediation would

--- a/k8s/apps/pocket-id/postgres/release.yaml
+++ b/k8s/apps/pocket-id/postgres/release.yaml
@@ -14,7 +14,7 @@ spec:
         kind: HelmRepository
         name: thaum-charts
       interval: 5m
-  interval: 30m
+  interval: 5m
   timeout: 10m
   install:
     # Helm's waiter cannot judge a CNPG Cluster, and install remediation would

--- a/k8s/apps/vod-arr/prowlarrdb/release.yaml
+++ b/k8s/apps/vod-arr/prowlarrdb/release.yaml
@@ -14,7 +14,7 @@ spec:
         kind: HelmRepository
         name: thaum-charts
       interval: 5m
-  interval: 30m
+  interval: 5m
   timeout: 10m
   install:
     # Helm's waiter cannot judge a CNPG Cluster, and install remediation would

--- a/k8s/apps/vod-arr/radarrdb/release.yaml
+++ b/k8s/apps/vod-arr/radarrdb/release.yaml
@@ -14,7 +14,7 @@ spec:
         kind: HelmRepository
         name: thaum-charts
       interval: 5m
-  interval: 30m
+  interval: 5m
   timeout: 10m
   install:
     # Helm's waiter cannot judge a CNPG Cluster, and install remediation would

--- a/k8s/apps/vod-arr/sonarrdb/release.yaml
+++ b/k8s/apps/vod-arr/sonarrdb/release.yaml
@@ -14,7 +14,7 @@ spec:
         kind: HelmRepository
         name: thaum-charts
       interval: 5m
-  interval: 30m
+  interval: 5m
   timeout: 10m
   install:
     # Helm's waiter cannot judge a CNPG Cluster, and install remediation would

--- a/k8s/platform/storage/cnpg-system/versity/release.yaml
+++ b/k8s/platform/storage/cnpg-system/versity/release.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: versity
       interval: 15m
-  interval: 30m
+  interval: 5m
   timeout: 10m
   install:
     remediation:

--- a/k8s/platform/storage/longhorn-system/versity/release.yaml
+++ b/k8s/platform/storage/longhorn-system/versity/release.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: versity
       interval: 15m
-  interval: 30m
+  interval: 5m
   timeout: 10m
   install:
     remediation:


### PR DESCRIPTION
A values-only edit changes the ConfigMap's content but nothing in the HelmRelease
spec, and helm-controller doesn't watch `valuesFrom` — it picks the change up
through `lastAttemptedConfigDigest` on its next interval. That interval was 30m
on fifteen releases and 10m on ai-gateway, so a forgotten `flux reconcile
helmrelease` looked like a failed deploy for half an hour.

All 50 releases now sit at 5m. Chart source polling is untouched. The skill gains
the rule, replacing a stale interval census that read as description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)