### PR TITLE
prometheus: size the volume for the 33 days it claims to keep

### DIFF
--- a/k8s/apps/datalake-metrics/prometheus/prometheus.yaml
+++ b/k8s/apps/datalake-metrics/prometheus/prometheus.yaml
@@ -60,8 +60,18 @@ spec:
     requests:
       cpu: 500m
       memory: 1800Mi
+  # 33d costs ~74.9GB per replica: measured 1.598 B/sample against 16449
+  # samples/s on 2026-09-03, so 2.27 GB/day. retentionSize sits deliberately
+  # above that, at roughly 35 days' worth, so the 33d time limit is what
+  # actually bounds the window and size is only a guard rail. They were the
+  # wrong way round before -- 35GB is 16.5 days at this rate, so the 33d was
+  # decorative and size would have started evicting around 2026-09-17.
+  #
+  # Re-measure after any large change in series count. #1267 removed 169k
+  # duplicate series and took this from 2.98 to 2.27 GB/day; sizing from the
+  # day before would have overshot by 30%.
   retention: 33d
-  retentionSize: 35GB
+  retentionSize: 75GB
   ruleNamespaceSelector: {}
   ruleSelector: {}
   scrapeConfigNamespaceSelector: {}
@@ -78,7 +88,11 @@ spec:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 40Gi
+            # 25% over retentionSize: compaction writes a merged block before
+            # dropping its sources, and max block duration is 10% of retention
+            # (~3.3d, ~7.5GB here). Thin-provisioned, so the unused part costs
+            # nothing until written.
+            storage: 100Gi
         storageClassName: lvm-thin
   # Image is derived from version; pinning both is how they drifted apart.
   version: 3.14.0


### PR DESCRIPTION
Phase 8. `retention: 33d` with `retentionSize: 35GB` meant **size bound first at 16.5 days** — the 33d was decorative, and eviction would have started around **2026-09-17** as a window quietly shorter than configured.

Measured 2026-09-03: `1.598 B/sample x 16449 samples/s` = **2.27 GB/day per replica**. Bytes-per-sample comes from the 11.05 GB of blocks already on disk divided by the samples that wrote them — which is why 3.7 days of history suffices. Sizing needs a rate, not a baseline.

| | before | after |
|---|---|---|
| `retention` | 33d | 33d |
| `retentionSize` | `35GB` (16.5d) | `75GB` (~35d) |
| PVC | 40Gi | 100Gi |

`retentionSize` sits deliberately *above* 33 days' worth so time bounds the window and size is a guard rail — they were the wrong way round. PVC is 25% over that for compaction headroom (max block duration is 10% of retention, ~3.3d ≈ 7.5 GB here). Thin-provisioned, so the unused part costs nothing until written; real consumption lands near 44% of beelink02's free pool.

Both replicas are on beelink01/02, which have 300 GB and 186 GB free in their thin pools — master01/02 are nearly full but host neither.

`lvm-thin` has `allowVolumeExpansion: true` and prometheus-operator is v0.93.1, so this should resize in place. Worth watching on the first replica rather than assuming.

**Re-measure after any large change in series count** — #1267 shed 169k duplicate series and took this from 2.98 to 2.27 GB/day; a day earlier this would have overshot by 30%. The rate also crept +5.6% across the 3-day window from series added that day.