### PR TITLE
csi-nfs: a storage class for backup repositories

### DIFF
--- a/k8s/apps/mealie/backup/pvc.yaml
+++ b/k8s/apps/mealie/backup/pvc.yaml
@@ -6,16 +6,20 @@ metadata:
     app.kubernetes.io/component: backup
     app.kubernetes.io/name: mealie
 spec:
-  # This namespace's restic repository. Repositories stay per-namespace even
-  # though the password is shared: a corrupted one then costs a single
-  # namespace, restic check stays cheap, and concurrent backups never contend
-  # for the same repository lock over an NFSv3 mount with nolock.
+  # This namespace's restic repository, at backups/mealie on the share.
+  # Repositories stay per-namespace even though the password is shared: a
+  # corrupted one then costs a single namespace, restic check stays cheap, and
+  # concurrent backups never contend for the same repository lock over an NFSv3
+  # mount with nolock.
   #
-  # excluded_from_alerts is stamped by kyverno's mutate-nfs-pvc-alert-exclusion
-  # for every unifi-nas claim. Do not add it here.
+  # unifi-nas-backups rather than unifi-nas: a readable, stable path, and
+  # onDelete: retain so removing this claim cannot destroy the repository.
+  #
+  # excluded_from_alerts is stamped by kyverno's mutate-nfs-pvc-alert-exclusion,
+  # which matches any unifi-nas* class. Do not add it here.
   accessModes:
     - ReadWriteMany
   resources:
     requests:
       storage: 10Gi
-  storageClassName: unifi-nas
+  storageClassName: unifi-nas-backups

--- a/k8s/platform/storage/csi-nfs/kustomization.yaml
+++ b/k8s/platform/storage/csi-nfs/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - namespace.yaml
   - release.yaml
   - mutatingpolicy.yaml
+  - storageclass-backups.yaml
 configMapGenerator:
   - name: values-csi-nfs
     files:

--- a/k8s/platform/storage/csi-nfs/mutatingpolicy.yaml
+++ b/k8s/platform/storage/csi-nfs/mutatingpolicy.yaml
@@ -49,7 +49,7 @@ spec:
   matchConditions:
     - name: only-nfs-storage-class
       expression: >-
-        object.spec.?storageClassName.orValue("") == "unifi-nas"
+        object.spec.?storageClassName.orValue("").startsWith("unifi-nas")
   mutations:
     - patchType: ApplyConfiguration
       applyConfiguration:

--- a/k8s/platform/storage/csi-nfs/storageclass-backups.yaml
+++ b/k8s/platform/storage/csi-nfs/storageclass-backups.yaml
@@ -1,0 +1,32 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: unifi-nas-backups
+# A second class rather than a knob on the chart's, which only renders one.
+#
+# Two things differ from unifi-nas, and both matter only for backups:
+#
+#   subDir has no ${pv.metadata.name}, so the path is backups/<namespace> --
+#   stable and readable. A recovery means mounting the share and running restic
+#   against backups/mealie, not hunting for
+#   backup-repo-pvc-115cec42-f8a6-47a6-ad0f-60bd470735c0. It also makes
+#   provisioning idempotent: a recreated claim lands on its existing repository
+#   rather than an empty directory.
+#
+#   onDelete: retain keeps that directory when the volume goes. The default is
+#   delete, which means removing a PVC destroys the repository -- a Flux prune
+#   or a bad edit should not be able to do that to the backups.
+provisioner: nfs.csi.k8s.io
+parameters:
+  server: 192.168.40.10
+  share: /var/nfs/shared/k8snfscsi
+  subDir: backups/${pvc.metadata.namespace}
+  onDelete: retain
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+mountOptions:
+  # Kept identical to unifi-nas; see that class for why each is set.
+  - nfsvers=3
+  - nolock
+  - nconnect=4
+  - noatime


### PR DESCRIPTION
Keeps CSI NFS dynamic provisioning — no hand-managed NAS volume — while putting every repository under one `backups/` folder with a readable subfolder per namespace.

### Two changes from `unifi-nas`, both only relevant to backups

**`onDelete: retain`.** `unifi-nas` is `reclaimPolicy: Delete` and the driver defaults `onDelete` to `delete`, so removing a PVC removed the restic repository with it:

```
PV for mealie/backup-repo   RECLAIM: Delete   PATH: mealie/backup-repo-pvc-115cec42-...
```

A Flux prune, a bad kustomization edit or a namespace deletion would silently destroy the backups. `onDelete: retain` keeps the directory when the volume goes. (Verified present in the deployed v4.13.4 — `pkg/nfs/controllerserver.go:141`, parameter matching is case-insensitive.)

**`subDir: backups/${pvc.metadata.namespace}`.** Dropping `${pv.metadata.name}` gives `backups/mealie` instead of `backup-repo-pvc-115cec42-f8a6-47a6-ad0f-60bd470735c0`. A recovery then means mounting the share and running `restic` against `backups/mealie` — which is the entire reason for keeping plain restic files rather than S3 behind a fourth versitygw.

It also makes provisioning **idempotent**: because the path no longer contains the PV name, a recreated claim lands on its existing repository rather than an empty directory. That is what makes `onDelete: retain` genuinely useful rather than merely tidy.

### Why a separate class

The `csi-driver-nfs` chart renders only one StorageClass, so this is a hand-written manifest — the same shape as `longhorn-r2` sitting beside the longhorn chart's own class.

### Policy change

`mutate-nfs-pvc-alert-exclusion` matched `== "unifi-nas"` exactly; it now matches `unifi-nas*`. The policy describes how this driver provisions — every claim reporting the whole share's fill level rather than its own — which is as true of the new class as the old.

### Note on one PV for everything

Worth saying explicitly: a single PV shared by all namespaces is not possible. PVCs are namespace-scoped and PV↔PVC binding is one-to-one, so per-namespace Schedules need a claim each. This gets the intent — one location, one readable subfolder per namespace, nothing to create by hand — the only way the API allows.

### Rollout

`storageClassName` is immutable on a bound PVC, so the existing `mealie/backup-repo` has to be deleted and recreated. That discards the current repository, which holds only the throwaway snapshot from the restore proof; the first scheduled run has not happened and Longhorn's `c-gvgagj` still covers the volume. I will re-run the backup, `restic check` and a restore afterwards.

Refs #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)