### PR TITLE
Stand up a documentation site at docs.thaum.xyz

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -77,6 +77,20 @@
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "mikefarah/yq"
+    },
+    {
+      "customType": "regex",
+      "description": "Zensical, pinned in the docs workflow and the Makefile.",
+      "managerFilePatterns": [
+        "/^\\.github\\/workflows\\/[^/]+\\.ya?ml$/",
+        "/^Makefile$/"
+      ],
+      "matchStrings": [
+        "zensical-version:\\s(?<currentValue>.*?)\\n",
+        "ZENSICAL_VERSION:=(?<currentValue>.*?)\\n"
+      ],
+      "datasourceTemplate": "pypi",
+      "depNameTemplate": "zensical"
     }
   ],
   "packageRules": [
@@ -154,6 +168,18 @@
       "groupName": "applications",
       "minimumReleaseAge": "0",
       "automerge": true
+    },
+    {
+      "description": "Zensical is alpha (0.0.x) and can change rendering between patch releases. The docs build gates it, but a green build does not prove the site still looks right, so it lands as its own PR and is never automerged.",
+      "matchDepNames": [
+        "zensical"
+      ],
+      "groupName": "zensical",
+      "addLabels": [
+        "dependencies/ci"
+      ],
+      "automerge": false,
+      "minimumReleaseAge": "3 days"
     }
   ],
   "kubernetes": {

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,50 @@
+---
+name: docs
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    paths: ['docs/**', 'zensical.toml', '.github/workflows/docs.yml']
+  pull_request:
+    branches: [master]
+    paths: ['docs/**', 'zensical.toml', '.github/workflows/docs.yml']
+
+env:
+  # Zensical is alpha (0.0.x) and ships every few days, so this is pinned rather
+  # than floating. A customManager in .github/renovate.json bumps it here and in
+  # the Makefile together; without that entry this line would simply freeze.
+  zensical-version: 0.0.59
+
+permissions:
+  contents: read
+
+jobs:
+  # Runs on pull requests too, so a docs change that does not build is caught
+  # before merge rather than by a red deploy on master.
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: 3.x
+      - run: pip install zensical==${{ env.zensical-version }}
+      - run: zensical build --clean
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v5
+        id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ master.key
 bin/
 .cache_ggshield
 tmp/
+
+# Rendered documentation site (see zensical.toml)
+site/
+.venv/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 SHELL:=/bin/bash
 
+# Kept in sync with .github/workflows/docs.yml by the zensical customManager
+# in .github/renovate.json, which matches both spellings.
+ZENSICAL_VERSION:=0.0.59
+
 .PHONY: help
 help: ## Display help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
@@ -24,3 +28,11 @@ prometheusrules:  ## Validate prometheus rules
 .PHONY: bootstrap
 bootstrap:  ## Bootstrap development environment
 	ggshield install -m local
+
+.PHONY: docs
+docs:  ## Serve the documentation site locally with live reload
+	uvx zensical==$(ZENSICAL_VERSION) serve
+
+.PHONY: docs-build
+docs-build:  ## Build the documentation site into ./site
+	uvx zensical==$(ZENSICAL_VERSION) build --clean

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.thaum.xyz

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,0 @@
-# Docs
-
-Due to issues with keeping docs up to date they were migrated to private instance of logseq and are no longer publicly
-available.

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -1,0 +1,35 @@
+# Explanation { .quad-explanation }
+
+!!! warning "Placeholder"
+
+    The site scaffold is in place; this section has mostly no content yet.
+
+## What belongs here
+
+Explanation is **discussion**. It is the only section that may argue, compare,
+admit uncertainty, or describe something that was tried and rejected. It is read
+away from the keyboard.
+
+Admission test:
+
+- [ ] It answers "why is it like this?" rather than "how do I?".
+- [ ] It is useful to someone who is not currently doing anything.
+- [ ] It can be read in any order relative to the rest of the site.
+
+This is where hard-won knowledge goes to stay found: measurements, trade-offs,
+and the reasoning behind conventions that otherwise look arbitrary. Most of it
+currently exists only in commit messages, per-app READMEs and
+`.claude/skills/app-deployment/SKILL.md`.
+
+## Planned
+
+- Why storage is split across four classes, and why nothing transactional runs on
+  Longhorn *(the fsync measurement)*
+- Why observability is split by role rather than by stack
+- How Flux is layered: bootstrap, platform, apps
+- Why Helm values live in `values.yaml` rather than inline in a HelmRelease
+- What stays private, and why the rest of this is public
+
+## Available now
+
+- [Postgres fleet upgrade plan](../postgres/fleet-upgrade-plan.md)

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,0 +1,39 @@
+# How-to { .quad-howto }
+
+!!! warning "Placeholder"
+
+    The site scaffold is in place; this section has no content yet.
+
+## What belongs here
+
+A how-to is a **recipe** for a reader who already knows what they want. It starts
+from a realistic situation, not a clean slate, and it is allowed to say "it
+depends" — that is the difference from a [tutorial](../tutorial/index.md).
+
+Admission test:
+
+- [ ] It answers "how do I …?" for a goal the reader already has.
+- [ ] It is a sequence of steps, not an explanation. Rationale goes in
+      [Explanation](../explanation/index.md); tables of options go in
+      [Reference](../reference/index.md).
+- [ ] It is specific to *this* cluster. If upstream documentation already covers
+      it, link out instead of restating it.
+
+Runbooks are how-to documents written for someone at 2am, and belong in this
+section once migrated.
+
+## Planned
+
+- Add persistent storage to an app
+- Expose an app on an ingress
+- Rotate a secret
+- Recover a Postgres cluster from backup
+- Drain and reboot a node outside the kured cycle
+- Debug a Flux reconcile that reports success but changes nothing
+
+## Open item: the existing runbooks
+
+[runbooks.thaum.xyz](https://runbooks.thaum.xyz/) is still serving, from a
+repository whose last commit was 2021-11-05. Its content predates most of this
+cluster. It needs to be triaged into this section and the old site retired —
+tracked at `docs/runbooks/README.md`, which currently just points at it.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,88 @@
+# Ankh-Morpork
+
+Documentation for the [thaum.xyz][repo] home Kubernetes cluster — a k3s cluster
+in a cupboard, managed entirely through Flux.
+
+[repo]: https://github.com/thaum-xyz/ankhmorpork
+
+<div class="grid cards" markdown>
+
+-   :material-school:{ .lg .middle .quad-tutorial } __Tutorial__
+
+    ---
+
+    Learning-oriented. Start here if you have never deployed anything to this
+    cluster. One guided path, guaranteed to work, no decisions to make.
+
+    [:octicons-arrow-right-24: Deploy your first app](tutorial/index.md)
+
+-   :material-wrench:{ .lg .middle .quad-howto } __How-to__
+
+    ---
+
+    Task-oriented. You know what you want and need the steps for *this* cluster.
+    Runbooks live here too.
+
+    [:octicons-arrow-right-24: Find a recipe](how-to/index.md)
+
+-   :material-file-document-outline:{ .lg .middle .quad-reference } __Reference__
+
+    ---
+
+    Information-oriented. Storage classes, admission policies, ingress classes,
+    the app inventory. Look things up, don't read it through.
+
+    [:octicons-arrow-right-24: Look something up](reference/index.md)
+
+-   :material-lightbulb-outline:{ .lg .middle .quad-explanation } __Explanation__
+
+    ---
+
+    Understanding-oriented. Why the cluster is built the way it is, and what was
+    measured or learned to justify it.
+
+    [:octicons-arrow-right-24: Understand the design](explanation/index.md)
+
+</div>
+
+## How this documentation is organised
+
+This site follows [Diátaxis](https://diataxis.fr/). The four sections above are
+document **types**, not subjects — the same component can appear in all four. A
+page belongs in a section based on what the reader is *doing* when they open it:
+
+|              | Practical       | Theoretical     |
+| ------------ | --------------- | --------------- |
+| **Studying** | Tutorial        | Explanation     |
+| **Working**  | How-to          | Reference       |
+
+Each section states its own admission test. Read it before adding a page there —
+the framework only pays for itself if the boxes stay honest.
+
+## Where documentation lives
+
+Two prior doc sets for this cluster died after being moved away from the code
+they described: `docs/` went to a private Logseq, and the runbooks went to
+[thaum-xyz/runbooks][rb], which last received a commit in November 2021. What
+survived instead was everything that stayed inside the repository — the per-app
+READMEs, `AGENTS.md`, the deployment skill.
+
+[rb]: https://github.com/thaum-xyz/runbooks
+
+So the rule here is proximity:
+
+- **This site is built from `docs/` in the `ankhmorpork` repository.** The source
+  is plain Markdown with no front matter, so every page stays readable on
+  github.com and shows up in the diff that invalidates it. Only the *rendering*
+  leaves the repo.
+- **Per-app documentation stays next to its manifests**, at
+  `k8s/apps/<app>/README.md`, for the same reason.
+- **Nothing here contains secrets, credentials, or break-glass paths.** The
+  repository is public on purpose. Anything failing that test does not belong on
+  this site — see [what stays private](explanation/index.md).
+
+!!! tip "Found something wrong?"
+
+    Every page has an :material-pencil: edit link in the top right that opens it
+    directly in the GitHub editor. Fixing a stale sentence should cost less than
+    tolerating it.

--- a/docs/reference/charts.md
+++ b/docs/reference/charts.md
@@ -1,0 +1,76 @@
+# Charts and images { .quad-reference }
+
+Two repositories hold code this cluster depends on. They were split out of
+`ankhmorpork` so that chart testing, image builds and releases have their own CI
+— not because they have an audience of their own.
+
+This page is a map. It says what exists, who consumes it, and where the
+authoritative reference lives. It deliberately does **not** copy values tables
+here: a chart's values are invalidated by a diff in the chart repository, so a
+copy in this repository would go stale without anything in a pull request ever
+hinting that it had.
+
+!!! info "Why the reference is elsewhere"
+
+    Renovate bumps chart versions in this repository, so a chart change does
+    eventually appear here — as a version string. `0.10.1` → `0.11.0` in a
+    HelmRelease says nothing about which values moved, so it would never prompt
+    anyone to correct a values table living here. That table is only reliably
+    correct next to the chart, which is why it is generated there instead.
+
+## Charts
+
+Published to `oci://ghcr.io/thaum-xyz/helm-charts`, source in
+[thaum-xyz/helm-charts][hc]. Values reference is generated from each chart's
+`values.yaml` and verified in that repository's CI.
+
+[hc]: https://github.com/thaum-xyz/helm-charts
+
+| Chart | Purpose | Used by | Values |
+| --- | --- | --- | --- |
+| `cnpg-database` | CloudNativePG cluster with barman-cloud object store, scheduled backups, Doppler-backed credentials and backup alerting | all eleven Postgres databases | [reference][v-cnpg] |
+| `lvm-diskprep` | Prepares LVM node disks for CSI stacks via privileged DaemonSets and textfile metrics | `topolvm-system` | [reference][v-lvm] |
+
+[v-cnpg]: https://github.com/thaum-xyz/helm-charts/tree/main/charts/cnpg-database
+[v-lvm]: https://github.com/thaum-xyz/helm-charts/tree/main/charts/lvm-diskprep
+
+## Images
+
+Published to `ghcr.io/thaum-xyz/containers/<name>`, source in
+[thaum-xyz/containers][co]. Tagged `YYYY.WW.PATCH`; there is no `latest`.
+
+[co]: https://github.com/thaum-xyz/containers
+
+| Image | Purpose | Used by |
+| --- | --- | --- |
+| `lvm-tools` | Debian with `lvm2` and `util-linux` for privileged node disk preparation | the `lvm-diskprep` chart |
+
+Nothing in `k8s/` references that image directly. It reaches the cluster only
+when the chart's image tag is bumped and the chart is then released — two hops,
+which is worth remembering when a fix appears not to have landed.
+
+## Where the S3 gateways come from
+
+All three S3 gateways — `cnpg-system`, `longhorn-system` and `datalake-logs` —
+run [upstream's chart][up] at v0.3.5 from `oci://ghcr.io/versity/versitygw/charts`,
+not a thaum-xyz chart. Their values follow upstream's shape: `gateway.backend`,
+`persistence`, `auth.existingSecret`.
+
+A thaum-xyz `versitygw` chart did exist, shaped differently (`storage.data`,
+`bucketName`) and stuck at 0.1.0. It was confirmed to have no consumer — here,
+in any sibling repository, or in the live cluster — and was deleted from
+`helm-charts` on 2026-09-06. The published
+`oci://ghcr.io/thaum-xyz/helm-charts/versitygw:0.1.0` was left in place rather
+than pulled, so nothing that already referenced it can break. Anything reaching
+for a gateway chart should use upstream's.
+
+[up]: https://github.com/versity/versitygw/tree/main/chart
+
+## The backup loop
+
+`cnpg-database` writes backups to the versitygw gateway in `cnpg-system` —
+`http://versitygw.cnpg-system.svc.cluster.local:7070`, from the upstream chart —
+which stores objects on a `unifi-nas` volume. Restoring any database depends on
+that gateway and that volume as well as on CloudNativePG. See
+[Postgres fleet upgrade plan](../postgres/fleet-upgrade-plan.md) for the state
+of the fleet itself.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,39 @@
+# Reference { .quad-reference }
+
+!!! warning "Placeholder"
+
+    The site scaffold is in place; this section has mostly no content yet.
+
+## What belongs here
+
+Reference is a **map**, consulted mid-task and never read through. It describes
+the machinery and does nothing else: no instruction, no persuasion, no worked
+examples.
+
+Admission test:
+
+- [ ] The reader arrives already knowing what they are looking for.
+- [ ] It is structured to match the thing it describes — one section per storage
+      class, one row per policy — not structured as an argument.
+- [ ] It is neutral. The moment a page starts justifying a choice, that part
+      belongs in [Explanation](../explanation/index.md).
+
+!!! tip "Prefer generated reference"
+
+    Reference rots faster than anything else here and benefits least from prose.
+    The app inventory, ingress hosts, namespaces and storage classes are all
+    derivable from the manifests — generate them in CI rather than typing them.
+
+## Planned
+
+- Storage classes — capabilities, ceilings, access modes, node affinity
+- Kyverno admission policies
+- Ingress classes and certificate issuers
+- Namespace and Flux Kustomization layout
+- App inventory *(generated)*
+
+## Available now
+
+- [Charts and images](charts.md) — the two sibling repositories, what they hold,
+  and where their generated reference lives
+- [UPS Modbus register map](../ups/modbus-register-map.md)

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,129 @@
+/* ---------------------------------------------------------------------------
+   Diataxis colour system
+
+   The four sections are document *types*, and the whole framework only works if
+   a reader can tell at a glance which type they are looking at. So colour is
+   used semantically here, not decoratively: one hue per quadrant, applied to the
+   landing cards and to that quadrant's own pages, and used nowhere else.
+
+     Tutorial     green   -- learning, safe to follow, "start here"
+     How-to       orange  -- action, hands-on, in the middle of a task
+     Reference    blue    -- neutral lookup
+     Explanation  purple  -- discussion, continuous with the site's primary
+
+   Each pair is a Material palette shade chosen to hold contrast against both
+   backgrounds: the darker shade on white, the lighter on slate.
+   --------------------------------------------------------------------------- */
+
+:root {
+  --diataxis-tutorial: #2e7d32;
+  --diataxis-howto: #d84315;
+  --diataxis-reference: #1565c0;
+  --diataxis-explanation: #6a1b9a;
+}
+
+[data-md-color-scheme="slate"] {
+  --diataxis-tutorial: #66bb6a;
+  --diataxis-howto: #ff8a65;
+  --diataxis-reference: #42a5f5;
+  --diataxis-explanation: #ce93d8;
+}
+
+/* Each quadrant marks itself by putting its class on an icon (landing cards) or
+   on its <h1> (section pages); everything downstream reads --quad. Selecting on
+   the marker rather than on nth-child keeps this correct if the cards are ever
+   reordered. */
+.quad-tutorial { --quad: var(--diataxis-tutorial); }
+.quad-howto { --quad: var(--diataxis-howto); }
+.quad-reference { --quad: var(--diataxis-reference); }
+.quad-explanation { --quad: var(--diataxis-explanation); }
+
+.md-typeset .grid.cards > ul > li:has(.quad-tutorial) { --quad: var(--diataxis-tutorial); }
+.md-typeset .grid.cards > ul > li:has(.quad-howto) { --quad: var(--diataxis-howto); }
+.md-typeset .grid.cards > ul > li:has(.quad-reference) { --quad: var(--diataxis-reference); }
+.md-typeset .grid.cards > ul > li:has(.quad-explanation) { --quad: var(--diataxis-explanation); }
+
+.md-content:has(.quad-tutorial) { --quad: var(--diataxis-tutorial); }
+.md-content:has(.quad-howto) { --quad: var(--diataxis-howto); }
+.md-content:has(.quad-reference) { --quad: var(--diataxis-reference); }
+.md-content:has(.quad-explanation) { --quad: var(--diataxis-explanation); }
+
+/* --- Landing page cards --------------------------------------------------- */
+
+.md-typeset .grid.cards > ul > li {
+  border-top: 3px solid var(--quad, var(--md-default-fg-color--lightest));
+  transition: border-color 125ms, box-shadow 125ms, transform 125ms;
+}
+
+.md-typeset .grid.cards > ul > li:hover {
+  box-shadow: 0 0 0.4rem rgba(0, 0, 0, 0.1);
+  transform: translateY(-1px);
+}
+
+.md-typeset .grid.cards > ul > li > hr {
+  background-color: var(--quad);
+  opacity: 0.25;
+}
+
+/* The icon and the call-to-action carry the quadrant colour; the body copy stays
+   at normal text contrast so the colour never costs legibility. */
+.md-typeset .grid.cards > ul > li > p:first-child .twemoji {
+  color: var(--quad);
+}
+
+.md-typeset .grid.cards > ul > li > p:last-child a {
+  color: var(--quad);
+  font-weight: 600;
+}
+
+.md-typeset .grid.cards > ul > li > p:last-child a:hover {
+  text-decoration: underline;
+}
+
+/* --- Section pages -------------------------------------------------------- */
+
+/* A coloured rule under the page title is the whole signal: it tells you which
+   kind of document you are in before you have read a word of it. */
+.md-typeset h1:is(.quad-tutorial, .quad-howto, .quad-reference, .quad-explanation) {
+  border-bottom: 3px solid var(--quad);
+  color: var(--md-default-fg-color);
+  display: inline-block;
+  padding-bottom: 0.2rem;
+}
+
+/* Admission-test criteria: rendered as task lists for their shape, but they are
+   conditions to check against, not work to tick off -- so drop the interactive
+   affordance and tint them to the section. */
+.md-typeset .task-list-control .task-list-indicator::before {
+  background-color: var(--quad, var(--md-default-fg-color--lighter));
+  opacity: 0.55;
+}
+
+/* --- Chrome --------------------------------------------------------------- */
+
+/* Without this the header is near-white in light mode and near-black in dark,
+   which is what made the first draft read as monochrome. */
+.md-header,
+.md-tabs {
+  background-color: var(--md-primary-fg-color);
+  color: var(--md-primary-bg-color);
+}
+
+/* Full-strength primary is right against white, but against the near-black slate
+   background (#0b0c0f) it glares. The dark variant keeps the identity without
+   making the header the brightest thing on the page. */
+[data-md-color-scheme="slate"] .md-header,
+[data-md-color-scheme="slate"] .md-tabs {
+  background-color: var(--md-primary-fg-color--dark);
+}
+
+.md-header__title,
+.md-tabs__link {
+  color: var(--md-primary-bg-color);
+}
+
+/* Several reference pages carry tables that are uncomfortable at the default
+   content width. */
+.md-grid {
+  max-width: 68rem;
+}

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -1,0 +1,33 @@
+# Tutorial { .quad-tutorial }
+
+!!! warning "Placeholder"
+
+    The site scaffold is in place; this section has no content yet.
+
+## What belongs here
+
+A tutorial is a **lesson**. The reader is learning the cluster, and the app they
+deploy is a means to that end — they do not care about it and will delete it at
+the end.
+
+Admission test, all four must hold:
+
+- [ ] It is safe to follow start to finish with no prior knowledge of this cluster.
+- [ ] It **succeeds every time**. No "depending on your setup", no branches.
+- [ ] It contains **no decisions**. Every choice is made for the reader, with the
+      reasoning deferred to [Explanation](../explanation/index.md) and the
+      alternatives to [Reference](../reference/index.md).
+- [ ] It ends with the reader having seen something work.
+
+That last constraint is why there is only ever going to be one tutorial here.
+Decision tables — pick a StorageClass, pick an ingress class — are exactly what a
+tutorial must not contain. They are how-to and reference material.
+
+## Planned
+
+- **Deploy your first app** — a throwaway app end to end: manifests under
+  `k8s/apps/`, a Flux Kustomization under `k8s/flux/apps/`, `make validate`,
+  merge, reconcile, watch it come up, delete it again.
+
+Individual applications (Plex, Immich, Mealie) will never have a tutorial. Nobody
+learns this cluster *through* Mealie. Those get reference and how-to instead.

--- a/k8s/platform/storage/topolvm-system/diskprep/values.yaml
+++ b/k8s/platform/storage/topolvm-system/diskprep/values.yaml
@@ -1,4 +1,4 @@
-# Config reference: https://github.com/thaum-xyz/helm-charts/blob/main/charts/lvm-diskprep/values.yaml
+# Config reference: https://github.com/thaum-xyz/helm-charts/tree/main/charts/lvm-diskprep
 
 nodeSelector:
   storage.topolvm.io/enabled: "true"

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,0 +1,147 @@
+# Documentation site for the Ankh-Morpork cluster -- https://docs.thaum.xyz
+#
+# Zensical is the successor to Material for MkDocs, by the same team. MkDocs core
+# has been unmaintained since 2024-08 and Material entered maintenance mode in
+# 2025-11, so a site started now goes straight to Zensical rather than adopting
+# something with a closing support window.
+#
+# Zensical is alpha (0.0.x), which is why the version is pinned in
+# .github/workflows/docs.yml rather than floating. The content is plain CommonMark
+# in docs/ with no front matter, so it stays readable on github.com in the diff
+# that invalidates it -- and portable to any other generator if this one stalls.
+
+[project]
+site_name = "Ankh-Morpork"
+site_url = "https://docs.thaum.xyz/"
+site_description = "Documentation for the thaum.xyz home Kubernetes cluster"
+site_author = "paulfantom"
+copyright = "Copyright &copy; 2026 paulfantom"
+
+repo_url = "https://github.com/thaum-xyz/ankhmorpork"
+repo_name = "thaum-xyz/ankhmorpork"
+edit_uri = "edit/master/docs/"
+
+docs_dir = "docs"
+extra_css = ["stylesheets/extra.css"]
+
+# Diataxis. The four sections are document *types*, not subjects: the same app
+# can appear in all four. Which section a page belongs in is decided by what the
+# reader is doing when they open it, not by what the page is about.
+#
+#             | practical        | theoretical
+#   ----------+------------------+-----------------
+#   studying  | Tutorial         | Explanation
+#   working   | How-to           | Reference
+#
+# Each section's index.md states its own admission test. Read it before adding a
+# page there.
+nav = [
+  { "Home" = "index.md" },
+  { "Tutorial" = [
+    "tutorial/index.md",
+  ] },
+  { "How-to" = [
+    "how-to/index.md",
+  ] },
+  { "Reference" = [
+    "reference/index.md",
+    { "Charts and images" = "reference/charts.md" },
+    { "UPS Modbus register map" = "ups/modbus-register-map.md" },
+  ] },
+  { "Explanation" = [
+    "explanation/index.md",
+    { "Postgres fleet upgrade plan" = "postgres/fleet-upgrade-plan.md" },
+  ] },
+]
+
+[project.theme]
+language = "en"
+features = [
+  "announce.dismiss",
+  # One click from "this page is wrong" to editing it on GitHub. The single most
+  # useful feature here given that staleness, not authoring, killed the last two
+  # doc sets.
+  "content.action.edit",
+  "content.action.view",
+  "content.code.annotate",
+  "content.code.copy",
+  "content.code.select",
+  "content.footnote.tooltips",
+  "content.tabs.link",
+  "content.tooltips",
+  "navigation.footer",
+  # Section index.md pages are reachable by clicking the section itself, which is
+  # what makes the bare "how-to/index.md" nav entries above work.
+  "navigation.indexes",
+  "navigation.instant",
+  "navigation.instant.prefetch",
+  "navigation.path",
+  "navigation.sections",
+  "navigation.tabs",
+  "navigation.tabs.sticky",
+  "navigation.top",
+  "navigation.tracking",
+  "search.highlight",
+  "search.suggest",
+  "toc.follow",
+]
+
+[project.theme.font]
+text = "Inter"
+code = "JetBrains Mono"
+
+[[project.theme.palette]]
+media = "(prefers-color-scheme)"
+primary = "deep purple"
+accent = "amber"
+toggle.icon = "lucide/sun-moon"
+toggle.name = "Switch to light mode"
+
+[[project.theme.palette]]
+media = "(prefers-color-scheme: light)"
+scheme = "default"
+primary = "deep purple"
+accent = "amber"
+toggle.icon = "lucide/sun"
+toggle.name = "Switch to dark mode"
+
+[[project.theme.palette]]
+media = "(prefers-color-scheme: dark)"
+scheme = "slate"
+primary = "deep purple"
+accent = "amber"
+toggle.icon = "lucide/moon"
+toggle.name = "Switch to system preference"
+
+[[project.extra.social]]
+icon = "fontawesome/brands/github"
+link = "https://github.com/thaum-xyz/ankhmorpork"
+
+[project.markdown_extensions]
+abbr = {}
+admonition = {}
+attr_list = {}
+def_list = {}
+footnotes = {}
+md_in_html = {}
+toc.permalink = true
+pymdownx.betterem = {}
+pymdownx.caret = {}
+pymdownx.details = {}
+pymdownx.emoji.emoji_generator = "zensical.extensions.emoji.to_svg"
+pymdownx.emoji.emoji_index = "zensical.extensions.emoji.twemoji"
+pymdownx.highlight.anchor_linenums = true
+pymdownx.highlight.line_spans = "__span"
+pymdownx.highlight.pygments_lang_class = true
+pymdownx.inlinehilite = {}
+pymdownx.keys = {}
+pymdownx.magiclink = {}
+pymdownx.mark = {}
+pymdownx.smartsymbols = {}
+pymdownx.superfences.custom_fences = [
+  { name = "mermaid", class = "mermaid", format = "pymdownx.superfences.fence_code_format" },
+]
+pymdownx.tabbed.alternate_style = true
+pymdownx.tabbed.combine_header_slug = true
+pymdownx.tasklist.custom_checkbox = true
+pymdownx.tilde = {}


### PR DESCRIPTION
Adds a Diátaxis-structured documentation site, built from `docs/` and published to
GitHub Pages. Placeholder content for now — the structure, tooling and deployment
path first, prose after.

### Why the source stays in this repository

Two previous doc sets for this cluster died after being moved away from the code
they described:

| Doc set | Moved to | State |
| --- | --- | --- |
| `docs/` | a private Logseq — explicitly "due to issues with keeping docs up to date" | gone |
| `docs/runbooks/` | `thaum-xyz/runbooks` | **last commit 2021-11-05** |
| per-app READMEs | stayed next to the manifests | alive and current |

So the source stays in `docs/`, as plain CommonMark with no front matter — readable
on github.com, in the diff that invalidates it. Only the rendering leaves.

### Zensical, not Material for MkDocs

MkDocs core has had no release since 2024-08-30 and Material
[entered maintenance mode in November 2025](https://squidfunk.github.io/mkdocs-material/blog/2025/11/05/zensical/),
with patches committed to roughly November 2026. Starting a new site on it would
mean adopting a two-month support window. Zensical is the same team's successor
and HTML-compatible.

It is **alpha (0.0.x)**, which is the main thing to weigh here. Mitigated by: the
content is portable plain Markdown; the version is pinned; and it now has a
Renovate `customManager`, deliberately **not** automerged — a green build proves
the site compiles, not that it still looks right.

### Diátaxis, and the app/platform question

The four sections are document *types*, not subjects, so `immich` and `mealie` can
appear in three of them while the platform gets the one tutorial that only makes
sense once. Each section index states its own **admission test**, so the boxes stay
honest rather than becoming four folders of miscellany.

Per-app READMEs stay at `k8s/apps/<app>/README.md` for the same proximity reason.

### Notable bits

- **Colour is semantic**, one hue per section, so you can tell which kind of
  document you are in before reading a word. It hooks off a class on the card icon
  and the page `<h1>` rather than `nth-child`, so reordering the cards cannot
  silently break it.
- **`docs/reference/charts.md`** maps the two sibling repositories without copying
  their values. A chart's values are invalidated by a diff in `helm-charts`, so the
  authoritative tables are generated there (thaum-xyz/helm-charts#18). The
  `diskprep` values comment now points at that generated README rather than raw
  `values.yaml` — the only `k8s/` change here, and comment-only.
- `docs/README.md` deleted: it was the tombstone saying docs had moved to Logseq,
  which this reverses, and Zensical maps `README.md` → `index.html`, so it would
  have collided with `docs/index.md`.

### Deployment setup

Pages is **already enabled** on this repository with `build_type: "workflow"`, so
the publishing source needs no change. What is missing is the custom domain, and it
must be set in settings — a `CNAME` file does not work here:

> If you are publishing from a custom GitHub Actions workflow, no `CNAME` file is
> created, and any existing `CNAME` file is ignored and is not required.
> — [GitHub docs](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site)

The second commit removes the `CNAME` file I had added on that mistaken assumption.

In order:

1. **Cloudflare DNS first** — `docs.thaum.xyz` CNAME → `thaum-xyz.github.io`, by
   hand; external-dns will not create it, since this is not a cluster ingress.
   Start **DNS-only (grey cloud)**: with Cloudflare proxying, GitHub cannot
   complete the ACME challenge to issue the certificate.
2. **Settings → Pages → Custom domain** → `docs.thaum.xyz`, then wait for the
   certificate, then enable *Enforce HTTPS*.

Until the domain is set the site publishes to `thaum-xyz.github.io/ankhmorpork/`, a
project subpath, while `site_url` in `zensical.toml` assumes the domain root — so
canonical links and the sitemap will be wrong in that window. Nothing else breaks.
The badge at README.md:3 can be uncommented once it is live.

Verified: `make validate` passes (122 targets), the site builds clean, and the
Renovate config validates against `renovate-config-validator` 44.65.5 with both
`zensical` match strings hitting their files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)