### PR TITLE
pint: accept the findings that describe a quiet cluster, not a broken rule

### DIFF
--- a/k8s/apps/datalake-metrics/pint/configmap.yaml
+++ b/k8s/apps/datalake-metrics/pint/configmap.yaml
@@ -72,6 +72,95 @@ data:
       disable = ["promql/counter"]
     }
 
+    # ---- Accepted promql/series findings -------------------------------
+    #
+    # Everything below is a rule that works, reported because the series it
+    # selects is not present *right now*. They are permanent findings, and the
+    # PintRuleProblems alert fires on pint_problems > 0, so left alone they keep
+    # issue #1237 open forever and train everyone to ignore it.
+    #
+    # Two things to know before adding to this list.
+    #
+    # pint's config file cannot disable a check for a single metric --
+    # `promql/series(kubelet_evictions)` is rejected with "unknown check name";
+    # that syntax only works as a comment inside the rule file, which is not an
+    # option for chart-generated rules. So every entry here disables
+    # promql/series for the whole rule, and a later rename or typo in any metric
+    # that rule reads goes unnoticed.
+    #
+    # That is why only two of pint's four wordings are accepted here: "has the
+    # metric ... but there are no series matching {label=value}" and "only
+    # sometimes present". In both the metric itself exists, so a typo would
+    # produce the *other* wording -- "didn't have any series for" -- against a
+    # rule that is not on this list, and still be caught. Findings of that third
+    # kind are deliberately left reported. One of them turned out to be a dead
+    # alert.
+
+    # The label value only exists when something is wrong: status="429",
+    # key="node.kubernetes.io/unreachable", access_mode="ReadOnlyMany",
+    # result="error", reason="OOMKilled", type="task-failed". Each metric is
+    # present and each alert is correct; there is simply nothing wrong yet.
+    #
+    # KubePersistentVolume.*FillingUp, not KubePersistentVolumeFillingUp: the
+    # Inodes variant carries the same `unless ... access_mode="ReadOnlyMany"`
+    # clause, and all four rules in kubernetes-storage (warning and critical of
+    # each) share it. pint deduplicates identical problems and shows one, so
+    # matching the name it happened to print just promotes the next. Verified by
+    # doing exactly that -- scoping the visible name surfaced
+    # KubePersistentVolumeInodesFillingUp on the next run. KubePersistentVolumeErrors
+    # does not use the clause and stays checked.
+    rule {
+      match {
+        name = "CertManagerHittingRateLimits|KubeNodeUnreachable|KubePersistentVolume.*FillingUp|KubeStateMetricsWatchErrors|MultipleContainersOOMKilled|TaskFailureRatioTooHigh"
+      }
+      disable = ["promql/series"]
+    }
+
+    # Pyrra ratio SLOs that have had no errors yet. sum(rate(...{code=~"5.."}))
+    # over an empty selector returns no series rather than zero, so the
+    # numerator is empty, the division is empty, and the burnrate record records
+    # nothing. Each clears itself the first time the thing it measures fails.
+    # SLOMetricAbsent already covers the input metric disappearing.
+    #
+    # `burnrate.+`, not the one window pint happened to name. Pyrra generates
+    # seven windows per SLO -- 5m, 30m, 1h, 2h, 6h, 1d, 4d for these three --
+    # all with the same empty numerator, so they are duplicates of each other
+    # and pint shows one. Matching that one just promotes the next window.
+    # apiserver_request:burnrate.+ is deliberately absent: the read SLO does
+    # produce series, so a break there should still be reported.
+    rule {
+      match {
+        name = "KubeAPIServerWriteErrorBudgetBurn|prometheus_http_requests:burnrate.+|prometheus_operator_kubernetes_client_http_requests:burnrate.+|prometheus_sd_kubernetes_http_request:burnrate.+"
+      }
+      disable = ["promql/series"]
+    }
+
+    # Union branches for pod owners this cluster does not have: owner_kind="Node"
+    # is static pods, owner_kind="" is ownerless ReplicaSets. The rule produces
+    # 225 series from DaemonSet, ReplicaSet, StatefulSet and Job owners. Only
+    # promql/series is scoped off -- the promql/impossible finding about the
+    # redundant owner_kind join stays visible, because that one is upstream
+    # style rather than a property of this cluster.
+    rule {
+      match {
+        name = "namespace_workload_pod:kube_pod_owner:relabel"
+      }
+      disable = ["promql/series"]
+    }
+
+    # Metrics that exist only while their condition holds, so pint sees them
+    # come and go: kube_job_failed (1d15h average life span),
+    # kube_pod_container_status_waiting_reason (6m55s),
+    # alertmanager_notifications_failed_total (3d17h), the *arr health metrics
+    # (3d17h-6h), and gotk_resource_info{ready=~"False|Unknown"} (5m), which is
+    # the healthy case for Flux.
+    rule {
+      match {
+        name = "AlertmanagerClusterFailedToSendAlerts|FluxCDReconciliationFailure|KubeJobFailed|KubePodCrashLooping|prowlarrUnhealthy|radarrUnhealthy|sonarrUnhealthy"
+      }
+      disable = ["promql/series"]
+    }
+
     checks {
       disabled = [
         # 48 findings, 41 of them namespace=~".*" inside the chart's own mixin

--- a/k8s/platform/observability/kube-prometheus-stack/values.yaml
+++ b/k8s/platform/observability/kube-prometheus-stack/values.yaml
@@ -47,8 +47,10 @@ defaultRules:
     KubeAggregatedAPIErrors: true
 
     # node_md_* comes from node-exporter's mdadm collector, which emits nothing
-    # without /proc/mdstat. No node here has mdraid.
+    # without /proc/mdstat. No node here has mdraid. NodeRAIDDiskFailure is the
+    # sibling on the same collector and was missed when NodeRAIDDegraded went.
     NodeRAIDDegraded: true
+    NodeRAIDDiskFailure: true
 
     # node_systemd_* needs --collector.systemd, off by default and expensive
     # enough that it is not worth turning on to serve two alerts. If it is ever


### PR DESCRIPTION
`PintRuleProblems` fires on `pint_problems > 0`, so 37 permanent findings keep #1237 open forever and train everyone to skim it. These are rules that **work**, reported because the series they select is not present right now.

## What is accepted, and what deliberately is not

Only two of pint's four wordings:

| wording | accepted | why |
|---|---|---|
| *has the metric … but there are no series matching `{label=value}`* | yes | metric exists; a typo would produce the other wording |
| *only sometimes present* | yes | same |
| *didn't have any series for `metric`* | **no** | this is where dead alerts hide |
| other checks | **no** | |

The third row is not caution for its own sake. **`K8upJobFailed` reads it, and `K8upJobFailed` is dead** — it joins on `kube_job_labels`, which has zero series because kube-state-metrics only emits `kube_<resource>_labels` for resources in `--metric-labels-allowlist`. `K8upBackupStale` is its hidden duplicate. Tracked in #1288. Excepting that wording would have buried a broken backup alert permanently.

Family A was investigated rather than assumed. The other six are legitimately quiet — `kube_horizontalpodautoscaler_*` (0 HPAs), `kube_resourcequota` (0 quotas), `kube_pod_status_reason` (0 pods with one), `kubelet_evictions` (no evictions yet) — and all four resources **are** enabled in KSM's `--resources`, so each appears the moment the object or event exists. That is exactly what `kube_job_labels` will never do.

## Four groups, by reason

- **Label values that only exist when something is wrong** — `status="429"`, `key="node.kubernetes.io/unreachable"`, `access_mode="ReadOnlyMany"`, `result="error"`, `reason="OOMKilled"`, `type="task-failed"`.
- **Pyrra ratio SLOs with no errors yet** — `sum(rate(…{code=~"5.."}))` over an empty selector records *nothing at all*, not zero.
- **Pod-owner union branches** — static pods and ownerless ReplicaSets, neither of which exists here. The rule produces 225 series from the other branches.
- **Metrics that live only while their condition holds** — from `kube_pod_container_status_waiting_reason` at 6m55s to the `*arr` health metrics at 3d17h.

Plus `NodeRAIDDiskFailure` into `defaultRules.disabled`, joining `NodeRAIDDegraded` — same mdadm collector, same absent `/proc/mdstat`, missed when the sibling went.

## Why every match is a family regex

**pint's config cannot disable a check for one metric.** `promql/series(kube_job_labels)` is rejected with `unknown check name`; that syntax only works as a comment inside the rule file, which chart-generated rules cannot carry. So each entry disables the check for the whole rule — which is why the accepted set is kept narrow.

And pint **deduplicates identical problems**, showing one and hiding the rest. Matching the name it printed just promotes the next. Caught three times by re-linting after each change:

```
KubePersistentVolumeFillingUp     -> promoted KubePersistentVolumeInodesFillingUp
one Pyrra burnrate window         -> would have promoted the other six
                                     (5m, 30m, 1h, 2h, 6h, 1d, 4d per SLO)
KubePersistentVolume.+FillingUp   -> matched only the Inodes variant. `.*`, not `.+`
```

`apiserver_request:burnrate.+` is excluded on purpose — the read SLO produces series, so a break there should still report. `KubePersistentVolumeErrors` has no `ReadOnlyMany` clause and stays checked.

## Verification

Final lint against the live rule set, every accepted name confirmed silent and every retained name confirmed still reported:

```
leaks: namespace_workload_pod (1)  -> its promql/impossible finding, kept on purpose;
                                      promql/series for it is silenced

still reported: K8upJobFailed, KubeNodeEviction, KubeHpaMaxedOut,
                KubeCPUQuotaOvercommit, KubePodNotReady, LonghornNodeDown,
                apiserver_request:availability30d
```

`make validate` — 122 targets. `make validate-flux` — 51 paths.

## What this does not do

**It does not close #1237.** Expect roughly 37 → 13: seven in family A (six legitimate, plus `K8upJobFailed` until #1288 lands) and six that are chart-internal or upstream-cosmetic. Whether to accept those too or reshape `PintRuleProblems` to fire on change rather than level is a separate decision, easier to take against a list of 13 than one of 37.

## After merge

The pint ConfigMap change rolls the Deployment automatically now, via #1284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)