### PR TITLE
etcd: keep the gRPC metrics etcd actually owns

### DIFF
--- a/k8s/platform/observability/kube-prometheus-stack/values.yaml
+++ b/k8s/platform/observability/kube-prometheus-stack/values.yaml
@@ -21,6 +21,15 @@ grafana:
 
 defaultRules:
   create: true
+  # Alerts whose metric cannot exist on this cluster, so they can only ever
+  # report as pint findings.
+  disabled:
+    # Needs grpc_server_handling_seconds_bucket, which k3s's embedded etcd does
+    # not export at all: the endpoint serves grpc_server_handled_total,
+    # _started_total and _msg_* but zero histogram lines. Unlike
+    # etcdHighNumberOfFailedGRPCRequests above, no relabeling change brings this
+    # one back.
+    etcdGRPCRequestsSlow: true
   rules:
     # Both select on job names this release does not create.
     alertmanager: false
@@ -54,10 +63,30 @@ kubeEtcd:
     # not etcd_* at all. Keep only what this job actually owns. `up` and the
     # scrape_* series are added after metric relabeling, so the 11 etcd alerts
     # that key off up{job="kube-etcd"} are unaffected.
+    #
+    # grpc_server_handled_total is here because "what this job owns" is not the
+    # same set as "names starting with etcd_", and the first regex assumed it
+    # was. The metric is etcd's own gRPC server -- the services carrying traffic
+    # are etcdserverpb.KV (4.6M Range, 2.3M Txn), etcdserverpb.Lease and
+    # etcdserverpb.Watch -- and dropping it killed
+    # etcdHighNumberOfFailedGRPCRequests, which had been working until #1267.
+    #
+    # It is the only etcd alert that sees failures from the client's side. The
+    # other eleven cover availability, raft, latency and capacity, but none of
+    # them fires when the backend quota trips and etcd starts returning
+    # ResourceExhausted to every write: proposals are rejected before they can
+    # fail, so etcdHighNumberOfFailedProposals stays quiet while the cluster is
+    # effectively read-only.
+    #
+    # Cost, measured on 192.168.50.31:2381: 748 series per endpoint, 2244 across
+    # the three. 738 of the 748 are permanently zero -- only OK and Canceled
+    # ever move -- so they cost head-index memory rather than disk. That takes
+    # job="kube-etcd" from 1950 series to roughly 4200, or 0.5% of the 453970 in
+    # the head.
     metricRelabelings:
       - action: keep
         sourceLabels: [__name__]
-        regex: etcd_.*
+        regex: etcd_.*|grpc_server_handled_total
 
 kubelet:
   serviceMonitor:


### PR DESCRIPTION
Settles the etcd item in the [pint findings worklist](https://claude.ai/code/artifact/9107a3b3-9945-4fef-ac28-c880cd71263c). Fixes a regression this repo introduced in #1267.

## What #1267 got wrong

#1267 scoped `job="kube-etcd"` down to `keep __name__ =~ etcd_.*`, because k3s serves apiserver, scheduler, controller-manager, kubelet and etcd from one merged registry and the etcd port returned all of it. That was right, and the stated intent was **"keep only what this job actually owns"**.

The regex was a *name prefix*, and those are not the same set. `grpc_server_handled_total` on 2381 is etcd's own gRPC server:

```
etcdserverpb.KV           Range         4,627,550
etcdserverpb.KV           Txn           2,348,663
etcdserverpb.Lease        LeaseGrant      106,079
etcdserverpb.Maintenance  Status          128,880
etcdserverpb.Watch        Watch                12
```

Dropping it killed `etcdHighNumberOfFailedGRPCRequests`, which had been working. The metric now exists only on `job="hubble-metrics"`, and pint surfaced the alert as a **new** `promql/series` bug once #1271 uncapped the list.

#1267's comment says the eleven alerts keyed off `up{job="kube-etcd"}` are unaffected — true, and the gRPC-based ones weren't considered.

## Why this alert is worth the series

It is the only etcd alert that sees failures **from the client's side**. The other eleven cover availability (`etcdNoLeader`, `etcdMembersDown`, `etcdInsufficientMembers`), raft (`etcdHighNumberOfFailedProposals`, `etcdHighNumberOfLeaderChanges`), latency (`etcdHighCommitDurations`, `etcdHighFsyncDurations`, `etcdMemberCommunicationSlow`) and capacity (`etcdDatabaseQuotaLowSpace`, `etcdExcessiveDatabaseGrowth`, `etcdDatabaseHighFragmentationRatio`).

None of them fires when the backend quota trips and etcd starts returning `ResourceExhausted` to every write: proposals are rejected before they can fail, so `etcdHighNumberOfFailedProposals` stays quiet while the cluster is effectively read-only.

## The cost, measured

On `192.168.50.31:2381`:

| | per endpoint | ×3 |
|---|---|---|
| `etcd_*` — admitted today | 637 | 1911 |
| `grpc_server_handled_total` — added here | 748 | 2244 |

`job="kube-etcd"` goes from 1950 series to roughly 4200 — **0.5%** of the 453,970 in the head. **738 of the 748 are permanently zero** (only `OK` and `Canceled` ever move), so they cost head-index memory rather than disk.

## Also: `etcdGRPCRequestsSlow` disabled

It needs `grpc_server_handling_seconds_bucket`, and that endpoint serves **zero** histogram lines. Unlike its sibling, no relabeling change brings it back, so it goes into `defaultRules.disabled` — the first entry in what will become the bucket-C bulk list.

## Verification

`helm template` of 88.6.2 with these values:

```
ServiceMonitor kube-prometheus-stack-kube-etcd
  metricRelabelings: [{action: keep, regex: 'etcd_.*|grpc_server_handled_total', sourceLabels: [__name__]}]

etcdGRPCRequestsSlow present:                False
etcdHighNumberOfFailedGRPCRequests present:  True
```

`make validate` — 121 targets clean. `make validate-flux` — 51 paths exist.

pint can't pre-verify this one: the alert stays reported until the metric is actually being scraped again, so it clears after rollout rather than before.

## After merge

Values-only, so the HelmRelease reconcile is not optional:

```bash
flux reconcile source git ankhmorpork
flux -n flux-system reconcile kustomization platform-observability
flux -n platform-observability reconcile helmrelease kube-prometheus-stack
```

Then confirm, allowing a scrape interval:

```promql
count(grpc_server_handled_total{job="kube-etcd"})   # expect ~2244
count({job="kube-etcd"})                            # 1950 -> ~4200
```

Expected effect on the worklist: 62 → 60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)