### PR TITLE
k8up: add the backup operator

### DIFF
--- a/k8s/flux/platform/k8up.yaml
+++ b/k8s/flux/platform/k8up.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: k8up
+  namespace: flux-system
+spec:
+  interval: 15m0s
+  path: ./k8s/platform/storage/k8up
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: ankhmorpork

--- a/k8s/platform/storage/k8up/kustomization.yaml
+++ b/k8s/platform/storage/k8up/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Namespace is declared by piraeus-datastore, the same way
+# prometheus-operator-crds declares platform-observability for its neighbours.
+namespace: platform-storage
+resources:
+  - repository.yaml
+  - release.yaml
+  - prometheusrule.yaml
+configMapGenerator:
+  - name: values-k8up
+    files:
+      - values.yaml=values.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/k8s/platform/storage/k8up/prometheusrule.yaml
+++ b/k8s/platform/storage/k8up/prometheusrule.yaml
@@ -1,0 +1,53 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/component: backup
+    app.kubernetes.io/name: k8up
+  name: k8up-rules
+spec:
+  groups:
+    - name: k8up.rules
+      rules:
+        - alert: K8upJobFailed
+          annotations:
+            description: K8up {{$labels.label_k8up_io_type}} job {{$labels.job_name}} in namespace {{$labels.namespace}} failed. Backups for that namespace are not landing until it is fixed.
+            runbook_url: https://runbooks.thaum.xyz/runbooks/thaum-xyz/K8upJobFailed
+            summary: K8up job failed
+          expr: |
+            sum by (job_name, namespace) (kube_job_status_failed)
+            * on (job_name, namespace) group_right ()
+            kube_job_labels{label_k8up_io_type=~"backup|check|prune|restore"}
+            > 0
+          for: 1m
+          labels:
+            severity: critical
+        - alert: K8upBackupNotRunning
+          annotations:
+            description: Namespace {{$labels.namespace}} has a K8up Schedule but no job of any type has run in 25h. The operator is not scheduling; check it for a deadlock.
+            runbook_url: https://runbooks.thaum.xyz/runbooks/thaum-xyz/K8upBackupNotRunning
+            summary: K8up scheduled no jobs for a namespace with a Schedule
+          # Upstream sums without by(namespace), which makes the `on(namespace)`
+          # join match nothing. Grouped here so the join actually works.
+          expr: |
+            sum by (namespace) (rate(k8up_jobs_total[25h])) == 0
+            and on (namespace) k8up_schedules_gauge > 0
+          for: 1h
+          labels:
+            severity: critical
+        - alert: K8upBackupStale
+          annotations:
+            description: No K8up backup job has completed in namespace {{$labels.namespace}} for over 36h. Backups run from the live volume, so this is also what a silently broken k8up.io/backupcommand hook looks like.
+            runbook_url: https://runbooks.thaum.xyz/runbooks/thaum-xyz/K8upBackupStale
+            summary: K8up backup is stale
+          expr: |
+            (
+              time() - max by (namespace) (
+                kube_job_status_completion_time
+                * on (job_name, namespace) group_left ()
+                kube_job_labels{label_k8up_io_type="backup"}
+              )
+            ) > 36 * 60 * 60
+          for: 15m
+          labels:
+            severity: warning

--- a/k8s/platform/storage/k8up/prometheusrule.yaml
+++ b/k8s/platform/storage/k8up/prometheusrule.yaml
@@ -8,6 +8,9 @@ metadata:
 spec:
   groups:
     - name: k8up.rules
+      # Nothing here is critical. severity=critical routes to opsgenie and pages;
+      # a backup that failed tonight is fixed tomorrow with the previous night's
+      # snapshot still on the NAS, so these go to github as issues instead.
       rules:
         - alert: K8upJobFailed
           annotations:
@@ -21,7 +24,7 @@ spec:
             > 0
           for: 1m
           labels:
-            severity: critical
+            severity: warning
         - alert: K8upBackupNotRunning
           annotations:
             description: Namespace {{$labels.namespace}} has a K8up Schedule but no job of any type has run in 25h. The operator is not scheduling; check it for a deadlock.
@@ -34,7 +37,7 @@ spec:
             and on (namespace) k8up_schedules_gauge > 0
           for: 1h
           labels:
-            severity: critical
+            severity: warning
         - alert: K8upBackupStale
           annotations:
             description: No K8up backup job has completed in namespace {{$labels.namespace}} for over 36h. Backups run from the live volume, so this is also what a silently broken k8up.io/backupcommand hook looks like.

--- a/k8s/platform/storage/k8up/release.yaml
+++ b/k8s/platform/storage/k8up/release.yaml
@@ -1,0 +1,26 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: k8up
+spec:
+  chart:
+    spec:
+      chart: k8up
+      version: "4.10.0"
+      sourceRef:
+        kind: HelmRepository
+        name: k8up
+      interval: 5m
+  interval: 5m
+  install:
+    # The chart ships the nine k8up.io CRDs under charts/k8up/crds/.
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: values-k8up

--- a/k8s/platform/storage/k8up/repository.yaml
+++ b/k8s/platform/storage/k8up/repository.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: k8up
+spec:
+  interval: 5m
+  url: https://k8up-io.github.io/k8up

--- a/k8s/platform/storage/k8up/values.yaml
+++ b/k8s/platform/storage/k8up/values.yaml
@@ -1,0 +1,39 @@
+k8up:
+  # Opt-in. Without this every bound PVC in a namespace with a Schedule is
+  # backed up, which would enrol plex-movies (8Ti), vod-tv (6Ti) and the immich
+  # library (3Ti) onto the same NAS they already live on.
+  skipWithoutAnnotation: true
+
+  envVars:
+    # ~100 MiB/s over a single 1GbE link to the UNAS, and nconnect=4 does not
+    # lift it. More parallel jobs only contend. See bench/storage-2026-09.
+    - name: BACKUP_GLOBAL_CONCURRENT_BACKUP_JOBS_LIMIT
+      value: "2"
+    # A restic repository is only consistent at rest, and prune rewrites pack
+    # files. Never let two prunes run at once against the same NFS export.
+    - name: BACKUP_GLOBAL_CONCURRENT_PRUNE_JOBS_LIMIT
+      value: "1"
+
+  # Kyverno's require-resource-requests applies to every container, and backup
+  # Pods are built by the operator rather than declared here.
+  globalResources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+
+metrics:
+  serviceMonitor:
+    enabled: true
+  # Rules are hand-written in prometheusrule.yaml. The chart's defaults omit the
+  # description annotation that .pint.hcl requires, and K8upResticErrors reads
+  # k8up_backup_restic_last_errors, which only exists with a pushgateway
+  # configured via promURL.
+  prometheusRule:
+    enabled: false
+
+resources:
+  limits:
+    memory: 256Mi
+  requests:
+    cpu: 20m
+    memory: 128Mi


### PR DESCRIPTION
First of three steps toward retiring Longhorn (#1266). This adds the operator
only — no `Schedule` exists yet, so **nothing is backed up and no alert can
fire from this alone**. The Schedules for the four volumes follow in a second
PR, and a proven restore gates the third.

Splitting it this way means the operator can be reviewed, rolled out and
reverted without touching an application.

## Why K8up

It backs up PVC data and command output *only*, never cluster objects — which
suits a cluster where Flux owns those. Velero is cluster-object-first and would
be fought the whole way.

It also handles the awkward part correctly: `backupcontroller/executor.go`
reads each PVC's access mode, finds the Pod that mounts it, and pins the backup
Job to that node via `nodeSelector`. karakeep's two RWO claims currently sit on
different nodes, so anything mounting them from one Pod would hit Multi-Attach.
Note it is `nodeSelector`, not `nodeName`, so the scheduler still runs and
`WaitForFirstConsumer` classes are unaffected.

## Opt-in, deliberately

`skipWithoutAnnotation: true`. Opt-out would enrol `plex-movies` (8Ti),
`vod-tv` (6Ti) and the immich library (3Ti) onto the NAS they already live on,
plus `plex/transcode` (96Gi of scratch). It also keeps the 22 CNPG claims out
for free — those self-backup to versitygw via barman and must stay out.

## Concurrency caps

Every backup crosses the same 1GbE link to the UNAS, and per
`bench/storage-2026-09` `nconnect=4` does not lift that ceiling, so parallel
jobs only contend. Prune is capped at one for a different reason: a restic
repository is only consistent at rest, and prune is the operation that rewrites
and deletes pack files.

## The chart's alert rules are disabled and rewritten here

Three problems with the upstream defaults:

- `K8upBackupNotRunning` and every `K8up*Failed` rule set `summary` but no
  `description`, which `.pint.hcl` rejects at severity `warning`.
- `K8upResticErrors` reads `k8up_backup_restic_last_errors`, which only exists
  if a Prometheus pushgateway is configured via `promURL`. We do not deploy one,
  so that alert would never fire and would look like health.
- Upstream's `K8upBackupNotRunning` is `sum(rate(k8up_jobs_total[25h])) == 0 and
  on(namespace) k8up_schedules_gauge > 0` — the bare `sum()` drops `namespace`,
  so the `on(namespace)` join matches nothing. The version here groups first.

Rules living with the component that produces their signal also matches
AGENTS.md, the way longhorn and cnpg already do.

## Validation

```
make validate              # 121 targets render and validate cleanly
make validate-flux         # all live Flux Kustomization paths exist
make validate-configmaps   # 65 ConfigMaps, none produced twice
make prometheusrules       # clean (one pre-existing longhorn warning, untouched)
flux-build --api-versions monitoring.coreos.com/v1 ./k8s/platform/storage/k8up
```

The last one renders the full chain: 9 CRDs, Deployment, ServiceMonitor, and
the hand-written PrometheusRule, with `BACKUP_SKIP_WITHOUT_ANNOTATION=true` and
the concurrency caps confirmed on the operator's env.

## Rollout

`spec.interval` is 5m per #1268. After merge:

```
flux reconcile source git ankhmorpork
flux -n flux-system reconcile kustomization k8up
flux -n platform-storage reconcile helmrelease k8up
```

Then confirm the nine `k8up.io` CRDs exist and the ServiceMonitor target reads
`up` in `/api/v1/targets` — a misdirected one reports `down`, not missing.

## Follow-ups

- Schedules for the four volumes, then a proven restore (#1266).
- #1269 tracks revisiting snapshot-based backup once the per-app hooks stop
  scaling; K8up reads the live filesystem, which is fine with hooks for these
  four and will not be for `plex/config` or the Prometheus TSDB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
