### PR TITLE
docs: drop the inert CNAME file

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-docs.thaum.xyz


### PR DESCRIPTION
Follow-up to #1301. This commit existed on that branch but was pushed after the
merge, so it never landed.

`docs/CNAME` does nothing. GitHub's documentation is explicit:

> If you are publishing from a custom GitHub Actions workflow, no `CNAME` file is
> created, and any existing `CNAME` file is ignored and is not required.
> — [Managing a custom domain for your GitHub Pages site](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site)

I had added it on the assumption that it set the custom domain, which is true for
branch-based publishing but not for the workflow-based publishing this repository
uses. Its only effect is to publish a stray `/CNAME` at the site root.

The custom domain is now set in the repository's Pages settings instead, which is
what actually took effect — the site is live at <https://docs.thaum.xyz/> with
HTTPS enforced.

No functional change; the site builds identically without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)