### PR TITLE
pint: accept K8upJobFailed's new wording after the rewrite

### DIFF
--- a/k8s/apps/datalake-metrics/pint/configmap.yaml
+++ b/k8s/apps/datalake-metrics/pint/configmap.yaml
@@ -166,9 +166,18 @@ data:
     #                                             prowlarr_system_health_issues,
     #                                             prowlarrIndexersUnavailable reads
     #                                             prowlarr_indexer_unavailable
+    #   kube_job_failed                           KubeJobFailed, K8upJobFailed
+    #
+    # K8upJobFailed joined this list by being rewritten, not by being missed:
+    # #1291 moved it off kube_job_labels -- which has no series at all, and is
+    # why it could never fire -- onto kube_job_failed and kube_job_owner. It now
+    # reports the same "only sometimes present" wording as KubeJobFailed, for
+    # the same reason: the metric exists only while a failed Job does, with an
+    # average life span of 1d15h. Re-check co-readers after a rule is rewritten,
+    # not just after one is accepted.
     rule {
       match {
-        name = "AlertmanagerClusterFailedToSendAlerts|AlertmanagerFailedToSendAlerts|FluxCDReconciliationFailure|KubeContainerWaiting|KubeJobFailed|KubePodCrashLooping|prowlarrIndexersUnavailable|prowlarrUnhealthy|radarrUnhealthy|sonarrUnhealthy"
+        name = "AlertmanagerClusterFailedToSendAlerts|AlertmanagerFailedToSendAlerts|FluxCDReconciliationFailure|K8upJobFailed|KubeContainerWaiting|KubeJobFailed|KubePodCrashLooping|prowlarrIndexersUnavailable|prowlarrUnhealthy|radarrUnhealthy|sonarrUnhealthy"
       }
       disable = ["promql/series"]
     }


### PR DESCRIPTION
#1291 fixed `K8upJobFailed` — it now works. pint still reports it, but for a different and benign reason.

## What changed

Before, it joined on `kube_job_labels`, which has **no series at all**, so it could never fire. pint reported it as *"didn't have any series for the `kube_job_labels` metric"* — the wording deliberately left un-accepted in #1289, which is how the dead alert was found.

#1291 moved it onto `kube_job_failed` and `kube_job_owner`. Now pint says:

> The `kube_job_failed` metric is **only sometimes present** … with an average life span of 1d15h25m

That is the healthy shape: the metric exists only while a failed Job does. It is the same reason `KubeJobFailed` is already accepted, and the two now read the same metric.

## How it was found, and the lesson

The co-reader sweep in #1290 — which added `KubeContainerWaiting`, `AlertmanagerFailedToSendAlerts` and `prowlarrIndexersUnavailable` — ran **before** #1291. At that point `K8upJobFailed` read `kube_job_labels` and shared it with nothing:

```
kube_job_failed   before #1291: ['KubeJobFailed']
                  after  #1291: ['KubeJobFailed', 'K8upJobFailed']
```

**Rewriting a rule can make it a co-reader of an already-accepted metric.** Worth repeating the sweep after a rewrite, not only after an acceptance.

## Verification

Live, after #1291 rolled out:

```
kube_job_labels                                    0 series   (the old join, now unused)
kube_job_owner                                    11 series   (no allowlist needed)
K8upJobFailed expression                           0 series   (healthy)
K8upBackupNotRunning expression                    0 series   (healthy)
```

`make validate` — 122 targets.

## Effect

`pint_problems` 13 → 12. `PintNewRuleProblem` is already firing on nothing, and this does not change that — same `(name, reporter)` pair either way, which is correct: the rule did not newly break, its reason for being reported changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)