### PR TITLE
mealie: hold the restic repository on a static NFS volume

### DIFF
--- a/k8s/apps/mealie/backup/kustomization.yaml
+++ b/k8s/apps/mealie/backup/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - pv.yaml
   - pvc.yaml
   - schedule.yaml

--- a/k8s/apps/mealie/backup/pv.yaml
+++ b/k8s/apps/mealie/backup/pv.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: mealie-backup-repo
+  labels:
+    app.kubernetes.io/component: backup
+    app.kubernetes.io/name: mealie
+spec:
+  # Static rather than a dynamically provisioned unifi-nas claim, because that
+  # StorageClass is reclaimPolicy: Delete -- removing the PVC would take the
+  # restic repository with it. A Flux prune or a bad edit should not be able to
+  # destroy the backups. Retain also means the repository outlives the cluster,
+  # which is the point of keeping it as plain restic files.
+  #
+  # One directory per namespace under a single backups export, so a namespace
+  # can only mount its own repository. The path has to exist on the NAS first;
+  # NFS will not create it.
+  accessModes:
+    - ReadWriteMany
+  capacity:
+    # nfs.csi.k8s.io does not enforce the request and neither does a static NFS
+    # mount, so this is a label rather than a reservation.
+    storage: 10Gi
+  nfs:
+    path: /var/nfs/shared/backups/mealie
+    server: 192.168.40.10
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: manual
+  volumeMode: Filesystem

--- a/k8s/apps/mealie/backup/pvc.yaml
+++ b/k8s/apps/mealie/backup/pvc.yaml
@@ -3,6 +3,10 @@ kind: PersistentVolumeClaim
 metadata:
   name: backup-repo
   labels:
+    # NFS on the UNAS: this claim reports the whole share's fill level, not its
+    # own. NASVolumeFillingUp covers the share itself. Set by hand here --
+    # kyverno's mutate-nfs-pvc-alert-exclusion only fires for unifi-nas.
+    excluded_from_alerts: "true"
     app.kubernetes.io/component: backup
     app.kubernetes.io/name: mealie
 spec:
@@ -10,12 +14,10 @@ spec:
   # though the password is shared: a corrupted one then costs a single
   # namespace, restic check stays cheap, and concurrent backups never contend
   # for the same repository lock over an NFSv3 mount with nolock.
-  #
-  # excluded_from_alerts is stamped by kyverno's mutate-nfs-pvc-alert-exclusion
-  # for every unifi-nas claim. Do not add it here.
   accessModes:
     - ReadWriteMany
   resources:
     requests:
       storage: 10Gi
-  storageClassName: unifi-nas
+  storageClassName: manual
+  volumeName: mealie-backup-repo


### PR DESCRIPTION
**Do not merge until `/var/nfs/shared/backups/mealie` exists on the NAS** — the rollout also needs a manual PVC delete, see below.

### Why, beyond matching the movies/tvshows idiom

`unifi-nas` is `reclaimPolicy: Delete`:

```
PV for mealie/backup-repo   RECLAIM: Delete   PATH: mealie/backup-repo-pvc-115cec42-...
PV vod-movies               RECLAIM: Retain   PATH: /var/nfs/shared/movies
```

So removing the PVC removes the restic repository. A Flux prune, a bad kustomization edit or a namespace deletion would silently destroy the backups — which is a poor property for any volume and close to disqualifying for this one. Static PVs are `Retain`.

The dynamic path is also `mealie/backup-repo-pvc-115cec42-…`, a bad thing to be hunting for during a recovery. `/var/nfs/shared/backups/mealie` is findable with an NFS mount and `restic` alone, which is the whole reason the repository is plain files rather than S3 behind a fourth versitygw.

### Layout

One `backups` export, one directory per namespace, one PV each — so a namespace can only mount its own repository. Same shape as `scans/paperless`. Onboarding each further namespace costs one `mkdir` on the NAS.

`excluded_from_alerts` is set by hand: kyverno's `mutate-nfs-pvc-alert-exclusion` only fires for `storageClassName: unifi-nas`.

### Rollout order

`storageClassName` and `volumeName` are immutable on a bound PVC, so Flux cannot update the existing claim in place. Applying this needs the old PVC deleted first, which also deletes the old repository — that is fine and deliberate: it holds only the throwaway snapshot from the restore proof, the first scheduled run has not happened, and Longhorn's `c-gvgagj` still covers this volume throughout.

I will verify the new mount and re-run a backup, `restic check` and a restore afterwards.

Refs #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)