### PR TITLE
pint: retire eleven alerts that cannot fire here, silence three checks

### DIFF
--- a/k8s/apps/datalake-metrics/pint/configmap.yaml
+++ b/k8s/apps/datalake-metrics/pint/configmap.yaml
@@ -44,14 +44,16 @@ data:
     # are no ResourceQuotas on this cluster for it to select from, and it is not
     # ours to rewrite, so scope the check off rather than carry a fork.
     #
-    # Both rules, not just the one pint names. They carry the same topk and pint
-    # deduplicates identical problems, so it reports KubeQuotaAlmostFull with
-    # KubeQuotaFullyUsed hidden behind it. Scoping only the visible one lets the
-    # duplicate step forward and the count does not move -- the same dynamic
-    # that made --max-problems=50 hide two dozen fixes in #1271.
+    # All three KubeQuota* rules, not the one pint happens to name. They share
+    # the same topk expression and pint deduplicates identical problems, so it
+    # reports one and hides the others behind it. Scoping the visible name lets
+    # the next duplicate step forward and the count does not move -- the same
+    # dynamic that made --max-problems=50 hide two dozen fixes in #1271.
+    # Demonstrated twice while writing this: scoping AlmostFull surfaced
+    # FullyUsed, and scoping both surfaced Exceeded. Match the family.
     rule {
       match {
-        name = "KubeQuota(AlmostFull|FullyUsed)"
+        name = "KubeQuota.+"
       }
       disable = ["promql/fragile"]
     }

--- a/k8s/apps/datalake-metrics/pint/configmap.yaml
+++ b/k8s/apps/datalake-metrics/pint/configmap.yaml
@@ -29,6 +29,41 @@ data:
       disable = ["promql/series"]
     }
 
+    # Watchdog is supposed to always fire -- that is the whole point of a
+    # dead-man's switch, and Alertmanager's watchdog receiver is built on it
+    # firing continuously. alerts/comparison is right in general and wrong here.
+    rule {
+      match {
+        name = "Watchdog"
+      }
+      disable = ["alerts/comparison"]
+    }
+
+    # promql/fragile objects to topk returning a different set on each
+    # evaluation, which is a fair criticism of the upstream mixin query. There
+    # are no ResourceQuotas on this cluster for it to select from, and it is not
+    # ours to rewrite, so scope the check off rather than carry a fork.
+    rule {
+      match {
+        name = "KubeQuotaAlmostFull"
+      }
+      disable = ["promql/fragile"]
+    }
+
+    # smartctl-exporter declares smartctl_device_percentage_used,
+    # _available_spare, _available_spare_threshold and _critical_warning as
+    # counters in its metadata. They are gauges -- a wear level does not
+    # monotonically accumulate in the way rate() assumes -- so reading them
+    # directly is correct and promql/counter is reacting to the exporter's
+    # mislabelling, not to these rules. The fix belongs upstream in the
+    # exporter.
+    rule {
+      match {
+        name = "SmartCTLDevice.+"
+      }
+      disable = ["promql/counter"]
+    }
+
     checks {
       disabled = [
         # 48 findings, 41 of them namespace=~".*" inside the chart's own mixin

--- a/k8s/apps/datalake-metrics/pint/configmap.yaml
+++ b/k8s/apps/datalake-metrics/pint/configmap.yaml
@@ -43,9 +43,15 @@ data:
     # evaluation, which is a fair criticism of the upstream mixin query. There
     # are no ResourceQuotas on this cluster for it to select from, and it is not
     # ours to rewrite, so scope the check off rather than carry a fork.
+    #
+    # Both rules, not just the one pint names. They carry the same topk and pint
+    # deduplicates identical problems, so it reports KubeQuotaAlmostFull with
+    # KubeQuotaFullyUsed hidden behind it. Scoping only the visible one lets the
+    # duplicate step forward and the count does not move -- the same dynamic
+    # that made --max-problems=50 hide two dozen fixes in #1271.
     rule {
       match {
-        name = "KubeQuotaAlmostFull"
+        name = "KubeQuota(AlmostFull|FullyUsed)"
       }
       disable = ["promql/fragile"]
     }

--- a/k8s/platform/observability/kube-prometheus-stack/values.yaml
+++ b/k8s/platform/observability/kube-prometheus-stack/values.yaml
@@ -30,6 +30,38 @@ defaultRules:
     # etcdHighNumberOfFailedGRPCRequests above, no relabeling change brings this
     # one back.
     etcdGRPCRequestsSlow: true
+
+    # k3s manages kubelet certificates itself, so client-go's certificate
+    # manager never runs and kubelet_certificate_manager_* is never registered.
+    # 134 other kubelet_* families are present on job="kubelet", so this is a
+    # property of k3s rather than a scrape gap, and nothing we configure
+    # changes it.
+    KubeletClientCertificateExpiration: true
+    KubeletClientCertificateRenewalErrors: true
+    KubeletServerCertificateExpiration: true
+    KubeletServerCertificateRenewalErrors: true
+
+    # aggregator_unavailable_apiservice_total was renamed upstream; only the
+    # aggregator_unavailable_apiservice gauge exists on this Kubernetes.
+    KubeAggregatedAPIErrors: true
+
+    # node_md_* comes from node-exporter's mdadm collector, which emits nothing
+    # without /proc/mdstat. No node here has mdraid.
+    NodeRAIDDegraded: true
+
+    # node_systemd_* needs --collector.systemd, off by default and expensive
+    # enough that it is not worth turning on to serve two alerts. If it is ever
+    # enabled, delete these two lines rather than leaving the rules dark.
+    NodeSystemdServiceFailed: true
+    NodeSystemdServiceCrashlooping: true
+
+    # kube_state_metrics_list_total has never existed across the full retention
+    # on kube-state-metrics v2.20.0, while its watch_total counterpart is
+    # populated -- so this is not the telemetry-port gap that selfMonitor above
+    # fixed. Kubernetes 1.32+ enables WatchListClient by default, so reflectors
+    # open a streaming WATCH with sendInitialEvents and never issue a LIST at
+    # all. KubeStateMetricsWatchErrors still covers the failure this was for.
+    KubeStateMetricsListErrors: true
   rules:
     # Both select on job names this release does not create.
     alertmanager: false
@@ -41,6 +73,10 @@ defaultRules:
     kubeSchedulerAlerting: false
     kubeSchedulerRecording: false
     windows: false
+    # The group holds one recording rule,
+    # node_namespace_pod_container:container_memory_swap, and cAdvisor emits
+    # container_memory_swap only with swap accounting on. Swap is off.
+    k8sContainerMemorySwap: false
 
 kubeControllerManager:
   enabled: false


### PR DESCRIPTION
Buckets C and F of the [pint findings worklist](https://claude.ai/code/artifact/9107a3b3-9945-4fef-ac28-c880cd71263c). **Nothing here changes a query.** It stops eleven rules that have never had a metric from reporting forever, and scopes three checks off rules where pint is objecting to something that is not a defect.

`ReconciliationFailure` was deliberately held out of this and rebuilt instead — #1280.

## Disabled: the metric cannot exist on this cluster

| rule | why |
|---|---|
| `KubeletClientCertificateExpiration`<br>`KubeletClientCertificateRenewalErrors`<br>`KubeletServerCertificateExpiration`<br>`KubeletServerCertificateRenewalErrors` | k3s manages kubelet certificates itself, so client-go's certificate manager never runs and `kubelet_certificate_manager_*` is never registered. **134 other `kubelet_*` families are present**, so this is a property of k3s, not a scrape gap. |
| `KubeAggregatedAPIErrors` | `aggregator_unavailable_apiservice_total` was renamed upstream; only the `aggregator_unavailable_apiservice` gauge exists now. |
| `NodeRAIDDegraded` | No mdraid on any node, so node-exporter's mdadm collector emits nothing. |
| `NodeSystemdServiceFailed`<br>`NodeSystemdServiceCrashlooping` | `--collector.systemd` is off by default and expensive enough not to enable for two alerts. If it is ever turned on, delete these two lines rather than leaving the rules dark. |
| `KubeStateMetricsListErrors` | `kube_state_metrics_list_total` has never existed across the full retention on v2.20.0 while `watch_total` **is** populated — so this is not the telemetry-port gap `selfMonitor` fixed in #1273. Kubernetes 1.32+ enables `WatchListClient` by default, so reflectors stream a WATCH with `sendInitialEvents` and never issue a LIST. `KubeStateMetricsWatchErrors` still covers the failure this was for. |
| `k8sContainerMemorySwap` group | One recording rule, and cAdvisor emits `container_memory_swap` only with swap accounting on. Swap is off. |

## Scoped in the pint config instead: the rule is fine

These stay live and keep working — only the check is silenced, and only on these names.

- **`Watchdog` / `alerts/comparison`** — it is *supposed* to always fire. That is what a dead-man's switch is, and Alertmanager's watchdog receiver depends on it firing continuously.
- **`KubeQuota.+` / `promql/fragile`** — a fair criticism of upstream's `topk`, but not ours to rewrite, and there are no ResourceQuotas for it to select from anyway.

  The family match is deliberate, and it took two rounds to get right. pint **deduplicates identical problems**, showing one and hiding the rest: scoping `KubeQuotaAlmostFull` surfaced `KubeQuotaFullyUsed`, and scoping both surfaced `KubeQuotaExceeded`. All three carry the same `topk`, so the count never moved. `kubernetes-resources` holds exactly three `KubeQuota*` rules and all three share the query, which makes `KubeQuota.+` provably complete.

  Worth knowing generally — the lint summary reads `total=133 duplicates=68 shown=65`. **Roughly half of all findings here are hidden duplicates**, so this is the same dynamic that let `--max-problems=50` hide two dozen real fixes until #1271.
- **`SmartCTLDevice.+` / `promql/counter`** — smartctl-exporter declares `smartctl_device_percentage_used`, `_available_spare`, `_available_spare_threshold` and `_critical_warning` as counters in its metadata. They are gauges; a wear level does not accumulate the way `rate()` assumes. Reading them directly is correct and the fix belongs upstream in the exporter.

## Verification

`helm template` of 88.6.2 — every disable checked individually rather than trusting the key names, because a typo'd key in `defaultRules.disabled` fails silently:

```
should be gone:                                should still be there:
  GONE  KubeletClientCertificateExpiration       kept  KubeStateMetricsWatchErrors
  GONE  KubeletClientCertificateRenewalErrors    kept  KubeQuotaAlmostFull
  GONE  KubeletServerCertificateExpiration       kept  Watchdog
  GONE  KubeletServerCertificateRenewalErrors    kept  etcdHighNumberOfFailedGRPCRequests
  GONE  KubeAggregatedAPIErrors                  kept  KubeletDown
  GONE  NodeRAIDDegraded                         kept  NodeFilesystemAlmostOutOfSpace
  GONE  NodeSystemdServiceFailed
  GONE  NodeSystemdServiceCrashlooping
  GONE  KubeStateMetricsListErrors
  GONE  etcdGRPCRequestsSlow
  GONE  node_namespace_pod_container:container_memory_swap
```

`make validate` — 122 targets. `make validate-flux` — 51 paths. The new pint config parses and loads all four `rule` blocks.

## Expected effect

Roughly **60 → 45**, allowing for #1280 landing separately. The floor after this is bucket D plus G — around 34 — which is a steady state rather than a backlog.

## After merge

Two components, so two reconciles:

```bash
flux reconcile source git ankhmorpork
flux -n flux-system reconcile kustomization platform-observability
flux -n platform-observability reconcile helmrelease kube-prometheus-stack
flux -n flux-system reconcile kustomization datalake-metrics   # pint config
```

The pint Deployment restarts on the config change, so allow ~4 minutes for its first check iteration before reading `pint_problems`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
