### PR TITLE
kube-state-metrics: scrape the exporter about itself

### DIFF
--- a/k8s/platform/observability/kube-prometheus-stack/values.yaml
+++ b/k8s/platform/observability/kube-prometheus-stack/values.yaml
@@ -107,6 +107,15 @@ kube-state-metrics:
   # clause back on without the cardinality cost of `*`.
   metricLabelsAllowlist:
     - persistentvolumeclaims=[excluded_from_alerts]
+  # kube-state-metrics serves its own telemetry on a second port, and the chart
+  # leaves that port off the Service by default. Four mixin alerts key off it --
+  # KubeStateMetricsListErrors, KubeStateMetricsWatchErrors,
+  # KubeStateMetricsShardingMismatch, KubeStateMetricsShardsMissing -- and all
+  # four were dead, with pint reporting no series for kube_state_metrics_*
+  # in the last 1w. The exporter cannot report that it has stopped seeing the
+  # API server unless it is scraped about itself.
+  selfMonitor:
+    enabled: true
   resources:
     requests:
       cpu: 2m


### PR DESCRIPTION
Bucket B of the [pint findings worklist](https://claude.ai/code/artifact/9107a3b3-9945-4fef-ac28-c880cd71263c) — one line, four alerts recovered.

## What's wrong

`kube_state_metrics_list_total`, `kube_state_metrics_watch_total`, `kube_state_metrics_total_shards` and `kube_state_metrics_shard_ordinal` have never had a single series. The KSM Service carries exactly one port (`http`); the chart leaves the telemetry port off by default.

Four mixin alerts key off those metrics and have been dead since installation:

- `KubeStateMetricsListErrors`
- `KubeStateMetricsWatchErrors`
- `KubeStateMetricsShardingMismatch`
- `KubeStateMetricsShardsMissing`

pint reports each as a separate `promql/series` bug — 4 of the 65 current findings.

## Why it matters more than four findings

These are the only alerts that fire when kube-state-metrics stops seeing the API server. In that failure every *other* `kube_*` alert simply goes quiet, which is indistinguishable from a healthy cluster.

## Verification

`helm template` of kube-prometheus-stack 88.6.2 with these values:

```
Service kube-prometheus-stack-kube-state-metrics
   port: {'name': 'http',    'port': 8080, 'targetPort': 'http'}
   port: {'name': 'metrics', 'port': 8081, 'targetPort': 'metrics'}
ServiceMonitor kube-prometheus-stack-kube-state-metrics
   endpoint port: http
   endpoint port: metrics
```

`make validate` — 120 targets clean. `make validate-flux` — 50 paths exist.

## After merge

Values-only change, so the HelmRelease reconcile is not optional:

```bash
flux reconcile source git ankhmorpork
flux -n flux-system reconcile kustomization platform-observability
flux -n platform-observability reconcile helmrelease kube-prometheus-stack
```

Then confirm the count moved — allowing ~4 minutes for pint's first check iteration after any restart:

```promql
count by (reporter) (pint_problem)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)