### PR TITLE
mealie: back up the recipe assets

### DIFF
--- a/k8s/apps/mealie/app/pvc.yaml
+++ b/k8s/apps/mealie/app/pvc.yaml
@@ -1,6 +1,16 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  annotations:
+    # Opt in to K8up. The operator runs with skipWithoutAnnotation, so a claim
+    # without this is not backed up -- which is what keeps the three CNPG
+    # claims in this namespace out, since they self-backup via barman.
+    k8up.io/backup: "true"
+    # 22.6M of the 25M on this volume is mealie.log and its rotations; the
+    # recipes are 2.1M. Backing up a log that churns daily costs a fresh copy
+    # in every snapshot for something Loki already collects and nobody would
+    # restore.
+    k8up.io/backup-restic-args: '["--exclude=mealie.log*"]'
   name: data
   labels:
     app.kubernetes.io/name: mealie

--- a/k8s/apps/mealie/backup/kustomization.yaml
+++ b/k8s/apps/mealie/backup/kustomization.yaml
@@ -1,8 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: mealie
 resources:
-  - namespace.yaml
-  - app/
-  - db/
-  - backup/
+  - pvc.yaml
+  - schedule.yaml

--- a/k8s/apps/mealie/backup/pvc.yaml
+++ b/k8s/apps/mealie/backup/pvc.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: backup-repo
+  labels:
+    app.kubernetes.io/component: backup
+    app.kubernetes.io/name: mealie
+spec:
+  # This namespace's restic repository. Repositories stay per-namespace even
+  # though the password is shared: a corrupted one then costs a single
+  # namespace, restic check stays cheap, and concurrent backups never contend
+  # for the same repository lock over an NFSv3 mount with nolock.
+  #
+  # excluded_from_alerts is stamped by kyverno's mutate-nfs-pvc-alert-exclusion
+  # for every unifi-nas claim. Do not add it here.
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: unifi-nas

--- a/k8s/apps/mealie/backup/schedule.yaml
+++ b/k8s/apps/mealie/backup/schedule.yaml
@@ -1,0 +1,59 @@
+apiVersion: k8up.io/v1
+kind: Schedule
+metadata:
+  name: backup
+  labels:
+    app.kubernetes.io/component: backup
+    app.kubernetes.io/name: mealie
+spec:
+  backend:
+    # No repoPasswordSecretRef: the operator supplies RESTIC_PASSWORD from
+    # BACKUP_GLOBALREPOPASSWORD. Setting it here would override that for this
+    # namespace alone.
+    #
+    # The repository is plain restic files on the UNAS rather than S3 via a
+    # fourth versitygw. versitygw's posix backend would write those same files
+    # to that same export; going direct means a restore needs restic and an NFS
+    # mount, with no cluster running.
+    local:
+      mountPath: /repo
+    volumeMounts:
+      - name: backup-repo
+        mountPath: /repo
+  # Runs as root, deliberately. csi-nfs creates each subdir 0775 owned by
+  # 977:988 -- measured on a live claim, where the sonarr pod at uid 1000
+  # cannot write to its own backup directory -- and the UNAS refuses chown, so
+  # fsGroup cannot fix it either. paperless works around this with a root
+  # initContainer that chmods the export; K8up builds these Pods itself, so
+  # that is not available. A backup agent also has to read every file it is
+  # pointed at, regardless of ownership.
+  podSecurityContext:
+    runAsUser: 0
+    runAsGroup: 0
+  backup:
+    # Fixed rather than @daily-random: a restic repository is only consistent at
+    # rest, so an off-site copy of it needs a known quiet window. Staggered
+    # clear of paperless (22:36), CNPG (23:17-03:47) and Longhorn (04:19).
+    schedule: "15 21 * * *"
+    volumes:
+      - name: backup-repo
+        persistentVolumeClaim:
+          claimName: backup-repo
+  check:
+    schedule: "45 5 * * 0"
+    volumes:
+      - name: backup-repo
+        persistentVolumeClaim:
+          claimName: backup-repo
+  prune:
+    # After check, so a repository that already fails verification is not
+    # repacked before anyone has seen the failure.
+    schedule: "15 7 * * 0"
+    retention:
+      keepDaily: 14
+      keepWeekly: 8
+      keepMonthly: 6
+    volumes:
+      - name: backup-repo
+        persistentVolumeClaim:
+          claimName: backup-repo


### PR DESCRIPTION
First namespace onto K8up (#1266), and deliberately the plain one.

mealie's database is the CNPG cluster, so `/app/data` is asset files with no SQLite anywhere in it. That makes this a clean test of the parts of the design that are genuinely unproven — writing the restic repository to the NFS export as root, and restic locking over an NFSv3 mount with `nolock` — without an application hook layered on top. karakeep and open-webui need dump scripts; those come after this works.

### What gets backed up

| | |
| --- | --- |
| `recipes` | 2.1M ← the data |
| `mealie.log` + rotations | 22.6M, **excluded** |
| `groups/`, `users/`, `templates/`, `backups/` | empty |

`k8up.io/backup-restic-args: '["--exclude=mealie.log*"]'` keeps a daily-churning log out of every snapshot. Loki already collects it and nobody restores logs from a backup.

The three CNPG claims in this namespace need no annotation to stay out — the operator runs with `skipWithoutAnnotation`, so opting in is explicit. They self-backup via barman.

### Notes

- No `repoPasswordSecretRef`; `RESTIC_PASSWORD` comes from the operator's `BACKUP_GLOBALREPOPASSWORD` (#1277).
- Backup Pods run as root. csi-nfs creates each subdir `0775` owned by `977:988` — measured on a live claim, where the sonarr pod at uid 1000 cannot write to its own backup directory — and the UNAS refuses `chown`, so `fsGroup` cannot fix it. K8up builds these Pods itself, so paperless's root chmod initContainer is not available.
- Repositories stay per-namespace despite the shared password: a corrupted one then costs one namespace, `restic check` stays cheap, and concurrent backups never contend for the same repository lock over `nolock`.
- Schedules are fixed rather than `@daily-random`, staggered clear of paperless (22:36), CNPG (23:17–03:47) and Longhorn (04:19).

### After merge

Longhorn's `c-gvgagj` keeps covering this volume. I will trigger a manual `Backup`, then prove a restore before anything is decommissioned — that restore is what gates #1266, and it is worth doing here on 2M of recipe photos rather than first discovering a problem on something that matters more.

Refs #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)