### PR TITLE
github-receiver: put the autoreload opt-in where the policy looks

### DIFF
--- a/k8s/apps/datalake-alerts/github-receiver/deployment.yaml
+++ b/k8s/apps/datalake-alerts/github-receiver/deployment.yaml
@@ -1,6 +1,24 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    # On the Deployment, not the pod template. mutate-configmap-autoreload
+    # matches object.metadata.annotations, and the policy writes its stamp into
+    # spec.template.metadata.annotations -- putting the opt-in there instead
+    # means the policy never sees it and silently does nothing, which is what
+    # happened in #1299.
+    #
+    # alertmanager-to-github reads both template files once at startup, so a
+    # change to them needs a new Pod. Two md5 annotations used to sit on the pod
+    # template and were maintained by hand; 84b6c1f7 shows the cost -- it added
+    # the `with` guard to the title template and changed nothing else, so the
+    # checksums did not move, no rollout happened, and the running Pod formatted
+    # titles with the pre-guard version for three days. Every alert without a
+    # namespace label was filed as "Alert: <name> in <no value>".
+    #
+    # One annotation covers the ConfigMap and so both template keys, where the
+    # hand-maintained scheme needed one per file and tolerated a stale value.
+    autoreloader.thaum.xyz/configmap: github-receiver-config
   labels:
     app.kubernetes.io/component: alertmanager-webhook-receiver
     app.kubernetes.io/name: github-receiver
@@ -13,22 +31,6 @@ spec:
       app.kubernetes.io/name: github-receiver
   template:
     metadata:
-      annotations:
-        # alertmanager-to-github reads both template files once at startup, so a
-        # change to them needs a new Pod. The two md5 annotations that used to
-        # live here were maintained by hand, and 84b6c1f7 shows what that costs:
-        # it added the `with` guard to the title template and did not touch this
-        # file, so the checksums did not move, no rollout happened, and the
-        # running Pod went on formatting titles with the pre-guard template for
-        # three days. Every alert without a namespace label -- which is every
-        # alert whose expression aggregates it away -- was filed as
-        # "Alert: <name> in <no value>".
-        #
-        # mutate-configmap-autoreload stamps the ConfigMap's resourceVersion
-        # into this pod template on every apply instead, so the rollout cannot
-        # be forgotten. One annotation covers the ConfigMap, so it covers both
-        # template keys.
-        autoreloader.thaum.xyz/configmap: github-receiver-config
       labels:
         app.kubernetes.io/component: alertmanager-webhook-receiver
         app.kubernetes.io/name: github-receiver


### PR DESCRIPTION
Follow-up to #1299. I replaced the hand-maintained checksums **in place**, which left the opt-in annotation on the pod template. It belongs on the Deployment's own metadata.

`mutate-configmap-autoreload` matches `object.metadata.annotations` and writes its stamp into `spec.template.metadata.annotations`. With the opt-in sitting in the *target* rather than the *source*, the policy never matched.

## Why it looked fine

The Deployment rolled on merge — its pod template had changed, so the Pod picked up the corrected templates and the visible symptom went away. But **nothing would have rolled on the next ConfigMap change**, which is the entire point of the annotation. The bug would have resurfaced the next time someone edited a template, looking exactly like the original problem.

pint has it in the right place, and the side-by-side is what showed it:

```
github-receiver   pod template:  {autoreloader.thaum.xyz/configmap: github-receiver-config}
                  stamp:         none

pint              deployment:    {autoreloader.thaum.xyz/configmap: pint-config}
                  stamp:         {autoreloader.thaum.xyz/version: 1098166123}
```

## Verification

Server-side apply dry-run as `kustomize-controller`, after the move:

```
pod template annotations: {'autoreloader.thaum.xyz/version': '1098420366'}
live cm resourceVersion:                                     1098420366
```

`make validate` — 122 targets. `make validate-flux` — 51 paths.

The comment now says explicitly that the annotation goes on the Deployment and why, so the next adopter does not repeat it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)