### PR TITLE
grafana: probe /api/health, which Grafana actually serves

### DIFF
--- a/k8s/apps/grafana/grafana/values.yaml
+++ b/k8s/apps/grafana/grafana/values.yaml
@@ -23,7 +23,13 @@ ingress:
   ingressClassName: public
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    probe-uri: /-/healthy
+    # /-/healthy is Prometheus's convention, not Grafana's -- Grafana has no
+    # such route, so the request fell through to the catch-all and redirected to
+    # /login, where the probe collected a 59KB login page and called it healthy.
+    # /api/health is Grafana's own, answers in 101 bytes without a redirect, and
+    # reports {"database": "ok"} -- so unlike the alternatives it fails when
+    # Grafana's database is unreachable rather than only when the process is.
+    probe-uri: /api/health
     item.homer.rajsingh.info/name: "Grafana"
     item.homer.rajsingh.info/logo: "https://grafana.com/static/img/logos/grafana_logo_swirl-events.svg"
     item.homer.rajsingh.info/order: "50"


### PR DESCRIPTION
A fourth instance of the defect #1306 fixed, found while verifying that one rolled out.

`grafana` was the only probe still showing a redirect:

```
https://grafana.krupa.net.pl/-/healthy
  -> 200 redirects=1 final=/login?redirectTo=%2F-%2Fhealthy  (59445B)
```

**`/-/healthy` is Prometheus's convention, not Grafana's.** Grafana has no such route, so the request fell through to the catch-all and redirected to the login page. The probe was collecting 59KB of login HTML and reporting the service healthy.

The plan's inventory had listed grafana under *"already probes a real endpoint"* — on the strength of the path looking like one. It wasn't checked, which is the same mistake in miniature that this whole thread is about.

## Why `/api/health` and not `/healthz`

Both return 200 with no redirect. They are not equivalent:

| path | size | body |
|---|---|---|
| `/api/health` | 101B | `{"database": "ok", "version": "13.2.0", ...}` |
| `/healthz` | 2B | `Ok` |
| `/-/healthy` | 59445B | the login page |

`/api/health` reports database status, so it fails when Grafana's database is unreachable. `/healthz` answers `Ok` from the process and would not. Given the point of this work is probes that fail when the service is actually broken, the deeper one wins.

`make validate` — 124 targets clean.

## After merge

```
flux reconcile source git ankhmorpork
flux -n flux-system reconcile kustomization apps
flux -n grafana reconcile helmrelease grafana
```

Then confirm `probe_http_redirects{instance=~".*grafana.*"} == 0` — that will be **every** probe target at zero redirects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)