### PR TITLE
k8up: one repository password for every namespace

### DIFF
--- a/k8s/platform/storage/k8up/kustomization.yaml
+++ b/k8s/platform/storage/k8up/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 # prometheus-operator-crds declares platform-observability for its neighbours.
 namespace: platform-storage
 resources:
+  - secret.yaml
   - repository.yaml
   - release.yaml
   - prometheusrule.yaml

--- a/k8s/platform/storage/k8up/secret.yaml
+++ b/k8s/platform/storage/k8up/secret.yaml
@@ -1,0 +1,28 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: k8up-repo
+spec:
+  # One password for every restic repository, injected into backup Jobs by the
+  # operator as BACKUP_GLOBALREPOPASSWORD. Keeping it here rather than in an
+  # ExternalSecret per app namespace means no namespace holds a readable Secret
+  # granting access to every other namespace's backups.
+  #
+  # A Schedule that sets backend.repoPasswordSecretRef overrides this, so a
+  # namespace can be carved out later without touching anything else --
+  # DefaultEnv only supplies values a Schedule has not set.
+  #
+  # From Doppler rather than an in-cluster Password generator: a value that
+  # exists nowhere but the cluster is fine for a gateway root key and fatal for
+  # a restic repository password. Losing it leaves undecryptable ciphertext on
+  # the NAS, so there is an offline copy too.
+  data:
+    - remoteRef:
+        key: K8UP_REPO_PASSWORD
+      secretKey: password
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-auth-api
+  target:
+    name: k8up-repo

--- a/k8s/platform/storage/k8up/values.yaml
+++ b/k8s/platform/storage/k8up/values.yaml
@@ -5,6 +5,13 @@ k8up:
   skipWithoutAnnotation: true
 
   envVars:
+    # Shared by every repository. Schedules omit repoPasswordSecretRef and
+    # inherit this; setting it there overrides this for that namespace only.
+    - name: BACKUP_GLOBALREPOPASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: k8up-repo
+          key: password
     # ~100 MiB/s over a single 1GbE link to the UNAS, and nconnect=4 does not
     # lift it. More parallel jobs only contend. See bench/storage-2026-09.
     - name: BACKUP_GLOBAL_CONCURRENT_BACKUP_JOBS_LIMIT


### PR DESCRIPTION
Prerequisite for the per-namespace Schedules, and it removes work from each of them.

`DefaultEnv` falls back to `cfg.Config.GlobalRepoPassword` for `RESTIC_PASSWORD` ([`envvarconverter.go:99`](https://github.com/k8up-io/k8up/blob/v2.16.0/operator/executor/envvarconverter.go#L99)), so `BACKUP_GLOBALREPOPASSWORD` on the operator lets every `Schedule` omit `backend.repoPasswordSecretRef`. Onboarding a namespace becomes a PVC, a Schedule and one PVC annotation — no ExternalSecret, no Doppler key per app.

### Why here rather than per namespace

Sharing one Doppler key across twelve app namespaces would put a Secret granting access to *every* namespace's backups into *every* namespace, readable by anything that can read Secrets there. Holding it in `platform-storage` and letting the operator inject it into Job envs avoids that.

### Still reversible per namespace

The merge is `mergo.Merge` without `WithOverride`, so `DefaultEnv` only supplies what a Schedule has not set. A namespace that later wants its own key sets `repoPasswordSecretRef` and nothing else changes. (Same mechanism is what makes the `local` backend work — the backend sets `RESTIC_REPOSITORY` at `backup_utils.go:186` before the S3 default is merged in.)

### What this trades

The password protects confidentiality, not integrity: anything that can reach `192.168.40.10` can delete a repository without any password, so "one compromise destroys all backups" was already true. Per-namespace passwords would only have stopped a compromised namespace *reading* another's backups — weighed against the likelier failure of not being able to decrypt when it matters, one key that is actually recorded offline wins.

This does relax the usual separation-of-duty rule; it stays in force for the versitygw and CNPG credentials, which are live-service creds with a different blast radius.

### Note on ordering

Adding the env var rolls the operator Deployment. If ESO has not synced `k8up-repo` yet the new pod will not start and the existing one keeps running until it does — self-healing, no outage. The key is already in Doppler.

### Validation

```
make validate            # 121 targets render and validate cleanly
flux-build --api-versions monitoring.coreos.com/v1 ./k8s/platform/storage/k8up
```

confirms `BACKUP_GLOBALREPOPASSWORD` reaches the Deployment as a `secretKeyRef`.

Refs #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)