### PR TITLE
karakeep: back up data and the search index

### DIFF
--- a/k8s/apps/karakeep/backup/kustomization.yaml
+++ b/k8s/apps/karakeep/backup/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pvc.yaml
+  - schedule.yaml

--- a/k8s/apps/karakeep/backup/pvc.yaml
+++ b/k8s/apps/karakeep/backup/pvc.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: backup-repo
+  labels:
+    app.kubernetes.io/component: backup
+    app.kubernetes.io/name: karakeep
+spec:
+  # This namespace's restic repository. Repositories stay per-namespace even
+  # though the password is shared: a corrupted one then costs a single
+  # namespace, restic check stays cheap, and concurrent backups never contend
+  # for the same repository lock over an NFSv3 mount with nolock.
+  #
+  # excluded_from_alerts is stamped by kyverno's mutate-nfs-pvc-alert-exclusion
+  # for every unifi-nas claim. Do not add it here.
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: unifi-nas

--- a/k8s/apps/karakeep/backup/schedule.yaml
+++ b/k8s/apps/karakeep/backup/schedule.yaml
@@ -1,0 +1,59 @@
+apiVersion: k8up.io/v1
+kind: Schedule
+metadata:
+  name: backup
+  labels:
+    app.kubernetes.io/component: backup
+    app.kubernetes.io/name: karakeep
+spec:
+  backend:
+    # No repoPasswordSecretRef: the operator supplies RESTIC_PASSWORD from
+    # BACKUP_GLOBALREPOPASSWORD. Setting it here would override that for this
+    # namespace alone.
+    #
+    # The repository is plain restic files on the UNAS rather than S3 via a
+    # fourth versitygw. versitygw's posix backend would write those same files
+    # to that same export; going direct means a restore needs restic and an NFS
+    # mount, with no cluster running.
+    local:
+      mountPath: /repo
+    volumeMounts:
+      - name: backup-repo
+        mountPath: /repo
+  # Runs as root, deliberately. csi-nfs creates each subdir 0775 owned by
+  # 977:988 -- measured on a live claim, where the sonarr pod at uid 1000
+  # cannot write to its own backup directory -- and the UNAS refuses chown, so
+  # fsGroup cannot fix it either. paperless works around this with a root
+  # initContainer that chmods the export; K8up builds these Pods itself, so
+  # that is not available. A backup agent also has to read every file it is
+  # pointed at, regardless of ownership.
+  podSecurityContext:
+    runAsUser: 0
+    runAsGroup: 0
+  backup:
+    # Fixed rather than @daily-random: a restic repository is only consistent at
+    # rest, so an off-site copy of it needs a known quiet window. Staggered
+    # clear of paperless (22:36), CNPG (23:17-03:47) and Longhorn (04:19).
+    schedule: "45 21 * * *"
+    volumes:
+      - name: backup-repo
+        persistentVolumeClaim:
+          claimName: backup-repo
+  check:
+    schedule: "15 6 * * 0"
+    volumes:
+      - name: backup-repo
+        persistentVolumeClaim:
+          claimName: backup-repo
+  prune:
+    # After check, so a repository that already fails verification is not
+    # repacked before anyone has seen the failure.
+    schedule: "45 7 * * 0"
+    retention:
+      keepDaily: 14
+      keepWeekly: 8
+      keepMonthly: 6
+    volumes:
+      - name: backup-repo
+        persistentVolumeClaim:
+          claimName: backup-repo

--- a/k8s/apps/karakeep/kustomization.yaml
+++ b/k8s/apps/karakeep/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - web/
   - search/
   - snapshotter/
+  - backup/

--- a/k8s/apps/karakeep/search/pvc.yaml
+++ b/k8s/apps/karakeep/search/pvc.yaml
@@ -1,6 +1,16 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  annotations:
+    # Opt in to K8up. The operator runs with skipWithoutAnnotation, so a claim
+    # without this is not backed up.
+    #
+    # The meilisearch index is derived data -- karakeep can rebuild it from
+    # db.db -- but #1266 has not yet confirmed it reindexes from empty, so it
+    # is backed up until that is settled. It is also a live LMDB store copied
+    # at the file level, so treat a restored index as a convenience, not a
+    # guarantee.
+    k8up.io/backup: "true"
   name: meilisearch-pvc
 spec:
   storageClassName: longhorn

--- a/k8s/apps/karakeep/web/pvc.yaml
+++ b/k8s/apps/karakeep/web/pvc.yaml
@@ -1,6 +1,15 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  annotations:
+    # Opt in to K8up. The operator runs with skipWithoutAnnotation, so a claim
+    # without this is not backed up.
+    #
+    # db.db is live SQLite and this is a file-level copy, so the database in a
+    # snapshot may be torn. Deliberate for now: a consistent dump needs a
+    # k8up.io/backupcommand, which comes separately. assets/ is the bulk of the
+    # volume and is write-once, so it is unaffected.
+    k8up.io/backup: "true"
   name: data-pvc
 spec:
   storageClassName: longhorn


### PR DESCRIPTION
Third namespace onto K8up (#1266). **File-level only — no hooks yet**, deliberately; the SQLite dump comes as a follow-up so this step and that one can be judged separately.

### The interesting part: two RWO volumes on different nodes

```
web           beelink01   -> data-pvc        (RWO)
meilisearch   beelink02   -> meilisearch-pvc (RWO)
```

This is the case that decided the engine. K8up reads each PVC's access mode, finds the pod using it, and pins the backup Job to that node (`backupcontroller/executor.go:103-176`, applied via `nodeSelector` at `:391`), so these are backed up by two separate node-pinned Jobs. Anything that mounts every PVC in a namespace into one pod would hit Multi-Attach here. Verifying that two Jobs land on the right nodes is the main thing I want out of this rollout.

### What is on the volumes

| | | |
| --- | --- | --- |
| `data-pvc` | 4.8M | `assets/` 4.1M, `db.db` 612K, `queue.db` 56K |
| `meilisearch-pvc` | 5.9M | the search index |

No excludes — unlike mealie, none of this is churn.

### Two caveats worth stating plainly

**`db.db` is live SQLite and this is a file-level copy**, so the database inside a snapshot may be torn. That is the accepted cost of shipping without hooks first. `assets/` is the bulk of the volume and is write-once, so it is unaffected. The dump script is already written and was verified against this container: `better-sqlite3`'s `serialize()` produced a 626K database passing `PRAGMA integrity_check` with 26 bookmarks intact. It follows in its own PR.

**meilisearch is derived data.** karakeep can rebuild it from `db.db`, so in principle it need not be backed up at all — but #1266 has not yet confirmed it reindexes from empty, so it stays in until that is settled. It is also a live LMDB store copied at the file level, so treat a restored index as a convenience rather than a guarantee; if it will not open, the answer is to reindex.

Both caveats are recorded as comments on the PVCs rather than only here.

### After merge

Longhorn's `c-gvgagj` keeps covering both volumes. I will run a backup, `restic check` and a restore, and confirm the two Jobs pinned to the right nodes.

Refs #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)