### PR TITLE
kyverno: roll workloads when the ConfigMap they read changes

### DIFF
--- a/k8s/apps/datalake-metrics/pint/deployment.yaml
+++ b/k8s/apps/datalake-metrics/pint/deployment.yaml
@@ -1,6 +1,17 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    # pint reads its config once at startup and has no reload endpoint, so a
+    # change to pint-config used to sit in the mounted volume unread until
+    # something happened to restart the Pod -- nothing did. #1281's three check
+    # scopes were live in the ConfigMap for six hours while pint went on
+    # reporting the six findings they silence.
+    #
+    # mutate-configmap-autoreload stamps this ConfigMap's resourceVersion into
+    # the pod template on every apply, so a change to it rolls the Pod on Flux's
+    # next reconcile.
+    autoreloader.thaum.xyz/configmap: pint-config
   labels:
     app.kubernetes.io/component: linter
     app.kubernetes.io/name: pint

--- a/k8s/platform/security/kyverno/policies/kustomization.yaml
+++ b/k8s/platform/security/kyverno/policies/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - validate-pdb-drain-safety.yaml
   - validate-helm-chart-version.yaml
   - validate-ingress-contract.yaml
+  - mutate-configmap-autoreload.yaml

--- a/k8s/platform/security/kyverno/policies/mutate-configmap-autoreload.yaml
+++ b/k8s/platform/security/kyverno/policies/mutate-configmap-autoreload.yaml
@@ -1,0 +1,89 @@
+apiVersion: policies.kyverno.io/v1
+kind: MutatingPolicy
+metadata:
+  # Cluster-scoped. kustomize cannot know that for a CRD kind and stamps the
+  # component's namespace on it in the rendered output; the API server ignores
+  # the field for cluster-scoped resources.
+  name: mutate-configmap-autoreload
+spec:
+  # A Pod mounting a ConfigMap sees file changes -- kubelet syncs the volume --
+  # but a process that reads its config once at startup never notices. pint is
+  # the case that surfaced this: #1281 merged three new check scopes into
+  # pint-config, the ConfigMap in the cluster carried them within minutes, and
+  # pint went on reporting six findings against a config that no longer objected
+  # to them, because nothing had restarted it. The pod template has no checksum
+  # annotation and the ConfigMap has a stable name, so a content change alters
+  # nothing the Deployment references.
+  #
+  # This stamps the referenced ConfigMap's resourceVersion into the pod template,
+  # which changes when the ConfigMap does, which rolls the Pods.
+  #
+  # Admission only, deliberately, and this is why it is written the way it is.
+  # The obvious shape -- match on the ConfigMap changing and mutate the
+  # Deployment -- is a mutate-existing rule, and an admission webhook can only
+  # mutate the object being admitted. mutate-existing needs kyverno's background
+  # controller, which is disabled in this cluster
+  # (k8s/platform/security/kyverno/controllers/values.yaml: "Generate rules and
+  # mutate-existing rules are not part of the initial use case"), where it would
+  # only park UpdateRequests in Pending forever -- the same trap already
+  # recorded on mutate-nfs-pvc-alert-exclusion.
+  #
+  # So the trigger is inverted: the Deployment is the admitted object, and it is
+  # stamped with the ConfigMap's version whenever it is applied. Flux re-applies
+  # every workload on its Kustomization interval -- 5m for datalake-metrics -- so
+  # that is the worst-case delay between a ConfigMap change and the rollout.
+  #
+  # No new RBAC: kyverno:admission-controller already holds get/list/watch on
+  # configmaps. Secrets are deliberately not covered -- the admission controller
+  # has no secrets permission, and granting it read on every Secret in the
+  # cluster is a decision to take on its own merits, not a side effect of this.
+  evaluation:
+    background:
+      enabled: false
+  # Ignore, not Fail. This policy runs on every Deployment and StatefulSet
+  # admission, including Flux's. A missing or renamed ConfigMap makes
+  # resource.Get error, and with Fail that would block the apply rather than
+  # skip the stamp. Failing open costs a stale Pod; failing closed costs the
+  # ability to deploy.
+  failurePolicy: Ignore
+  matchConstraints:
+    resourceRules:
+      - apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - deployments
+          - statefulsets
+  matchConditions:
+    # Opt-in per workload rather than by labelling the ConfigMap. Naming the
+    # ConfigMap here keeps it to one API read per admission instead of a
+    # comprehension over every volume, env and envFrom entry, and makes it
+    # visible in the workload's own manifest which config it reloads on.
+    - name: opted-in
+      expression: >-
+        has(object.metadata.annotations) &&
+        object.metadata.annotations.exists(k, k == "autoreloader.thaum.xyz/configmap")
+  variables:
+    - name: cmname
+      expression: >-
+        object.metadata.annotations["autoreloader.thaum.xyz/configmap"]
+    - name: cmversion
+      expression: >-
+        resource.Get("v1", "configmaps", object.metadata.namespace, variables.cmname).metadata.resourceVersion
+  mutations:
+    - patchType: ApplyConfiguration
+      applyConfiguration:
+        expression: >-
+          Object{
+            spec: Object.spec{
+              template: Object.spec.template{
+                metadata: Object.spec.template.metadata{
+                  annotations: {"autoreloader.thaum.xyz/version": variables.cmversion}
+                }
+              }
+            }
+          }


### PR DESCRIPTION
## The problem

A Pod mounting a ConfigMap sees file changes — kubelet syncs the volume — but a process that reads its config once at startup never notices.

pint is the case that surfaced it. #1281 merged three new check scopes into `pint-config`; the ConfigMap in the cluster carried them within minutes; and **pint went on reporting the six findings they silence for six hours**, because nothing had restarted it. Its pod template has no checksum annotation and the ConfigMap has a stable name, so a content change alters nothing the Deployment references and no rollout is triggered. That config would have sat unread indefinitely.

A linter running a config nobody can tell is stale is a worse problem than the noise it was meant to remove.

## Why the trigger is inverted

The obvious shape — *match the ConfigMap changing, mutate the Deployment* — is a **mutate-existing** rule, because an admission webhook can only mutate the object being admitted. Mutate-existing needs kyverno's background controller, which is disabled here on purpose:

```yaml
# Generate rules and mutate-existing rules are not part of the initial use case.
backgroundController:
  enabled: false
```

Enabled anyway, it would park UpdateRequests in Pending forever — the trap already recorded on `mutate-nfs-pvc-alert-exclusion`.

So the Deployment is the admitted object and carries the stamp:

```
ConfigMap changes  ->  resourceVersion bumps
Flux reconciles    ->  webhook stamps the new value into the pod template
                   ->  template changed -> rollout
```

Flux re-applies every workload on its Kustomization interval — **5m** for `datalake-metrics` — which is the worst-case delay.

## What it costs

Nothing to run. No background controller, and `kyverno:admission-controller` already holds `get/list/watch` on configmaps, so there is no new RBAC.

**Secrets are deliberately not covered.** `resource.Get` on a Secret needs the admission controller to read every Secret in the cluster. That is a privilege decision to take on its own merits, not a side effect of this — and worth taking separately, since there are 69 ExternalSecrets whose rotations restart nothing today.

## Verification

Policy applied to the live cluster, exercised, then removed. All four behaviours:

| case | result |
|---|---|
| opted-in Deployment | stamped `1097316597`, matching `pint-config` exactly |
| same, server-side apply as `kustomize-controller` | stamped `1097316597` |
| Deployment without the annotation | untouched, no stamp |
| opted in, ConfigMap missing | no stamp, **apply still admitted** |

That last row is why it is `failurePolicy: Ignore`. This policy runs on every Deployment and StatefulSet admission including Flux's; a renamed ConfigMap must not be able to block deploys. Failing open costs a stale Pod, failing closed costs the ability to deploy.

`make validate` — 122 targets. `make validate-flux` — 51 paths.

## Design notes

- **Opt-in by annotation on the workload**, not by labelling the ConfigMap. One API read per admission instead of a comprehension over every volume, env and envFrom entry — and it is visible in the workload's own manifest which config it reloads on.
- **`policies.kyverno.io/v1 MutatingPolicy`**, matching all five existing policies here rather than the legacy `kyverno.io/v2beta1 ClusterPolicy`.
- **Deployments and StatefulSets** both, though only pint uses it today.
- The stamp is stable while the ConfigMap is — same version in, same value out — so a re-apply is a no-op and cannot churn.

## After merge

pint opts in as the first consumer, so expect one rollout of `deploy/pint` on the next reconcile, which also picks up #1281's three check scopes it has never read. That should take `pint_problems` **50 → 44**.

`ups`, `karakeep` and `grafana-datasource-cm` mount plain ConfigMaps the same way and can adopt it whenever it is worth a rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)