### PR TITLE
observability: one budget engine — Pyrra, not the mixin

### DIFF
--- a/k8s/apps/datalake-metrics/prometheus/prometheusrule.yaml
+++ b/k8s/apps/datalake-metrics/prometheus/prometheusrule.yaml
@@ -61,22 +61,6 @@ spec:
           for: 15m
           labels:
             severity: warning
-        - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
-          annotations:
-            description: '{{ printf "%.1f" $value }}% errors while sending alerts from Prometheus {{$labels.instance}} to Alertmanager {{$labels.alertmanager}}.'
-            runbook_url: https://runbooks.thaum.xyz/runbooks/prometheus/prometheuserrorsendingalertstosomealertmanagers
-            summary: Prometheus has encountered more than 1% errors sending alerts to a specific Alertmanager.
-          expr: |
-            (
-              rate(prometheus_notifications_errors_total{job="prometheus-k8s"}[5m])
-            /
-              rate(prometheus_notifications_sent_total{job="prometheus-k8s"}[5m])
-            )
-            * 100
-            > 1
-          for: 15m
-          labels:
-            severity: warning
         - alert: PrometheusNotConnectedToAlertmanagers
           annotations:
             description: Prometheus {{$labels.instance}} is not connected to any Alertmanagers.
@@ -200,16 +184,6 @@ spec:
           for: 15m
           labels:
             severity: warning
-        - alert: PrometheusRuleFailures
-          annotations:
-            description: Prometheus {{$labels.instance}} has failed to evaluate {{ printf "%.0f" $value }} rules in the last 5m.
-            runbook_url: https://runbooks.thaum.xyz/runbooks/prometheus/prometheusrulefailures
-            summary: Prometheus is failing rule evaluations.
-          expr: |
-            increase(prometheus_rule_evaluation_failures_total{job="prometheus-k8s"}[5m]) > 0
-          for: 15m
-          labels:
-            severity: critical
         - alert: PrometheusMissingRuleEvaluations
           annotations:
             description: Prometheus {{$labels.instance}} has missed {{ printf "%.0f" $value }} rule group evaluations in the last 5m.
@@ -280,19 +254,3 @@ spec:
           for: 15m
           labels:
             severity: warning
-        - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
-          annotations:
-            description: '{{ printf "%.1f" $value }}% minimum errors while sending alerts from Prometheus {{$labels.instance}} to any Alertmanager.'
-            runbook_url: https://runbooks.thaum.xyz/runbooks/prometheus/prometheuserrorsendingalertstoanyalertmanager
-            summary: Prometheus encounters more than 3% errors sending alerts to any Alertmanager.
-          expr: |
-            min without (alertmanager) (
-              rate(prometheus_notifications_errors_total{job="prometheus-k8s",alertmanager!~``}[5m])
-            /
-              rate(prometheus_notifications_sent_total{job="prometheus-k8s",alertmanager!~``}[5m])
-            )
-            * 100
-            > 3
-          for: 15m
-          labels:
-            severity: critical

--- a/k8s/apps/datalake-metrics/pyrra/slo-apiserver-read-cluster-latency.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/slo-apiserver-read-cluster-latency.yaml
@@ -6,19 +6,25 @@ metadata:
     role: alert-rules
   name: apiserver-read-cluster-latency
 spec:
-  # le must name a bucket that survives kube-prometheus-stack's cardinality
-  # drop on the apiserver ServiceMonitor, which discards
-  # apiserver_request_duration_seconds_bucket for le 1.5 among others. k3s
-  # serves one merged registry, so the kubelet endpoint re-exports these same
-  # metrics without that drop: at le=1.5 the numerator had only job="kubelet"
-  # while the denominator had both jobs, and the SLO read 51% against a 99%
-  # target. 1.0 is kept on both jobs, and is the stricter objective anyway.
+  # Measures apiserver_request_sli_duration_seconds, not the raw
+  # apiserver_request_duration_seconds: the SLI variant is the apiserver's own,
+  # excluding time spent in admission webhooks and priority-and-fairness
+  # queueing. It is what kubernetes-mixin's KubeAPIErrorBudgetBurn measured
+  # before this SLO took the budget over, so keeping the same metric keeps the
+  # same definition -- the raw histogram would bill someone else's webhook
+  # latency to the apiserver.
+  #
+  # le must name a bucket that survives the cardinality drop on the apiserver
+  # ServiceMonitor. The SLI variant keeps 0.05, 0.1, 1.0, 5.0, 10.0, 30.0 and
+  # 60.0 -- there is no 0.25 to reach for.
   description: ""
+  alerting:
+    name: APIServerReadClusterLatencyBudgetBurn
   indicator:
     latency:
       success:
-        metric: apiserver_request_duration_seconds_bucket{component="apiserver",scope=~"cluster|",verb=~"LIST|GET",le="1.0"}
+        metric: apiserver_request_sli_duration_seconds_bucket{component="apiserver",scope=~"cluster|",verb=~"LIST|GET",le="1.0"}
       total:
-        metric: apiserver_request_duration_seconds_count{component="apiserver",scope=~"cluster|",verb=~"LIST|GET"}
+        metric: apiserver_request_sli_duration_seconds_count{component="apiserver",scope=~"cluster|",verb=~"LIST|GET"}
   target: "99"
   window: 2w

--- a/k8s/apps/datalake-metrics/pyrra/slo-apiserver-read-cluster-latency.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/slo-apiserver-read-cluster-latency.yaml
@@ -19,7 +19,7 @@ spec:
   # 60.0 -- there is no 0.25 to reach for.
   description: ""
   alerting:
-    name: APIServerReadClusterLatencyBudgetBurn
+    name: KubeAPIServerReadClusterLatencyBudgetBurn
   indicator:
     latency:
       success:

--- a/k8s/apps/datalake-metrics/pyrra/slo-apiserver-read-namespace-latency.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/slo-apiserver-read-namespace-latency.yaml
@@ -19,7 +19,7 @@ spec:
   # 60.0 -- there is no 0.25 to reach for.
   description: ""
   alerting:
-    name: APIServerReadNamespaceLatencyBudgetBurn
+    name: KubeAPIServerReadNamespaceLatencyBudgetBurn
   indicator:
     latency:
       success:

--- a/k8s/apps/datalake-metrics/pyrra/slo-apiserver-read-namespace-latency.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/slo-apiserver-read-namespace-latency.yaml
@@ -6,19 +6,25 @@ metadata:
     role: alert-rules
   name: apiserver-read-namespace-latency
 spec:
-  # le must name a bucket that survives kube-prometheus-stack's cardinality
-  # drop on the apiserver ServiceMonitor, which discards
-  # apiserver_request_duration_seconds_bucket for le 1.5 among others. k3s
-  # serves one merged registry, so the kubelet endpoint re-exports these same
-  # metrics without that drop: at le=1.5 the numerator had only job="kubelet"
-  # while the denominator had both jobs, and the SLO read 51% against a 99%
-  # target. 1.0 is kept on both jobs, and is the stricter objective anyway.
+  # Measures apiserver_request_sli_duration_seconds, not the raw
+  # apiserver_request_duration_seconds: the SLI variant is the apiserver's own,
+  # excluding time spent in admission webhooks and priority-and-fairness
+  # queueing. It is what kubernetes-mixin's KubeAPIErrorBudgetBurn measured
+  # before this SLO took the budget over, so keeping the same metric keeps the
+  # same definition -- the raw histogram would bill someone else's webhook
+  # latency to the apiserver.
+  #
+  # le must name a bucket that survives the cardinality drop on the apiserver
+  # ServiceMonitor. The SLI variant keeps 0.05, 0.1, 1.0, 5.0, 10.0, 30.0 and
+  # 60.0 -- there is no 0.25 to reach for.
   description: ""
+  alerting:
+    name: APIServerReadNamespaceLatencyBudgetBurn
   indicator:
     latency:
       success:
-        metric: apiserver_request_duration_seconds_bucket{component="apiserver",scope=~"namespace|",verb=~"LIST|GET",le="1.0"}
+        metric: apiserver_request_sli_duration_seconds_bucket{component="apiserver",scope=~"namespace|",verb=~"LIST|GET",le="1.0"}
       total:
-        metric: apiserver_request_duration_seconds_count{component="apiserver",scope=~"namespace|",verb=~"LIST|GET"}
+        metric: apiserver_request_sli_duration_seconds_count{component="apiserver",scope=~"namespace|",verb=~"LIST|GET"}
   target: "99"
   window: 2w

--- a/k8s/apps/datalake-metrics/pyrra/slo-apiserver-read-resource-latency.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/slo-apiserver-read-resource-latency.yaml
@@ -19,7 +19,7 @@ spec:
   # 60.0 -- there is no 0.25 to reach for.
   description: ""
   alerting:
-    name: APIServerReadResourceLatencyBudgetBurn
+    name: KubeAPIServerReadResourceLatencyBudgetBurn
   indicator:
     latency:
       success:

--- a/k8s/apps/datalake-metrics/pyrra/slo-apiserver-read-resource-latency.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/slo-apiserver-read-resource-latency.yaml
@@ -6,12 +6,25 @@ metadata:
     role: alert-rules
   name: apiserver-read-resource-latency
 spec:
+  # Measures apiserver_request_sli_duration_seconds, not the raw
+  # apiserver_request_duration_seconds: the SLI variant is the apiserver's own,
+  # excluding time spent in admission webhooks and priority-and-fairness
+  # queueing. It is what kubernetes-mixin's KubeAPIErrorBudgetBurn measured
+  # before this SLO took the budget over, so keeping the same metric keeps the
+  # same definition -- the raw histogram would bill someone else's webhook
+  # latency to the apiserver.
+  #
+  # le must name a bucket that survives the cardinality drop on the apiserver
+  # ServiceMonitor. The SLI variant keeps 0.05, 0.1, 1.0, 5.0, 10.0, 30.0 and
+  # 60.0 -- there is no 0.25 to reach for.
   description: ""
+  alerting:
+    name: APIServerReadResourceLatencyBudgetBurn
   indicator:
     latency:
       success:
-        metric: apiserver_request_duration_seconds_bucket{component="apiserver",scope=~"resource|",verb=~"LIST|GET",le="0.1"}
+        metric: apiserver_request_sli_duration_seconds_bucket{component="apiserver",scope=~"resource|",verb=~"LIST|GET",le="0.1"}
       total:
-        metric: apiserver_request_duration_seconds_count{component="apiserver",scope=~"resource|",verb=~"LIST|GET"}
+        metric: apiserver_request_sli_duration_seconds_count{component="apiserver",scope=~"resource|",verb=~"LIST|GET"}
   target: "99"
   window: 2w

--- a/k8s/apps/datalake-metrics/pyrra/slo-apiserver-read-response-errors.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/slo-apiserver-read-response-errors.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   description: ""
   alerting:
-    name: APIServerReadBudgetBurn
+    name: KubeAPIServerReadErrorBudgetBurn
   indicator:
     ratio:
       errors:

--- a/k8s/apps/datalake-metrics/pyrra/slo-apiserver-read-response-errors.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/slo-apiserver-read-response-errors.yaml
@@ -7,6 +7,8 @@ metadata:
   name: apiserver-read-response-errors
 spec:
   description: ""
+  alerting:
+    name: APIServerReadBudgetBurn
   indicator:
     ratio:
       errors:

--- a/k8s/apps/datalake-metrics/pyrra/slo-apiserver-write-response-errors.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/slo-apiserver-write-response-errors.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   description: ""
   alerting:
-    name: APIServerWriteBudgetBurn
+    name: KubeAPIServerWriteErrorBudgetBurn
   indicator:
     ratio:
       errors:

--- a/k8s/apps/datalake-metrics/pyrra/slo-apiserver-write-response-errors.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/slo-apiserver-write-response-errors.yaml
@@ -7,6 +7,8 @@ metadata:
   name: apiserver-write-response-errors
 spec:
   description: ""
+  alerting:
+    name: APIServerWriteBudgetBurn
   indicator:
     ratio:
       errors:

--- a/k8s/apps/datalake-metrics/pyrra/slo-coredns-response-errors.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/slo-coredns-response-errors.yaml
@@ -7,6 +7,8 @@ metadata:
   name: coredns-response-errors
 spec:
   description: ""
+  alerting:
+    name: CoreDNSBudgetBurn
   indicator:
     ratio:
       errors:

--- a/k8s/apps/datalake-metrics/pyrra/slo-ingress.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/slo-ingress.yaml
@@ -3,6 +3,8 @@ kind: ServiceLevelObjective
 metadata:
   name: blackbox-probe-success
 spec:
+  alerting:
+    name: ProbeBudgetBurn
   indicator:
     bool_gauge:
       grouping:

--- a/k8s/apps/datalake-metrics/pyrra/slo-kubelet-request-errors.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/slo-kubelet-request-errors.yaml
@@ -7,6 +7,8 @@ metadata:
   name: kubelet-request-errors
 spec:
   description: ""
+  alerting:
+    name: KubeletClientBudgetBurn
   indicator:
     ratio:
       errors:

--- a/k8s/apps/datalake-metrics/pyrra/slo-kubelet-runtime-errors.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/slo-kubelet-runtime-errors.yaml
@@ -7,6 +7,8 @@ metadata:
   name: kubelet-runtime-errors
 spec:
   description: ""
+  alerting:
+    name: KubeletRuntimeBudgetBurn
   indicator:
     ratio:
       errors:

--- a/k8s/apps/datalake-metrics/pyrra/slo-prometheus-notification-errors.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/slo-prometheus-notification-errors.yaml
@@ -7,6 +7,8 @@ metadata:
   name: prometheus-notification-errors
 spec:
   description: ""
+  alerting:
+    name: PrometheusNotificationBudgetBurn
   indicator:
     ratio:
       errors:

--- a/k8s/apps/datalake-metrics/pyrra/slo-prometheus-operator-http-errors.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/slo-prometheus-operator-http-errors.yaml
@@ -7,6 +7,8 @@ metadata:
   name: prometheus-operator-http-errors
 spec:
   description: ""
+  alerting:
+    name: PrometheusOperatorHTTPBudgetBurn
   indicator:
     ratio:
       errors:

--- a/k8s/apps/datalake-metrics/pyrra/slo-prometheus-operator-reconcile-errors.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/slo-prometheus-operator-reconcile-errors.yaml
@@ -7,6 +7,8 @@ metadata:
   name: prometheus-operator-reconcile-errors
 spec:
   description: ""
+  alerting:
+    name: PrometheusOperatorReconcileBudgetBurn
   indicator:
     ratio:
       errors:

--- a/k8s/apps/datalake-metrics/pyrra/slo-prometheus-query-errors.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/slo-prometheus-query-errors.yaml
@@ -7,6 +7,8 @@ metadata:
   name: prometheus-query-errors
 spec:
   description: ""
+  alerting:
+    name: PrometheusQueryBudgetBurn
   indicator:
     ratio:
       errors:

--- a/k8s/apps/datalake-metrics/pyrra/slo-prometheus-rule-evaluation-failures.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/slo-prometheus-rule-evaluation-failures.yaml
@@ -7,6 +7,8 @@ metadata:
   name: prometheus-rule-evaluation-failures
 spec:
   description: Rule and alerting rules are being evaluated every few seconds. This needs to work for recording rules to be created and most importantly for alerts to be evaluated.
+  alerting:
+    name: PrometheusRuleEvaluationBudgetBurn
   indicator:
     ratio:
       errors:

--- a/k8s/apps/datalake-metrics/pyrra/slo-prometheus-sd-kubernetes-errors.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/slo-prometheus-sd-kubernetes-errors.yaml
@@ -7,6 +7,8 @@ metadata:
   name: prometheus-sd-kubernetes-errors
 spec:
   description: If there are too many errors Prometheus is having a bad time discovering new Kubernetes services.
+  alerting:
+    name: PrometheusSDKubernetesBudgetBurn
   indicator:
     ratio:
       errors:

--- a/k8s/platform/observability/kube-prometheus-stack/values.yaml
+++ b/k8s/platform/observability/kube-prometheus-stack/values.yaml
@@ -21,8 +21,9 @@ grafana:
 
 defaultRules:
   create: true
-  # Alerts whose metric cannot exist on this cluster, so they can only ever
-  # report as pint findings.
+  # Two reasons an alert lands here: its metric cannot exist on this cluster, so
+  # the rule can only ever report as a pint finding; or a Pyrra SLO measures the
+  # same thing and owns the budget instead. The second kind names its SLO.
   disabled:
     # Needs grpc_server_handling_seconds_bucket, which k3s's embedded etcd does
     # not export at all: the endpoint serves grpc_server_handled_total,
@@ -62,6 +63,14 @@ defaultRules:
     # open a streaming WATCH with sendInitialEvents and never issue a LIST at
     # all. KubeStateMetricsWatchErrors still covers the failure this was for.
     KubeStateMetricsListErrors: true
+
+    # Superseded by the prometheus-operator-reconcile-errors Pyrra SLO, which
+    # divides the same two counters over a window instead of thresholding a 5m
+    # rate. One budget engine: where a mixin alert and an SLO measure the same
+    # thing, the SLO wins. Its siblings stay -- PrometheusOperatorListErrors and
+    # PrometheusOperatorWatchErrors read *_operations_failed_total, which the
+    # prometheus-operator-http-errors SLO does not cover.
+    PrometheusOperatorReconcileErrors: true
   rules:
     # Both select on job names this release does not create.
     alertmanager: false
@@ -77,6 +86,22 @@ defaultRules:
     # node_namespace_pod_container:container_memory_swap, and cAdvisor emits
     # container_memory_swap only with swap accounting on. Swap is off.
     k8sContainerMemorySwap: false
+
+    # KubeAPIErrorBudgetBurn and the burnrate records that feed it. The five
+    # apiserver-* Pyrra SLOs measure the same requests, and both sides recorded
+    # apiserver_request:burnrate30m and :burnrate1h -- the mixin labelled
+    # verb=read|write, Pyrra labelled slo=. KubeAPIErrorBudgetBurn then reads
+    # `sum by (cluster) (...)`, and no series here carries a cluster label, so
+    # the sum collapsed every producer into one number and compared four
+    # unrelated burn rates against one threshold. Nothing but the slos group
+    # ever read the burnrate records, so both groups go together.
+    #
+    # kubeApiserverAvailability and kubeApiserverHistogram stay: they are
+    # recording rules only, and the chart's own kube-apiserver dashboard reads
+    # apiserver_request:availability30d and
+    # cluster_quantile:apiserver_request_sli_duration_seconds:histogram_quantile.
+    kubeApiserverSlos: false
+    kubeApiserverBurnrate: false
 
 kubeControllerManager:
   enabled: false


### PR DESCRIPTION
Phase 6a of the SLI/SLO plan. Where a chart mixin alert and a Pyrra SLO measure the same thing, the mixin alert is retired and the SLO stays.

## Why

`apiserver_request:burnrate30m` and `:burnrate1h` had **three producers** — kubernetes-mixin's `kube-apiserver-burnrate.rules` (labelled `verb=read|write`) and the `apiserver-read-response-errors` / `apiserver-write-response-errors` SLOs (labelled `slo=…`). `KubeAPIErrorBudgetBurn` evaluates `sum by (cluster) (…)`, and no series here carries a `cluster` label — pint flags exactly that as `promql/impossible` — so the `sum by` collapsed every producer into one number and compared the sum of four unrelated burn rates against one threshold. It had not fired only because each polluted arm is `and`-ed with a clean one (`burnrate5m`, `burnrate6h`).

Patching the query would leave two systems owning one metric name. Picking one is the repair.

The deciding argument for picking Pyrra: every SLO also generates `SLOMetricAbsent` — `absent(metric{selectors}) == 1`, `for: 1m`. An SLO cannot silently measure nothing, because the absence of the series is itself the alert. That is the structural antidote to this cluster's recurring failure mode.

## What changes

| retire | keep | mechanism |
|---|---|---|
| `KubeAPIErrorBudgetBurn` ×4 | the 5 `apiserver-*` SLOs | `defaultRules.rules.kubeApiserverSlos: false` |
| `apiserver_request:burnrate*` ×7 records | Pyrra's own burnrates | `defaultRules.rules.kubeApiserverBurnrate: false` |
| `PrometheusOperatorReconcileErrors` | `prometheus-operator-reconcile-errors` | `defaultRules.disabled` |
| `PrometheusErrorSendingAlertsToAny`/`…Some` | `prometheus-notification-errors` | deleted from `prometheusrule.yaml` |
| `PrometheusRuleFailures` | `prometheus-rule-evaluation-failures` | deleted from `prometheusrule.yaml` |

Plus: the three latency SLOs move to `apiserver_request_sli_duration_seconds`, and every SLO gets `spec.alerting.name`.

## What deliberately stays

- **`kubeApiserverAvailability` / `kubeApiserverHistogram`** — recording rules only, and the chart's kube-apiserver dashboard reads `apiserver_request:availability30d` and the SLI histogram quantile. Verified by rendering: nothing but the `slos` group ever read the burnrate records.
- **`PrometheusOperatorListErrors` / `…WatchErrors`** — they read `*_operations_failed_total`; the operator HTTP SLO reads `…client_http_requests_total{status_code=~"5.."}`. Different metrics.
- **`PrometheusKubernetesListWatchFailures`** — reads `prometheus_sd_kubernetes_failures_total`, not the SLO's `…http_request_total`. Retiring it would be a silent loss of coverage.

## Behaviour changes worth reviewing

**Rule-evaluation failures.** `PrometheusRuleFailures` fired on any failure sustained 15m. The SLO is 99.99%/2w — roughly two minutes of failing evaluations before the budget is gone. Its 3m/30m fast burn reacts sooner to a real outage and ignores a single transient blip. Probably what we want, but it is not like-for-like.

**Apiserver latency definition.** The SLI histogram excludes admission-webhook and priority-and-fairness wait. That is what the mixin measured, so this preserves the definition rather than changing it — but the numbers will differ from the raw histogram the SLOs used yesterday.

## Not in this PR

`spec.alerting.severities` — the deployed CRD accepts it (confirmed by server-side dry-run) but the datreeio CRDs-catalog schema CI validates against predates the field, so `make validate` rejects it. Left out rather than loosening validation. **This is not a regression:** critical rules go from 54 to 52 with this PR, since the two `KubeAPIErrorBudgetBurn` criticals are removed and no Pyrra severity changes.

## Verification

```
make validate        # 122 targets render and validate cleanly
make validate-flux   # 51 live Flux Kustomization paths exist
make prometheusrules # 84 entries, 1 pre-existing warning (LonghornNodeDown)
```

Render checks against chart 88.6.2 with this repo's values:

| | |
|---|---|
| `KubeAPIErrorBudgetBurn` | 4 → 0 |
| `apiserver_request:burnrate*` records | 14 → 0 |
| `PrometheusOperatorReconcileErrors` | 1 → 0 |
| `PrometheusOperatorListErrors` / `WatchErrors` | 1 / 1, unchanged |
| `apiserver_request:availability30d` | 3, unchanged |
| `cluster_quantile:apiserver_request_sli…` | 2, unchanged |

New SLI selectors confirmed against live Prometheus — cluster 407 series, namespace 1050, resource 523. An SLO over a selector matching nothing reads as a perfect 100%, so this mattered.

## After merge

Reconcile order matters — the Kustomization regenerates the ConfigMap, and only then does the HelmRelease see new values:

```
flux reconcile source git ankhmorpork
flux -n flux-system reconcile kustomization platform-observability
flux -n platform-observability reconcile helmrelease kube-prometheus-stack
```

Then confirm `count(apiserver_request:burnrate1h) == 1` — one producer left — and that `count by (alertname) (ALERTS{slo!=""})` shows one name per SLO rather than two names total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)