### PR TITLE
changedetection: back up the watch history

### DIFF
--- a/k8s/apps/changedetection/app/release.yaml
+++ b/k8s/apps/changedetection/app/release.yaml
@@ -50,3 +50,16 @@ spec:
                   port: http
                 periodSeconds: 5
                 failureThreshold: 36
+        # The chart's persistence block has no annotations knob, and K8up runs
+        # with skipWithoutAnnotation, so the claim has to be opted in here.
+        # No excludes: the UUID directories are the watch history, which is the
+        # thing worth keeping, and the rest is config.
+        - target:
+            version: v1
+            kind: PersistentVolumeClaim
+            name: changedetection
+          patch: |-
+            - op: add
+              path: /metadata/annotations
+              value:
+                k8up.io/backup: "true"

--- a/k8s/apps/changedetection/backup/kustomization.yaml
+++ b/k8s/apps/changedetection/backup/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pvc.yaml
+  - schedule.yaml

--- a/k8s/apps/changedetection/backup/pvc.yaml
+++ b/k8s/apps/changedetection/backup/pvc.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: backup-repo
+  labels:
+    app.kubernetes.io/component: backup
+    app.kubernetes.io/name: changedetection
+spec:
+  # This namespace's restic repository. Repositories stay per-namespace even
+  # though the password is shared: a corrupted one then costs a single
+  # namespace, restic check stays cheap, and concurrent backups never contend
+  # for the same repository lock over an NFSv3 mount with nolock.
+  #
+  # excluded_from_alerts is stamped by kyverno's mutate-nfs-pvc-alert-exclusion
+  # for every unifi-nas claim. Do not add it here.
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: unifi-nas

--- a/k8s/apps/changedetection/backup/schedule.yaml
+++ b/k8s/apps/changedetection/backup/schedule.yaml
@@ -1,0 +1,59 @@
+apiVersion: k8up.io/v1
+kind: Schedule
+metadata:
+  name: backup
+  labels:
+    app.kubernetes.io/component: backup
+    app.kubernetes.io/name: changedetection
+spec:
+  backend:
+    # No repoPasswordSecretRef: the operator supplies RESTIC_PASSWORD from
+    # BACKUP_GLOBALREPOPASSWORD. Setting it here would override that for this
+    # namespace alone.
+    #
+    # The repository is plain restic files on the UNAS rather than S3 via a
+    # fourth versitygw. versitygw's posix backend would write those same files
+    # to that same export; going direct means a restore needs restic and an NFS
+    # mount, with no cluster running.
+    local:
+      mountPath: /repo
+    volumeMounts:
+      - name: backup-repo
+        mountPath: /repo
+  # Runs as root, deliberately. csi-nfs creates each subdir 0775 owned by
+  # 977:988 -- measured on a live claim, where the sonarr pod at uid 1000
+  # cannot write to its own backup directory -- and the UNAS refuses chown, so
+  # fsGroup cannot fix it either. paperless works around this with a root
+  # initContainer that chmods the export; K8up builds these Pods itself, so
+  # that is not available. A backup agent also has to read every file it is
+  # pointed at, regardless of ownership.
+  podSecurityContext:
+    runAsUser: 0
+    runAsGroup: 0
+  backup:
+    # Fixed rather than @daily-random: a restic repository is only consistent at
+    # rest, so an off-site copy of it needs a known quiet window. Staggered
+    # clear of paperless (22:36), CNPG (23:17-03:47) and Longhorn (04:19).
+    schedule: "30 21 * * *"
+    volumes:
+      - name: backup-repo
+        persistentVolumeClaim:
+          claimName: backup-repo
+  check:
+    schedule: "0 6 * * 0"
+    volumes:
+      - name: backup-repo
+        persistentVolumeClaim:
+          claimName: backup-repo
+  prune:
+    # After check, so a repository that already fails verification is not
+    # repacked before anyone has seen the failure.
+    schedule: "30 7 * * 0"
+    retention:
+      keepDaily: 14
+      keepWeekly: 8
+      keepMonthly: 6
+    volumes:
+      - name: backup-repo
+        persistentVolumeClaim:
+          claimName: backup-repo

--- a/k8s/apps/changedetection/kustomization.yaml
+++ b/k8s/apps/changedetection/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - app/
   - playwright/
   - proxy/
+  - backup/


### PR DESCRIPTION
Second namespace onto K8up (#1266), and the last one that needs no application hook — the datastore is JSON config plus per-watch snapshot files, no database.

### What is on the volume

Checked before writing anything, because the same check on mealie found 90% of that volume was a churning log:

| | |
| --- | --- |
| 1012 `.txt.br` | brotli-compressed change history |
| 314 `.txt` | recent uncompressed snapshots |
| 12 `.tar.gz` | before-update tarballs from version upgrades, 4K each |
| 7 `.json` + `secret.txt` | config, incl. `url-watches.json` |

15M across ~1300 small files, and **nothing worth excluding** — the change history is precisely what the app exists to keep. So no `k8up.io/backup-restic-args` here, in contrast to mealie.

### Notes

- The chart's `persistence` block exposes no PVC annotations, so the claim is opted in through the postRenderer that already patches this release for its startupProbe.
- No `repoPasswordSecretRef`; `RESTIC_PASSWORD` comes from the operator's `BACKUP_GLOBALREPOPASSWORD` (#1277).
- Schedules staggered 15 minutes after mealie's, keeping one backup on the 1GbE NAS link at a time.
- Backup Pods run as root, for the reasons recorded on the mealie Schedule.

### One accepted risk

changedetection writes `url-watches.json` as it runs and K8up reads the live filesystem, so a backup could in principle catch that 16K file mid-write. There is no dump hook available for this app and the exposure is small, but it is real and worth naming rather than discovering later. The snapshot history files are write-once, so they are unaffected.

### After merge

Longhorn's `c-gvgagj` keeps covering this volume. I will run a backup, `restic check` and a restore before treating it as done, as with mealie.

Refs #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)