### PR TITLE
github-receiver: stop titling issues "in <no value>"

### DIFF
--- a/k8s/apps/datalake-alerts/github-receiver/configmap.yaml
+++ b/k8s/apps/datalake-alerts/github-receiver/configmap.yaml
@@ -3,7 +3,7 @@ data:
   body-template.txt: |
     {{- $payload := .Payload -}}
 
-    # Alert {{ $payload.GroupLabels.alertname }} firing in {{ $payload.GroupLabels.namespace }} namespace
+    # Alert {{ $payload.GroupLabels.alertname }} firing{{ with $payload.GroupLabels.namespace }} in {{ . }} namespace{{ end }}
 
     This is an automated issue created by the monitoring system. Please do not edit this message.
 

--- a/k8s/apps/datalake-alerts/github-receiver/deployment.yaml
+++ b/k8s/apps/datalake-alerts/github-receiver/deployment.yaml
@@ -14,8 +14,21 @@ spec:
   template:
     metadata:
       annotations:
-        template.checksum.md5/body: 978e0810afef6389ecd4ca8ca9b9bb12
-        template.checksum.md5/title: e0e001470816a17057e5ee7afe721561
+        # alertmanager-to-github reads both template files once at startup, so a
+        # change to them needs a new Pod. The two md5 annotations that used to
+        # live here were maintained by hand, and 84b6c1f7 shows what that costs:
+        # it added the `with` guard to the title template and did not touch this
+        # file, so the checksums did not move, no rollout happened, and the
+        # running Pod went on formatting titles with the pre-guard template for
+        # three days. Every alert without a namespace label -- which is every
+        # alert whose expression aggregates it away -- was filed as
+        # "Alert: <name> in <no value>".
+        #
+        # mutate-configmap-autoreload stamps the ConfigMap's resourceVersion
+        # into this pod template on every apply instead, so the rollout cannot
+        # be forgotten. One annotation covers the ConfigMap, so it covers both
+        # template keys.
+        autoreloader.thaum.xyz/configmap: github-receiver-config
       labels:
         app.kubernetes.io/component: alertmanager-webhook-receiver
         app.kubernetes.io/name: github-receiver


### PR DESCRIPTION
Fixes the title in #1295. Two problems, and the interesting one is why the first was invisible.

## The title template was already fixed. The Pod never saw it.

`84b6c1f7` added the guard:

```
Alert: {{ .Payload.GroupLabels.alertname }}{{ with .Payload.GroupLabels.namespace }} in {{ . }}{{ end }}
```

…and changed **only** `configmap.yaml`. The two hand-maintained md5 annotations on the Deployment did not move, so the pod template was unchanged, no rollout happened, and `alertmanager-to-github` — which reads both template files once at startup — went on using the pre-guard version.

```
running Pod                    3d14h old
checksum annotation (title)    e0e001470816a17057e5ee7afe721561
actual template md5            ef197164fe8915926fcd9900f3ca79c4
```

The annotation matches nothing in the repository. So every alert **without** a namespace label was filed as `Alert: <name> in <no value>` — which is every alert whose expression aggregates namespace away. #1295 and #1237 are both examples.

## The fix

Replace the checksums with `autoreloader.thaum.xyz/configmap`, the mechanism added in #1284 for exactly this. The Kyverno policy stamps the ConfigMap's `resourceVersion` into the pod template on every apply, so the rollout cannot be forgotten.

One annotation covers the ConfigMap and therefore both template keys, where the hand-maintained scheme needed one per file and silently tolerated a stale value — which is how this happened.

## The body template was genuinely broken

Separate from the above, and still wrong in git:

```
# Alert {{ $payload.GroupLabels.alertname }} firing in {{ $payload.GroupLabels.namespace }} namespace
```

No `with`, so it prints the same `<no value>` in the issue body. Guarded here.

## Verification

Both templates rendered through Go's `text/template`, with and without a namespace label:

```
TITLE  with namespace     -> Alert: KubePodCrashLooping in vod-arr
       without namespace  -> Alert: PintNewRuleProblem

BODY   with namespace     -> # Alert KubePodCrashLooping firing in vod-arr namespace
       without namespace  -> # Alert PintNewRuleProblem firing
```

`make validate` — 122 targets. `make validate-flux` — 51 paths.

## After merge

Allow up to two reconcile intervals before the Pod rolls — Flux applies the Deployment before it writes the new ConfigMap, so the first reconcile stamps the old `resourceVersion` and the second one rolls it. Existing issue titles are not rewritten; new ones will be correct.

## Not fixed here

The pint finding in #1295 is real and separate: `http_server_request_duration_seconds:burnrate5m` is a new Pyrra SLO whose burnrate has no errors yet. That is `PintNewRuleProblem` working as intended — it fired on a genuinely new finding — and it belongs in the accepted set alongside the other zero-error SLO burnrates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)