### PR TITLE
probes: check the application, not the login page it redirects to

### DIFF
--- a/k8s/apps/karakeep/web/ingress.yaml
+++ b/k8s/apps/karakeep/web/ingress.yaml
@@ -22,7 +22,10 @@ metadata:
     homer.rajsingh.info/enabled: "true"
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    probe-uri: /
+    # /  redirects to /signin, a 28KB Next.js shell that renders from static
+    # assets -- it returns 200 with the backend dead. /api/health is served by
+    # the app itself and answers {"status":"ok"} in 46 bytes.
+    probe-uri: /api/health
     item.homer.rajsingh.info/name: "Karakeep"
     item.homer.rajsingh.info/subtitle: "Bookmarks hoarder"
     item.homer.rajsingh.info/logo: "https://avatars.githubusercontent.com/u/202258986?s=60&v=4"

--- a/k8s/apps/paperless/manifests/app/ingress.yaml
+++ b/k8s/apps/paperless/manifests/app/ingress.yaml
@@ -3,6 +3,12 @@ kind: Ingress
 metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    # Without this the relabeling builds the bare host, so the probe followed a
+    # redirect to /accounts/login/?next=/ and depended on a default nobody
+    # chose. Same page, named explicitly and without the hop -- it is also what
+    # paperless's own readiness probe uses, and Django renders it server-side,
+    # so unlike an SPA shell a 200 does mean the application is running.
+    probe-uri: /accounts/login/
     item.homer.rajsingh.info/name: "Paperless"
     item.homer.rajsingh.info/subtitle: "Document management system"
     item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/refs/heads/main/assets/paperlessng.svg"

--- a/k8s/apps/vod-arr/seerr/ingress.yaml
+++ b/k8s/apps/vod-arr/seerr/ingress.yaml
@@ -6,7 +6,10 @@ kind: Ingress
 metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    probe-uri: /
+    # /  redirects to /login, a 297KB SPA bundle that renders from static
+    # assets whether or not the backend is alive. /api/v1/status is what seerr's
+    # own readiness probe uses, and answers in 98 bytes.
+    probe-uri: /api/v1/status
     item.homer.rajsingh.info/name: "Seerr"
     item.homer.rajsingh.info/subtitle: "Request movies and shows"
     item.homer.rajsingh.info/logo: "https://cdn.jsdelivr.net/npm/@loganmarchione/homelab-svg-assets@latest/assets/jellyseerr.svg"


### PR DESCRIPTION
6c item 2. Three probes still resolved to a bare host; two of them could not detect their own service failing — the same defect the `pdf` probe turned out to have, where it terminated on pocket-id's login page and would have stayed green with Stirling entirely down.

| target | before | lands on | after |
|---|---|---|---|
| `keep` | `/` | 1 redirect → `/signin`, **28KB Next.js shell** | `/api/health` → 200, 46B |
| `seek` | `/` | 1 redirect → `/login`, **297KB SPA bundle** | `/api/v1/status` → 200, 98B |
| `papers` | *no annotation* | 1 redirect → `/accounts/login/?next=/` | `/accounts/login/` → 200, 7.2KB |

A login page for `keep` and `seek` renders from static assets, so it answers 200 whether or not the backend is alive. The replacements are served by the application process itself.

**Corroborated by the apps' own probes**, not just my judgement: `/api/v1/status` is exactly what seerr's readiness probe uses, and `/accounts/login/?next=/` is exactly what paperless's uses. karakeep configures no probes at all, so `/api/health` is its designated endpoint returning `{"status":"ok"}`.

**`papers` is the mild case and worth naming as such.** Django renders that page server-side, so its 200 already meant the application was running. The change there removes a redirect and stops depending on a default nobody chose — it had no `probe-uri` annotation, so the relabeling built the bare host.

## Verification

All three end to end through the public URL — 200, **zero redirects**, no oauth2 proxy in the path:

```
https://keep.krupa.net.pl/api/health        200 redirects=0  46B
https://seek.krupa.net.pl/api/v1/status     200 redirects=0  98B
https://papers.krupa.net.pl/accounts/login/ 200 redirects=0  7247B
```

`make validate` — 123 targets clean. `make validate-flux` — 51 paths exist.

## Why now rather than later

With `ProbeBudgetBurn` unrouted for the burn-in, these probes are what the measurement phase is measuring. A probe that cannot see its service fail produces four weeks of evidence that reads "never fired" for the wrong reason.

**One side effect:** changing `probe-uri` changes the target URL and therefore the `instance` label, so the old series go stale and `blackbox-probe-success` starts fresh for these three. Doing it today costs a day of burn-in instead of three weeks.

Also incidental but real: `seek` was pulling a 297KB SPA bundle every 30s from two Prometheus replicas. That drops to 98 bytes.

## After merge

```
flux reconcile source git ankhmorpork
flux -n flux-system reconcile kustomization apps
```

Then confirm the three new targets appear with `probe_http_redirects == 0`, and that the old bare-host instances have stopped being scraped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)