### PR TITLE
pint: alert when a finding is new, not when the count is non-zero

### DIFF
--- a/k8s/apps/datalake-metrics/pint/configmap.yaml
+++ b/k8s/apps/datalake-metrics/pint/configmap.yaml
@@ -154,9 +154,21 @@ data:
     # alertmanager_notifications_failed_total (3d17h), the *arr health metrics
     # (3d17h-6h), and gotk_resource_info{ready=~"False|Unknown"} (5m), which is
     # the healthy case for Flux.
+    #
+    # Every rule reading each of those metrics is listed, not just the one pint
+    # named. Three were found only by asking which other rules read the same
+    # metric, and the first of them had already stepped forward:
+    #   kube_pod_container_status_waiting_reason  KubePodCrashLooping,
+    #                                             KubeContainerWaiting
+    #   alertmanager_notifications_failed_total   AlertmanagerClusterFailedToSendAlerts,
+    #                                             AlertmanagerFailedToSendAlerts
+    #   the prowlarr pair                         prowlarrUnhealthy reads
+    #                                             prowlarr_system_health_issues,
+    #                                             prowlarrIndexersUnavailable reads
+    #                                             prowlarr_indexer_unavailable
     rule {
       match {
-        name = "AlertmanagerClusterFailedToSendAlerts|FluxCDReconciliationFailure|KubeJobFailed|KubePodCrashLooping|prowlarrUnhealthy|radarrUnhealthy|sonarrUnhealthy"
+        name = "AlertmanagerClusterFailedToSendAlerts|AlertmanagerFailedToSendAlerts|FluxCDReconciliationFailure|KubeContainerWaiting|KubeJobFailed|KubePodCrashLooping|prowlarrIndexersUnavailable|prowlarrUnhealthy|radarrUnhealthy|sonarrUnhealthy"
       }
       disable = ["promql/series"]
     }

--- a/k8s/apps/datalake-metrics/pint/prometheusrule.yaml
+++ b/k8s/apps/datalake-metrics/pint/prometheusrule.yaml
@@ -9,14 +9,42 @@ spec:
   groups:
     - name: pint.rules
       rules:
-        # max, not sum: every replica lints the same rule set and reports the
-        # same total, so summing would multiply the count by the replica count.
-        - alert: PintRuleProblems
+        # Fires when pint starts reporting something it was not reporting
+        # before, not when the count is non-zero.
+        #
+        # The old shape was max(pint_problems) > 0 for 1h. The count has a floor
+        # -- rules that work, reported because the series they select is not
+        # present right now, like an alert waiting on a label value that only
+        # appears when something breaks -- so it was permanently true, held one
+        # github issue open forever, and taught everyone to skim it.
+        #
+        # The count is also the wrong signal even as a delta. Findings replace
+        # each other: silencing one can promote a hidden duplicate, and pint
+        # shows one problem per group. On 2026-09-06 the total fell 37 -> 15
+        # while KubeContainerWaiting appeared underneath -- a delta alert would
+        # have seen the drop and said nothing. Comparing the *set* caught it.
+        #
+        # Aggregating to (name, reporter) is required, not tidiness. `problem`
+        # embeds durations that change every run ("average life span of 6m55s"),
+        # `filename` embeds the PrometheusRule's UID, and the scrape adds pod
+        # and instance -- so a pint rollout alone would mark every finding new.
+        #
+        # `for` must stay well under the offset. The baseline catches up an hour
+        # after a finding appears, so a longer `for` would never fire. 24h is
+        # deliberate: a new finding is news for a day, after which the worklist
+        # owns it and this resolves, closing its issue with a dated record.
+        #
+        # If pint is down for more than 25h the baseline window is empty and
+        # everything reads as new. PintNotReporting fires long before that.
+        - alert: PintNewRuleProblem
           annotations:
-            description: pint reports {{ $value }} problem(s) in the rules Prometheus has loaded. Most often an alert referencing a metric that no longer exists.
-            summary: Prometheus rules have problems pint can see
-          expr: max(pint_problems{job="pint"}) > 0
-          for: 1h
+            description: pint has started reporting {{ $labels.reporter }} against {{ $labels.name }}, which it was not reporting in the previous 24h. Either a rule changed, or the cluster changed underneath one.
+            summary: pint found a problem it was not reporting before
+          expr: |
+            count by (name, reporter) (pint_problem{job="pint"})
+            unless
+            count by (name, reporter) (last_over_time(pint_problem{job="pint"}[24h] offset 1h))
+          for: 15m
           labels:
             severity: warning
         # Zero problems and a dead linter look identical from the outside, so


### PR DESCRIPTION
`max(pint_problems) > 0` was permanently true. The count has a floor — rules that work, reported because the series they select is not present right now — so the alert never cleared, held #1237 open indefinitely, and taught everyone to skim it.

## The count is the wrong signal even as a delta

This is the part worth keeping. **Findings replace each other.** pint shows one problem per group and hides the duplicates, so silencing the visible name promotes the next one.

Measured today: the total fell **37 → 15** as #1289's exceptions landed, while `KubeContainerWaiting` appeared underneath. A delta alert would have seen a *drop* and said nothing.

Comparing the set catches it:

```promql
count by (name, reporter) (pint_problem{job="pint"})
unless
count by (name, reporter) (last_over_time(pint_problem{job="pint"}[24h] offset 1h))
```

Evaluated against the live cluster before merging:

| expression | fires on |
|---|---|
| `max(pint_problems) > 0` (old) | **15** — every one accepted and permanent |
| the set comparison (new) | **1** — `KubeContainerWaiting`, genuinely new |

## Design notes

**Aggregating to `(name, reporter)` is required, not tidiness.** `problem` embeds durations that change every run (*"average life span of 6m55s"* — 8 of the 37 did), `filename` embeds the PrometheusRule's UID, and the scrape adds `pod` and `instance`. A pint rollout alone would otherwise mark every finding new.

**`for: 15m` must stay well under `offset 1h`.** The baseline catches up an hour after a finding appears, so a longer `for` would never fire at all.

**The 24h window is deliberate.** A new finding is news for a day, after which the worklist owns it and the alert resolves — closing its issue as a dated record of what changed and when.

**Failure mode:** if pint is down for more than 25h the baseline window is empty and everything reads as new. That is what `PintNotReporting` is for, and it fires long before.

## Also: three co-readers

Found by asking which *other* rules read each accepted metric, rather than waiting for each to surface on its own lint run:

```
kube_pod_container_status_waiting_reason   KubeContainerWaiting
alertmanager_notifications_failed_total    AlertmanagerFailedToSendAlerts
prowlarr_indexer_unavailable               prowlarrIndexersUnavailable
```

The first had already stepped forward once `KubePodCrashLooping` was accepted — the fifth time in this work that matching the name pint printed turned out to mean matching half a family. The prowlarr pair is a genuine two-metric split: `prowlarrUnhealthy` reads `prowlarr_system_health_issues`, `prowlarrIndexersUnavailable` reads `prowlarr_indexer_unavailable`.

## Verification

`make validate` — 122 targets. `make validate-flux` — 51 paths. pint CI lint — clean apart from the known `LonghornNodeDown` warning, so the new alert satisfies `.pint.hcl`'s severity and annotation checks.

## After merge

`PintRuleProblems` disappears, so #1237 resolves and closes. The pint ConfigMap change rolls the Deployment automatically via #1284. Expect `PintNewRuleProblem` to fire once on `KubeContainerWaiting` if the rollout order puts the alert in before the exception — and to go quiet as soon as both are live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)