### PR TITLE
flux: alert on reconciliation again, via kube-state-metrics

### DIFF
--- a/k8s/platform/cluster/flux-system/controllers/prometheusRules.yaml
+++ b/k8s/platform/cluster/flux-system/controllers/prometheusRules.yaml
@@ -12,14 +12,29 @@ spec:
   groups:
     - name: GitOpsToolkit
       rules:
-        - alert: ReconciliationFailure
+        # Was ReconciliationFailure, on gotk_reconcile_condition. Flux no longer
+        # exports that metric -- flux2 still serves gotk_reconcile_duration_seconds
+        # and 18 other gotk_ families, so the controllers look scraped and healthy
+        # while this alert quietly had nothing to evaluate. pint found it as a
+        # promql/series bug once --max-problems stopped truncating the list.
+        #
+        # gotk_resource_ready comes from kube-state-metrics reading the Ready
+        # condition off the CRs, so it does not depend on the controllers
+        # exporting anything about themselves. StateSet gives one series per
+        # state with a 1 on the current one.
+        #
+        # Unknown is the in-progress state and is normal in bursts, which is what
+        # `for` is sized for: a Flux object still Unknown a quarter of an hour
+        # later is stuck, not busy.
+        - alert: FluxCDReconciliationFailure
           annotations:
-            description: '{{ $labels.kind }} {{ $labels.namespace }}/{{ $labels.name }} reconciliation has been failing for more than 10 minutes.'
-            summary: Flux objects reconciliation failure
+            description: '{{ $labels.customresource_kind }} {{ $labels.namespace }}/{{ $labels.name }} has not reached Ready for more than 15 minutes ({{ $labels.status }}). Everything on this cluster arrives through Flux, so changes stop landing until it is fixed.'
+            runbook_url: https://runbooks.thaum.xyz/runbooks/thaum-xyz/FluxCDReconciliationFailure
+            summary: Flux object is not reconciling
           expr: |
-            sum by (kind, name, namespace) (
-              max_over_time(gotk_reconcile_condition{status=~"False|Unknown",type="Ready"}[3m])
-            ) != 0
-          for: 20m
+            max by (customresource_kind, namespace, name) (
+              max_over_time(gotk_resource_ready{status=~"False|Unknown"}[5m])
+            ) > 0
+          for: 15m
           labels:
             severity: warning

--- a/k8s/platform/cluster/flux-system/controllers/prometheusRules.yaml
+++ b/k8s/platform/cluster/flux-system/controllers/prometheusRules.yaml
@@ -18,23 +18,37 @@ spec:
         # while this alert quietly had nothing to evaluate. pint found it as a
         # promql/series bug once --max-problems stopped truncating the list.
         #
-        # gotk_resource_ready comes from kube-state-metrics reading the Ready
+        # gotk_resource_info comes from kube-state-metrics reading the Ready
         # condition off the CRs, so it does not depend on the controllers
-        # exporting anything about themselves. StateSet gives one series per
-        # state with a 1 on the current one.
+        # exporting anything about themselves.
         #
-        # Unknown is the in-progress state and is normal in bursts, which is what
-        # `for` is sized for: a Flux object still Unknown a quarter of an hour
-        # later is stuck, not busy.
+        # ready=~"False|Unknown" rather than ready!="True". Unknown is the
+        # in-progress state and worth alerting on after 15m, but the negative
+        # match would also catch objects with no Ready condition at all -- and
+        # 17 of the 45 HelmRepositories here are spec.type=oci, which
+        # source-controller never reconciles because they are resolved at chart
+        # pull time. They have no Ready condition and never will. Measured
+        # before merging: ready!="True" selects those 17, ready=~"False|Unknown"
+        # selects none.
+        #
+        # suspended!="true" rather than suspended="false". kube-state-metrics
+        # omits the label entirely when spec.suspend is unset, which is every
+        # object on this cluster, so suspended="false" would match nothing and
+        # this alert could never fire.
+        #
+        # The aggregation is not cosmetic. gotk_resource_info carries revision,
+        # and on a Kustomization that is the git SHA -- it changes on every
+        # commit. Without max by(), a stuck object's series identity would
+        # change under it and reset the `for` clock whenever anyone pushed.
         - alert: FluxCDReconciliationFailure
           annotations:
-            description: '{{ $labels.customresource_kind }} {{ $labels.namespace }}/{{ $labels.name }} has not reached Ready for more than 15 minutes ({{ $labels.status }}). Everything on this cluster arrives through Flux, so changes stop landing until it is fixed.'
+            description: '{{ $labels.customresource_kind }} {{ $labels.namespace }}/{{ $labels.name }} has not reached Ready for more than 15 minutes. Everything on this cluster arrives through Flux, so changes stop landing until it is fixed.'
             runbook_url: https://runbooks.thaum.xyz/runbooks/thaum-xyz/FluxCDReconciliationFailure
             summary: Flux object is not reconciling
           expr: |
             max by (customresource_kind, namespace, name) (
-              max_over_time(gotk_resource_ready{status=~"False|Unknown"}[5m])
-            ) > 0
+              gotk_resource_info{ready=~"False|Unknown", suspended!="true"}
+            ) == 1
           for: 15m
           labels:
             severity: warning

--- a/k8s/platform/observability/kube-prometheus-stack/values.yaml
+++ b/k8s/platform/observability/kube-prometheus-stack/values.yaml
@@ -145,6 +145,104 @@ kube-state-metrics:
   # API server unless it is scraped about itself.
   selfMonitor:
     enabled: true
+  # Flux stopped exporting gotk_reconcile_condition, which took
+  # FluxCDReconciliationFailure with it -- the only alert that fires when a
+  # Kustomization or HelmRelease stops reconciling. flux2 still exports
+  # gotk_reconcile_duration_seconds, so the controllers look scraped and healthy
+  # while nothing watches whether they are succeeding.
+  #
+  # kube-state-metrics can read the Ready condition straight off the CRs
+  # instead, which does not depend on the controllers exporting anything.
+  # StateSet emits one series per state with a 1 on the current one, so
+  # gotk_resource_ready{status="False"} == 1 means exactly what it says.
+  #
+  # Verified against this cluster with kube-state-metrics v2.20.0 before
+  # merging: 387 series -- Kustomization 153, HelmRelease 147, HelmRepository 84,
+  # GitRepository 3 -- and no object currently not-Ready, so the alert is silent.
+  # HelmChart is deliberately absent: Flux generates one per HelmRelease, and a
+  # chart that fails to fetch already takes its HelmRelease not-Ready, so
+  # including it would double every alert.
+  customResourceState:
+    enabled: true
+    config:
+      kind: CustomResourceStateMetrics
+      spec:
+        resources:
+          - groupVersionKind:
+              group: kustomize.toolkit.fluxcd.io
+              version: v1
+              kind: Kustomization
+            metricNamePrefix: gotk
+            labelsFromPath:
+              name: [metadata, name]
+              namespace: [metadata, namespace]
+            metrics: &fluxReadyCondition
+              - name: resource_ready
+                help: The current Ready condition of a Flux resource.
+                each:
+                  type: StateSet
+                  stateSet:
+                    labelName: status
+                    path: [status, conditions, "[type=Ready]"]
+                    valueFrom: [status]
+                    list: ["True", "False", "Unknown"]
+          - groupVersionKind:
+              group: helm.toolkit.fluxcd.io
+              version: v2
+              kind: HelmRelease
+            metricNamePrefix: gotk
+            labelsFromPath:
+              name: [metadata, name]
+              namespace: [metadata, namespace]
+            metrics: *fluxReadyCondition
+          - groupVersionKind:
+              group: source.toolkit.fluxcd.io
+              version: v1
+              kind: GitRepository
+            metricNamePrefix: gotk
+            labelsFromPath:
+              name: [metadata, name]
+              namespace: [metadata, namespace]
+            metrics: *fluxReadyCondition
+          - groupVersionKind:
+              group: source.toolkit.fluxcd.io
+              version: v1
+              kind: HelmRepository
+            metricNamePrefix: gotk
+            labelsFromPath:
+              name: [metadata, name]
+              namespace: [metadata, namespace]
+            metrics: *fluxReadyCondition
+          # No objects today, but the CRDs exist and cost nothing to watch.
+          - groupVersionKind:
+              group: source.toolkit.fluxcd.io
+              version: v1
+              kind: OCIRepository
+            metricNamePrefix: gotk
+            labelsFromPath:
+              name: [metadata, name]
+              namespace: [metadata, namespace]
+            metrics: *fluxReadyCondition
+          - groupVersionKind:
+              group: source.toolkit.fluxcd.io
+              version: v1
+              kind: Bucket
+            metricNamePrefix: gotk
+            labelsFromPath:
+              name: [metadata, name]
+              namespace: [metadata, namespace]
+            metrics: *fluxReadyCondition
+  rbac:
+    # customResourceState reads the CRs directly, so the ServiceAccount needs
+    # list/watch on each group above. Without these the exporter starts, logs a
+    # permission error per kind and serves no gotk_ series at all.
+    extraRules:
+      - apiGroups:
+          - kustomize.toolkit.fluxcd.io
+          - helm.toolkit.fluxcd.io
+          - source.toolkit.fluxcd.io
+        resources: ["*"]
+        verbs: ["list", "watch"]
   resources:
     requests:
       cpu: 2m

--- a/k8s/platform/observability/kube-prometheus-stack/values.yaml
+++ b/k8s/platform/observability/kube-prometheus-stack/values.yaml
@@ -145,27 +145,36 @@ kube-state-metrics:
   # API server unless it is scraped about itself.
   selfMonitor:
     enabled: true
-  # Flux stopped exporting gotk_reconcile_condition, which took
-  # FluxCDReconciliationFailure with it -- the only alert that fires when a
-  # Kustomization or HelmRelease stops reconciling. flux2 still exports
+  # Flux stopped exporting gotk_reconcile_condition, which took the
+  # reconciliation alert with it -- the only one that fires when a Kustomization
+  # or HelmRelease stops reconciling. flux2 still exports
   # gotk_reconcile_duration_seconds, so the controllers look scraped and healthy
   # while nothing watches whether they are succeeding.
   #
-  # kube-state-metrics can read the Ready condition straight off the CRs
-  # instead, which does not depend on the controllers exporting anything.
-  # StateSet emits one series per state with a 1 on the current one, so
-  # gotk_resource_ready{status="False"} == 1 means exactly what it says.
+  # kube-state-metrics reads the Ready condition straight off the CRs instead,
+  # which does not depend on the controllers exporting anything. This is the
+  # gotk_resource_info shape the Flux project publishes, matching what
+  # platform/helm-charts already runs, so the two clusters stay queryable the
+  # same way. Info emits one series per object carrying ready, suspended and
+  # revision as labels.
   #
   # Verified against this cluster with kube-state-metrics v2.20.0 before
-  # merging: 387 series -- Kustomization 153, HelmRelease 147, HelmRepository 84,
-  # GitRepository 3 -- and no object currently not-Ready, so the alert is silent.
-  # HelmChart is deliberately absent: Flux generates one per HelmRelease, and a
-  # chart that fails to fetch already takes its HelmRelease not-Ready, so
-  # including it would double every alert.
+  # merging: one series per object, all 100 Kustomizations and HelmReleases
+  # carrying ready="True".
+  #
+  # Two things the alert depends on, both confirmed by that run rather than
+  # assumed:
+  #   - When spec.suspend is unset -- which is every object here -- the
+  #     suspended label is omitted entirely rather than rendered "false". The
+  #     alert must therefore say suspended!="true"; suspended="false" would
+  #     match nothing and the alert could never fire.
+  #   - revision is the git SHA on a Kustomization, so it changes on every
+  #     commit. The alert aggregates it away, or a stuck object's series
+  #     identity would change under it and reset the `for` clock whenever
+  #     anyone pushes.
   customResourceState:
     enabled: true
     config:
-      kind: CustomResourceStateMetrics
       spec:
         resources:
           - groupVersionKind:
@@ -173,65 +182,99 @@ kube-state-metrics:
               version: v1
               kind: Kustomization
             metricNamePrefix: gotk
-            labelsFromPath:
-              name: [metadata, name]
-              namespace: [metadata, namespace]
-            metrics: &fluxReadyCondition
-              - name: resource_ready
-                help: The current Ready condition of a Flux resource.
+            metrics:
+              - name: "resource_info"
+                help: "The current state of a Flux Kustomization resource."
                 each:
-                  type: StateSet
-                  stateSet:
-                    labelName: status
-                    path: [status, conditions, "[type=Ready]"]
-                    valueFrom: [status]
-                    list: ["True", "False", "Unknown"]
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name: [ metadata, name ]
+                labelsFromPath:
+                  namespace: [ metadata, namespace ]
+                  ready: [ status, conditions, "[type=Ready]", status ]
+                  suspended: [ spec, suspend ]
+                  revision: [ status, lastAppliedRevision ]
+                  source_name: [ spec, sourceRef, name ]
           - groupVersionKind:
               group: helm.toolkit.fluxcd.io
               version: v2
               kind: HelmRelease
             metricNamePrefix: gotk
-            labelsFromPath:
-              name: [metadata, name]
-              namespace: [metadata, namespace]
-            metrics: *fluxReadyCondition
+            metrics:
+              - name: "resource_info"
+                help: "The current state of a Flux HelmRelease resource."
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name: [ metadata, name ]
+                labelsFromPath:
+                  namespace: [ metadata, namespace ]
+                  ready: [ status, conditions, "[type=Ready]", status ]
+                  suspended: [ spec, suspend ]
+                  revision: [ status, history, "0", chartVersion ]
+                  chart_name: [ status, history, "0", chartName ]
+                  chart_app_version: [ status, history, "0", appVersion ]
+                  chart_ref_name: [ spec, chartRef, name ]
+                  chart_source_name: [ spec, chart, spec, sourceRef, name ]
           - groupVersionKind:
               group: source.toolkit.fluxcd.io
               version: v1
               kind: GitRepository
             metricNamePrefix: gotk
-            labelsFromPath:
-              name: [metadata, name]
-              namespace: [metadata, namespace]
-            metrics: *fluxReadyCondition
+            metrics:
+              - name: "resource_info"
+                help: "The current state of a Flux GitRepository resource."
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name: [ metadata, name ]
+                labelsFromPath:
+                  namespace: [ metadata, namespace ]
+                  ready: [ status, conditions, "[type=Ready]", status ]
+                  suspended: [ spec, suspend ]
+                  revision: [ status, artifact, revision ]
+                  url: [ spec, url ]
           - groupVersionKind:
               group: source.toolkit.fluxcd.io
               version: v1
               kind: HelmRepository
             metricNamePrefix: gotk
-            labelsFromPath:
-              name: [metadata, name]
-              namespace: [metadata, namespace]
-            metrics: *fluxReadyCondition
-          # No objects today, but the CRDs exist and cost nothing to watch.
+            metrics:
+              - name: "resource_info"
+                help: "The current state of a Flux HelmRepository resource."
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name: [ metadata, name ]
+                labelsFromPath:
+                  namespace: [ metadata, namespace ]
+                  ready: [ status, conditions, "[type=Ready]", status ]
+                  suspended: [ spec, suspend ]
+                  revision: [ status, artifact, revision ]
+                  url: [ spec, url ]
           - groupVersionKind:
               group: source.toolkit.fluxcd.io
               version: v1
               kind: OCIRepository
             metricNamePrefix: gotk
-            labelsFromPath:
-              name: [metadata, name]
-              namespace: [metadata, namespace]
-            metrics: *fluxReadyCondition
-          - groupVersionKind:
-              group: source.toolkit.fluxcd.io
-              version: v1
-              kind: Bucket
-            metricNamePrefix: gotk
-            labelsFromPath:
-              name: [metadata, name]
-              namespace: [metadata, namespace]
-            metrics: *fluxReadyCondition
+            metrics:
+              - name: "resource_info"
+                help: "The current state of a Flux OCIRepository resource."
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name: [ metadata, name ]
+                labelsFromPath:
+                  namespace: [ metadata, namespace ]
+                  ready: [ status, conditions, "[type=Ready]", status ]
+                  suspended: [ spec, suspend ]
+                  revision: [ status, artifact, revision ]
+                  url: [ spec, url ]
   rbac:
     # customResourceState reads the CRs directly, so the ServiceAccount needs
     # list/watch on each group above. Without these the exporter starts, logs a


### PR DESCRIPTION
The highest-value item in the [pint findings worklist](https://claude.ai/code/artifact/9107a3b3-9945-4fef-ac28-c880cd71263c) — the one alert that was held back from the bulk disable, because turning it off would have removed the finding and left the gap.

## What was broken

`ReconciliationFailure` keyed off `gotk_reconcile_condition`. **Flux no longer exports that metric.** flux2 still serves `gotk_reconcile_duration_seconds` and 18 other `gotk_` families, so `job="flux-system/flux2"` looks perfectly healthy while the only alert that fires when a Kustomization or HelmRelease stops reconciling had nothing to evaluate.

On a cluster where everything arrives through Flux, that is the gap worth closing first.

## How it is rebuilt

kube-state-metrics reads the `Ready` condition straight off the CRs, so the signal no longer depends on the controllers exporting anything about themselves — the same shape as the `K8up*` rules, which are built on `kube_job_*` rather than a bespoke exporter.

This uses the **`gotk_resource_info` shape the Flux project publishes**, matching what `platform/helm-charts` already runs, so both clusters stay queryable the same way. `Info` emits one series per object with `ready`, `suspended` and `revision` as labels:

```
gotk_resource_info{customresource_kind="HelmRelease",name="atuin",namespace="atuin",
                   ready="True",revision="0.4.1",chart_name="atuin",
                   chart_app_version="18.3.0",chart_source_name="atuin"} 1
```

`suspended` is the reason this matters beyond consistency: it is the only way to express *"do not alert on an object someone deliberately suspended"*.

## Three things measured, not assumed

Each would have shipped a broken alert.

**`suspended="false"` would never match.** kube-state-metrics omits the label entirely when `spec.suspend` is unset — which is all 100 objects here — rather than rendering `"false"`. The alert says `suspended!="true"`.

**`ready!="True"` is the natural selector and is wrong.** It also matches objects with **no** Ready condition, and 17 of the 45 HelmRepositories are `spec.type=oci`, which source-controller never reconciles because they are resolved at chart-pull time. They have no Ready condition and never will:

```
ready!="True"            -> 17 series   # all type=oci HelmRepositories
ready=~"False|Unknown"   ->  0 series
```

Left as-is, this alert would have fired 17 times on merge.

**`revision` is volatile.** On a Kustomization it is the git SHA, so it changes on every commit. Without `max by()`, a stuck object's series identity would change under it and reset the `for` clock whenever anyone pushed.

## Verification

kube-state-metrics v2.20.0 run against the ConfigMap **as Helm renders it**, against this cluster, before merging:

```
146 series      Kustomization 51   HelmRelease 49   HelmRepository 45   GitRepository 1
                (matches the object counts exactly)
no RBAC errors  the alert's selector returns nothing
```

`make validate` — 122 targets. `make validate-flux` — 51 paths. pint CI lint — clean apart from the known `LonghornNodeDown` warning.

## Other choices worth flagging

- **Renamed to `FluxCDReconciliationFailure`** so it says which system it is about, matching `K8up*` / `CNPG*`.
- **RBAC is required.** Without the `extraRules`, kube-state-metrics starts, logs a permission error per kind and serves no `gotk_` series at all.
- **`Unknown` counts as failing, with `for: 15m`.** It is the in-progress state and normal in bursts; an object still Unknown a quarter of an hour later is stuck, not busy.

## After merge

Values-only, so the HelmRelease reconcile is not optional:

```bash
flux reconcile source git ankhmorpork
flux -n flux-system reconcile kustomization platform-observability
flux -n platform-observability reconcile helmrelease kube-prometheus-stack
```

Then:

```promql
count(gotk_resource_ready)                      # expect ~387
count(gotk_resource_ready{status="False"} == 1) # expect 0 on a healthy cluster
```

Like #1276, this finding clears **after** rollout rather than before — pint cannot see the metric until it is being scraped, and it needs two iterations (one to re-read the rules, one to re-query Prometheus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
