### PR TITLE
pocket-id: an SLI for the SSO everything else depends on

### DIFF
--- a/k8s/apps/datalake-metrics/pyrra/kustomization.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/kustomization.yaml
@@ -14,6 +14,8 @@ resources:
   - slo-ingress.yaml
   - slo-kubelet-request-errors.yaml
   - slo-kubelet-runtime-errors.yaml
+  - slo-pocket-id-availability.yaml
+  - slo-pocket-id-latency.yaml
   - slo-prometheus-notification-errors.yaml
   - slo-prometheus-operator-http-errors.yaml
   - slo-prometheus-operator-reconcile-errors.yaml

--- a/k8s/apps/datalake-metrics/pyrra/slo-pocket-id-availability.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/slo-pocket-id-availability.yaml
@@ -1,0 +1,41 @@
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: pocket-id-availability
+spec:
+  # SSO, so the blast radius of an outage here is every OIDC service. This is
+  # one of only two services in the cluster exporting a real request signal.
+  #
+  # target is a PLACEHOLDER. Prometheus holds days, not weeks, so no number
+  # here would be grounded -- burnrates are off until there is a month of
+  # history to pick one from. Revisit from 2026-10-06.
+  #
+  # Read the denominator before trusting a ratio over it: essentially all of
+  # this traffic is synthetic. The blackbox probe for pdf.krupa.net.pl follows
+  # its oauth2 redirect into /authorize here, and both Prometheus replicas run
+  # that probe every 30s, so pocket-id sees ~5760 authorize redirects a day
+  # against a handful of real requests. That is not a defect and it is not
+  # useless -- it exercises routing, TLS, client lookup and PKCE validation end
+  # to end, and a steady synthetic denominator is what stops one real error
+  # reading as a catastrophic burn on a low-traffic service. It does mean this
+  # SLO measures the authorize path, not a logged-in user's experience.
+  description: >-
+    Fraction of HTTP requests pocket-id answers without a server error. Nearly
+    all of the denominator is the pdf blackbox probe's authorize redirect.
+  alerting:
+    name: PocketIDAvailabilityBudgetBurn
+    # No budget alerts until the target is grounded. The absent alert stays on
+    # deliberately: it is the guard that an SLO is measuring something at all.
+    burnrates: false
+    absent: true
+  indicator:
+    ratio:
+      errors:
+        metric: http_server_request_duration_seconds_count{job="pocket-id/pocket-id",http_response_status_code=~"5.."}
+      total:
+        metric: http_server_request_duration_seconds_count{job="pocket-id/pocket-id"}
+  target: "99"
+  window: 4w

--- a/k8s/apps/datalake-metrics/pyrra/slo-pocket-id-latency.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/slo-pocket-id-latency.yaml
@@ -1,0 +1,33 @@
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: pocket-id-latency
+spec:
+  # target is a PLACEHOLDER, and burnrates are off, for the same reason as
+  # pocket-id-availability: days of history, not weeks. Revisit from
+  # 2026-10-06.
+  #
+  # le=0.1 measured rather than guessed. Over 24h on 2026-09-06 the
+  # distribution was 59.7% under 5ms, 98.4% under 10ms, 99.97% under 25ms and
+  # 100% under 100ms, so 0.1 sits above the whole observed spread and leaves
+  # headroom to pick a target from data. Tighter buckets exist (0.025, 0.05,
+  # 0.075) if this turns out too loose once there is real user traffic to
+  # measure -- today the sample is dominated by the pdf probe's authorize
+  # redirect, which pocket-id answers in 2-5ms.
+  description: >-
+    Fraction of HTTP requests pocket-id answers within 100ms.
+  alerting:
+    name: PocketIDLatencyBudgetBurn
+    burnrates: false
+    absent: true
+  indicator:
+    latency:
+      success:
+        metric: http_server_request_duration_seconds_bucket{job="pocket-id/pocket-id",le="0.1"}
+      total:
+        metric: http_server_request_duration_seconds_count{job="pocket-id/pocket-id"}
+  target: "99"
+  window: 4w

--- a/k8s/apps/pocket-id/app/release.yaml
+++ b/k8s/apps/pocket-id/app/release.yaml
@@ -56,3 +56,18 @@ spec:
                   name: metrics
                   containerPort: 9464
                   protocol: TCP
+          # blackbox discovers targets from Ingresses labelled probe=enabled and
+          # the chart exposes annotations but no labels, so the label has to be
+          # patched on. It goes on this Ingress, not pocket-id-cloudflare:
+          # blackbox derives the scheme from whether the Ingress declares TLS,
+          # and the cloudflare twin declares none, so probing that one would
+          # build an http:// target the tunnel never answers.
+          - target:
+              group: networking.k8s.io
+              version: v1
+              kind: Ingress
+              name: pocket-id
+            patch: |-
+              - op: add
+                path: /metadata/labels/probe
+                value: enabled

--- a/k8s/apps/pocket-id/app/values.yaml
+++ b/k8s/apps/pocket-id/app/values.yaml
@@ -82,6 +82,12 @@ ingress:
   enabled: true
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-dns01
+    # The OIDC discovery document rather than /healthz: /healthz is a 204 the
+    # kubelet already checks locally, while this is the document every relying
+    # party must fetch, so it fails when SSO is actually unusable. Matches the
+    # house style of probing a real app endpoint (mealie /api/app/about,
+    # immich /api/server/config) rather than a liveness path.
+    probe-uri: /.well-known/openid-configuration
   className: private
   host: login.krupa.net.pl
   tls:


### PR DESCRIPTION
First of the 6b service SLOs. pocket-id goes first: its blast radius is every OIDC service, and it is one of only two services in the cluster exporting a real request signal.

Two SLOs and a blackbox probe it did not have.

| | |
|---|---|
| `pocket-id-availability` | `http_server_request_duration_seconds_count{http_response_status_code=~"5.."}` over total |
| `pocket-id-latency` | same histogram at `le="0.1"` |
| probe | `https://login.krupa.net.pl/.well-known/openid-configuration` |

## SLIs now, target later

Both land with `alerting.burnrates: false`. Prometheus holds 4.4 days, so any target would be a guess — the recording rules start accumulating from today and the number gets picked from data around **2026-10-06**.

`alerting.absent` stays **on**. That is the point of the arrangement: an SLO over a selector matching nothing reads as a perfect 100%, and `SLOMetricAbsent` is the only thing that says otherwise.

(`severities` and `absentName` are still unavailable — the datreeio catalog schema CI validates against predates them. `burnrates` and `absent` validate fine.)

`le=0.1` is measured, not guessed. Over 24h: 59.7% under 5ms, 98.4% under 10ms, 99.97% under 25ms, 100% under 100ms. So 0.1 sits above the observed spread with headroom; 0.025/0.05/0.075 are available if it proves too loose.

## Read the denominator before trusting the ratio

**Almost all of pocket-id's traffic is synthetic**, and it is worth knowing why before reading the SLO.

The blackbox probe for `pdf.krupa.net.pl` follows its oauth2 redirect into `/authorize` here. Both Prometheus replicas run that probe every 30s — 2 × 2880 = **5,760 authorize redirects a day**, against roughly three real requests. The logs are unambiguous: 2,880 of 2,882 `/authorize` hits carry `user_agent="Blackbox Exporter/0.25.0"`, and 5,761 of 5,762 carry `redirect_uri=https://pdf.krupa.net.pl/oauth2/callback`.

That is not a defect, and not useless — it exercises routing, TLS, client lookup and PKCE validation end to end, and a steady synthetic denominator is exactly what stops one real error reading as a catastrophic burn on a low-traffic service. But it means **this SLO measures the authorize path, not a logged-in user's experience.**

## Probe choices

**The discovery document, not `/healthz`.** `/healthz` returns 204 and the kubelet already checks it locally. The discovery document is what every relying party must fetch, so it fails when SSO is genuinely unusable — and it matches the house style of probing a real app endpoint (`/api/app/about`, `/api/server/config`) rather than a liveness path.

**The label goes on the chart's Ingress, via postRenderer.** The chart exposes `ingress.annotations` but no labels, and the Probe CR selects on `probe: enabled`. pocket-id already uses postRenderers for exactly this class of gap.

**Not on `pocket-id-cloudflare`.** blackbox derives the scheme from whether the Ingress declares TLS, and that one declares none — probing it would build an `http://` target the tunnel never answers. Same trap karakeep documented in its own Ingress comment.

## Verification

`make validate` — 122 targets render and validate cleanly.

Chart rendered at 2.2.1 with these values, then the postRenderer patch applied through kustomize:

```
labels:
  app.kubernetes.io/name: pocket-id
  ...
  probe: enabled
probe_uri: /.well-known/openid-configuration
tls_hosts: [login.krupa.net.pl]
```

So the patch target resolves, `metadata.labels` exists for the add-op, and TLS is declared — blackbox will build `https://login.krupa.net.pl/.well-known/openid-configuration`.

## After merge

```
flux reconcile source git ankhmorpork
flux -n flux-system reconcile kustomization datalake-metrics
flux -n pocket-id reconcile helmrelease pocket-id
```

Then confirm the probe target appears (`probe_success{instance=~".*login.*"}`), that both SLOs record burnrates, and that **no** `ErrorBudgetBurn` rule exists for them while `SLOMetricAbsent` does.

## Separate finding, not fixed here

Tracing that traffic turned up a live blind spot in 6c's territory: **the `pdf` probe does not measure stirling-pdf.** It follows two redirects and terminates on pocket-id's `/interaction` login page with 200 and `body_size=5174`. The `http_2xx` module sets no body assertion and follows redirects by default, so **if stirling-pdf were entirely down the probe would stay green** as long as pocket-id is up. Raising separately rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)