### PR TITLE
pint: uncap the worklist, and keep the remote-write rules

### DIFF
--- a/k8s/apps/datalake-metrics/pint/configmap.yaml
+++ b/k8s/apps/datalake-metrics/pint/configmap.yaml
@@ -16,6 +16,19 @@ data:
       concurrency = 4
     }
 
+    # Remote write is not configured, so prometheus_remote_storage_* has no
+    # series and promql/series reports these three as bugs. They are kept
+    # deliberately -- they become correct the moment remote write is turned on,
+    # which is the likely path if Thanos comes back -- so the check is scoped
+    # off them rather than the rules being deleted. Verified against pint
+    # 0.87.0: without this block the three report 5 problems, with it, none.
+    rule {
+      match {
+        name = "PrometheusRemoteStorageFailures|PrometheusRemoteWriteBehind|PrometheusRemoteWriteDesiredShards"
+      }
+      disable = ["promql/series"]
+    }
+
     checks {
       disabled = [
         # 48 findings, 41 of them namespace=~".*" inside the chart's own mixin

--- a/k8s/apps/datalake-metrics/pint/deployment.yaml
+++ b/k8s/apps/datalake-metrics/pint/deployment.yaml
@@ -88,8 +88,14 @@ spec:
             - watch
             # Default is bug, which hides series problems reported as warnings.
             - --min-severity=warning
-            # Bounds pint_problem cardinality; pint_problems stays a true total.
-            - --max-problems=50
+            # 0 is "no limit", and is pint's default. It was 50, on the
+            # reasoning that pint_problems stays a true total -- which is true
+            # but misses that pint_problem is the worklist. Demonstrated
+            # 2026-09-05: fixing the job="prometheus" selector took
+            # pint_problems 91 -> 67 while pint_problem sat at exactly 50, as
+            # hidden problems stepped forward to refill the cap. Two dozen real
+            # fixes moved the visible list by nothing.
+            - --max-problems=0
             - --listen=:8081
             - glob
             - /rules/*.yaml

--- a/k8s/apps/datalake-metrics/prometheus/prometheusrule.yaml
+++ b/k8s/apps/datalake-metrics/prometheus/prometheusrule.yaml
@@ -24,16 +24,6 @@ spec:
           for: 10m
           labels:
             severity: critical
-        - alert: PrometheusSDRefreshFailure
-          annotations:
-            description: Prometheus {{$labels.instance}} has failed to refresh SD with mechanism {{$labels.mechanism}}.
-            runbook_url: https://runbooks.thaum.xyz/runbooks/prometheus/prometheussdrefreshfailure
-            summary: Failed Prometheus SD refresh.
-          expr: |
-            increase(prometheus_sd_refresh_failures_total{job="prometheus-k8s"}[10m]) > 0
-          for: 20m
-          labels:
-            severity: warning
         - alert: PrometheusKubernetesListWatchFailures
           annotations:
             description: Kubernetes service discovery of Prometheus {{$labels.instance}} is experiencing {{ printf "%.0f" $value }} failures with LIST/WATCH requests to the Kubernetes API in the last 5 minutes.


### PR DESCRIPTION
**`--max-problems: 50 → 0`** (no limit, pint's default).

The cap was deliberate — "bounds `pint_problem` cardinality; `pint_problems` stays a true total" — which is true but misses that `pint_problem` *is* the worklist. Your selector fix demonstrated it:

| | before | after |
|---|---|---|
| `pint_problems` | 91 | **67** |
| `pint_problem` series | 50 | **50** |
| `Prometheus*` series problems | 24 | 6 |

24 problems fixed, visible list unmoved — hidden entries refilled the cap. The other 41 were invisible with nothing indicating they existed.

**The three remote-write alerts stay**, per your call: `prometheus_remote_storage_*` has no series today, but they become correct the moment remote write is configured, which is the likely path if Thanos returns. `promql/series` is scoped off those three names in the in-cluster pint config instead of deleting the rules.

Verified with the rendered config against a live Prometheus — without the `rule` block those three report 5 problems; with it, none, and only `PrometheusSDRefreshFailure` remains:

```
Bug: query on nonexistent series (promql/series)
  ---> `PrometheusSDRefreshFailure`
Problems found Bug=1
```

**`PrometheusSDRefreshFailure` deleted.** Unlike remote write, `prometheus_sd_refresh_failures_total` doesn't exist on this Prometheus version at all — no configuration change brings it back. Confirmed 0 series.

Expect `pint_problems` to stay ~62 and `pint_problem` to jump from 50 to match it once this rolls out — that jump is the cap lifting, not a regression.