### PR TITLE
k8up: join K8upBackupNotRunning on the namespace being backed up

### DIFF
--- a/k8s/platform/storage/k8up/prometheusrule.yaml
+++ b/k8s/platform/storage/k8up/prometheusrule.yaml
@@ -27,14 +27,21 @@ spec:
             severity: warning
         - alert: K8upBackupNotRunning
           annotations:
-            description: Namespace {{$labels.namespace}} has a K8up Schedule but no job of any type has run in 25h. The operator is not scheduling; check it for a deadlock.
+            description: Namespace {{$labels.exported_namespace}} has a K8up Schedule but no job of any type has run in 25h. The operator is not scheduling; check it for a deadlock.
             runbook_url: https://runbooks.thaum.xyz/runbooks/thaum-xyz/K8upBackupNotRunning
             summary: K8up scheduled no jobs for a namespace with a Schedule
-          # Upstream sums without by(namespace), which makes the `on(namespace)`
-          # join match nothing. Grouped here so the join actually works.
+          # exported_namespace, not namespace. K8up labels these metrics with the
+          # namespace it is backing up, but that collides with the target label
+          # from the ServiceMonitor, so prometheus renames it and `namespace` is
+          # the operator's own -- platform-storage for every series. Grouping on
+          # that sums every namespace into one, where a healthy one masks a dead
+          # one and the alert names platform-storage rather than the app.
+          #
+          # Upstream also sums without a by() at all, which leaves its
+          # `on(namespace)` join matching nothing.
           expr: |
-            sum by (namespace) (rate(k8up_jobs_total[25h])) == 0
-            and on (namespace) k8up_schedules_gauge > 0
+            sum by (exported_namespace) (rate(k8up_jobs_total[25h])) == 0
+            and on (exported_namespace) k8up_schedules_gauge > 0
           for: 1h
           labels:
             severity: warning


### PR DESCRIPTION
Found while verifying mealie (#1278). The rule was wrong in a way that only becomes visible once a `Schedule` exists, and only becomes *harmful* once there is more than one.

K8up labels its metrics with the namespace it is backing up. That collides with the `namespace` target label the ServiceMonitor adds, so prometheus renames K8up's to `exported_namespace`:

```
k8up_schedules_gauge{exported_namespace="mealie", namespace="platform-storage", jobType=...}
```

So `sum by (namespace)` groups on the *operator's* namespace and collapses every app into one series:

| expression | result today |
| --- | --- |
| `sum by (namespace) (rate(k8up_jobs_total[25h]))` | `{namespace="platform-storage"}` — one series, all apps |
| `sum by (exported_namespace) (...)` | `{exported_namespace="mealie"}` — one per app |

With four namespaces onboarded, a healthy karakeep would mask a completely dead mealie, and the alert would name `platform-storage` rather than the app that stopped. The description was interpolating the wrong label for the same reason.

This is a second, independent defect from the missing `by()` already fixed against upstream in #1272 — upstream has both.

`K8upJobFailed` and `K8upBackupStale` are unaffected: they join on kube-state-metrics series, which carry the real namespace with no collision.

### Not using honorLabels

That would let K8up's label win, but it would also make `namespace` mean "the namespace being backed up" for these series only, which is a worse surprise than an explicit `exported_namespace` with a comment saying why.

Refs #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)