### PR TITLE
alerts: revive the notification queue alert, retire the spread alert

### DIFF
--- a/k8s/apps/datalake-metrics/prometheus/prometheusrule.yaml
+++ b/k8s/apps/datalake-metrics/prometheus/prometheusrule.yaml
@@ -42,8 +42,19 @@ spec:
           expr: |
             # Without min_over_time, failed scrapes could create false negatives, see
             # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+            #
+            # queue_length is per-Alertmanager (three of them, so six series across
+            # the two Prometheis); queue_capacity is per-Prometheus, with two. The
+            # label sets therefore never matched and this alert could not fire --
+            # pint reports it as promql/vector_matching, and it stayed invisible
+            # until --max-problems stopped truncating the list. max without() takes
+            # the fullest queue and leaves both sides on identical labels.
+            # ignoring(alertmanager) is not enough on its own: it turns the
+            # mismatch into "many-to-one matching must be explicit".
             (
-              predict_linear(prometheus_notifications_queue_length{job="prometheus-k8s"}[5m], 60 * 30)
+              max without(alertmanager) (
+                predict_linear(prometheus_notifications_queue_length{job="prometheus-k8s"}[5m], 60 * 30)
+              )
             >
               min_over_time(prometheus_notifications_queue_capacity{job="prometheus-k8s"}[5m])
             )

--- a/k8s/platform/observability/kube-prometheus-stack/prometheusrule-workloads.yaml
+++ b/k8s/platform/observability/kube-prometheus-stack/prometheusrule-workloads.yaml
@@ -9,36 +9,15 @@ spec:
   groups:
     - name: workload-custom.rules
       rules:
-        # Cluster-wide: the OpenShift original filtered to openshift-*/kube-*/default,
-        # which here meant it could never fire for an actual workload.
-        - alert: HighlyAvailableWorkloadIncorrectlySpread
-          annotations:
-            description: Workload {{ $labels.namespace }}/{{ $labels.workload }} is incorrectly spread across multiple nodes which breaks high-availability requirements. Since the workload is using persistent volumes, manual intervention is needed. Please follow the guidelines provided in the runbook of this alert to fix this issue.
-            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/HighlyAvailableWorkloadIncorrectlySpread.md
-            summary: Highly-available workload is incorrectly spread across multiple nodes and manual intervention is needed.
-          expr: |
-            count without (node)
-            (
-              group by (node, workload, namespace)
-              (
-                kube_pod_info{node!=""}
-                * on(namespace,pod) group_left(workload)
-                (
-                  kube_pod_spec_volumes_persistentvolumeclaims_info
-                  * on(namespace,pod) group_left(workload)
-                  (
-                    namespace_workload_pod:kube_pod_owner:relabel
-                    * on(namespace,workload,workload_type) group_left()
-                    (
-                      count without(pod) (namespace_workload_pod:kube_pod_owner:relabel) > 1
-                    )
-                  )
-                )
-              )
-            ) == 1
-          for: 1h
-          labels:
-            severity: warning
+        # HighlyAvailableWorkloadIncorrectlySpread lived here until 2026-09-05.
+        # It never once evaluated: kube_pod_spec_volumes_persistentvolumeclaims_info
+        # emits one series per volume, so any Pod with two PVCs made the join
+        # ambiguous and Prometheus errored with "many-to-many matching not
+        # allowed" every evaluation. Deduping the right-hand side fixed the
+        # query and showed why it should not come back -- it matched all eleven
+        # CNPG clusters, which are spread across nodes on purpose. The OpenShift
+        # original targets workloads sharing one RWO volume; nothing here is
+        # shaped like that.
         - alert: MultipleContainersOOMKilled
           annotations:
             description: Multiple containers were out of memory killed within the past 15 minutes. There are many potential causes of OOM errors, however issues on a specific node or containers breaching their limits is common.


### PR DESCRIPTION
Bucket A of the [pint findings worklist](https://claude.ai/code/artifact/9107a3b3-9945-4fef-ac28-c880cd71263c). Both of these surfaced only after #1271 lifted `--max-problems`, and both had been dead since the day they were written.

## `PrometheusNotificationQueueRunningFull` — fixed

`prometheus_notifications_queue_length` carries an `alertmanager` label — three Alertmanagers × two Prometheis = **6 series**. `prometheus_notifications_queue_capacity` does not, and has **2**. The `>` therefore never matched, and the alert could not fire.

```promql
max without(alertmanager) (
  predict_linear(prometheus_notifications_queue_length{job="prometheus-k8s"}[5m], 60 * 30)
)
>
min_over_time(prometheus_notifications_queue_capacity{job="prometheus-k8s"}[5m])
```

Takes the fullest queue and leaves both sides on identical labels. Returns nothing today because the queue isn't filling — which is the correct result rather than the absence of one.

`ignoring(alertmanager)` on its own is **not** enough: it converts the mismatch into `many-to-one matching must be explicit`.

## `HighlyAvailableWorkloadIncorrectlySpread` — removed

This one never evaluated at all. Prometheus errored on every evaluation:

> `found duplicate series for the match group {namespace="vod-arr", pod="radarr-0"} on the right hand-side […] many-to-many matching not allowed`

`kube_pod_spec_volumes_persistentvolumeclaims_info` emits one series per volume, and `radarr-0` has two (`backups`, `config`), so the join is ambiguous.

Deduping the right-hand side with `group by (namespace, pod, workload)` fixes the query — and shows why the rule shouldn't come back. It then returns **13 results**: every CNPG cluster in the estate, including `pocket-id/postgres`, `photos/postgres`, `atuin/postgres` and the three `vod-arr/postgres-*` databases. Those are spread across nodes deliberately; that's what replication is for.

The OpenShift original targets workloads sharing a single RWO volume. Nothing here is shaped like that, so the rule is removed rather than repaired. A comment in its place records why, so it doesn't get reintroduced.

## Verification

```
make validate       # 120 targets clean
make validate-flux  # 50 paths exist
```

pint 0.87.0 against the live Prometheus, over the git-tracked rules:

```
9 Bug:     query on nonexistent series (promql/series)
4 Warning: query on nonexistent series (promql/series)
1 Warning: dead code in query (promql/impossible)
```

No `promql/vector_matching` findings remain. The one `promql/impossible` is `LonghornNodeDown`, left alone — Longhorn is on its way out. The `promql/series` findings are buckets C and D in the worklist and are handled separately.

## After merge

```bash
flux reconcile source git ankhmorpork
flux -n flux-system reconcile kustomization platform-observability
flux -n flux-system reconcile kustomization datalake-metrics
```

Then `count by (reporter) (pint_problem)`, allowing ~4 minutes for pint's first check iteration if the pod restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)