### PR TITLE
open-webui: back up the data, not the model cache

### DIFF
--- a/k8s/apps/mended-drum/backup/kustomization.yaml
+++ b/k8s/apps/mended-drum/backup/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pvc.yaml
+  - schedule.yaml

--- a/k8s/apps/mended-drum/backup/pvc.yaml
+++ b/k8s/apps/mended-drum/backup/pvc.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: backup-repo
+  labels:
+    app.kubernetes.io/component: backup
+    app.kubernetes.io/name: mended-drum
+spec:
+  # This namespace's restic repository. Repositories stay per-namespace even
+  # though the password is shared: a corrupted one then costs a single
+  # namespace, restic check stays cheap, and concurrent backups never contend
+  # for the same repository lock over an NFSv3 mount with nolock.
+  #
+  # excluded_from_alerts is stamped by kyverno's mutate-nfs-pvc-alert-exclusion
+  # for every unifi-nas claim. Do not add it here.
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: unifi-nas

--- a/k8s/apps/mended-drum/backup/schedule.yaml
+++ b/k8s/apps/mended-drum/backup/schedule.yaml
@@ -1,0 +1,59 @@
+apiVersion: k8up.io/v1
+kind: Schedule
+metadata:
+  name: backup
+  labels:
+    app.kubernetes.io/component: backup
+    app.kubernetes.io/name: mended-drum
+spec:
+  backend:
+    # No repoPasswordSecretRef: the operator supplies RESTIC_PASSWORD from
+    # BACKUP_GLOBALREPOPASSWORD. Setting it here would override that for this
+    # namespace alone.
+    #
+    # The repository is plain restic files on the UNAS rather than S3 via a
+    # fourth versitygw. versitygw's posix backend would write those same files
+    # to that same export; going direct means a restore needs restic and an NFS
+    # mount, with no cluster running.
+    local:
+      mountPath: /repo
+    volumeMounts:
+      - name: backup-repo
+        mountPath: /repo
+  # Runs as root, deliberately. csi-nfs creates each subdir 0775 owned by
+  # 977:988 -- measured on a live claim, where the sonarr pod at uid 1000
+  # cannot write to its own backup directory -- and the UNAS refuses chown, so
+  # fsGroup cannot fix it either. paperless works around this with a root
+  # initContainer that chmods the export; K8up builds these Pods itself, so
+  # that is not available. A backup agent also has to read every file it is
+  # pointed at, regardless of ownership.
+  podSecurityContext:
+    runAsUser: 0
+    runAsGroup: 0
+  backup:
+    # Fixed rather than @daily-random: a restic repository is only consistent at
+    # rest, so an off-site copy of it needs a known quiet window. Staggered
+    # clear of paperless (22:36), CNPG (23:17-03:47) and Longhorn (04:19).
+    schedule: "0 22 * * *"
+    volumes:
+      - name: backup-repo
+        persistentVolumeClaim:
+          claimName: backup-repo
+  check:
+    schedule: "30 6 * * 0"
+    volumes:
+      - name: backup-repo
+        persistentVolumeClaim:
+          claimName: backup-repo
+  prune:
+    # After check, so a repository that already fails verification is not
+    # repacked before anyone has seen the failure.
+    schedule: "0 8 * * 0"
+    retention:
+      keepDaily: 14
+      keepWeekly: 8
+      keepMonthly: 6
+    volumes:
+      - name: backup-repo
+        persistentVolumeClaim:
+          claimName: backup-repo

--- a/k8s/apps/mended-drum/kustomization.yaml
+++ b/k8s/apps/mended-drum/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - open-webui/
   - tools/
   - db/
+  - backup/

--- a/k8s/apps/mended-drum/open-webui/pvc.yaml
+++ b/k8s/apps/mended-drum/open-webui/pvc.yaml
@@ -1,6 +1,24 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  annotations:
+    # Opt in to K8up. The operator runs with skipWithoutAnnotation, so a claim
+    # without this is not backed up -- which is what keeps the two CNPG claims
+    # in this namespace out, since they self-backup via barman.
+    k8up.io/backup: "true"
+    # cache/embedding and cache/whisper are 1.03G of the 1.1G on this volume:
+    # HuggingFace blobs for all-MiniLM-L6-v2 and faster-whisper-base, which
+    # open-webui re-downloads on demand. Copying them to the NAS nightly over
+    # one 1GbE link would make this backup a hundred times larger than every
+    # other one in the cluster combined, to protect nothing.
+    #
+    # cache/audio/transcriptions is deliberately kept: it is small, and the
+    # uploads it was derived from are already gone.
+    #
+    # webui.db is live SQLite in WAL mode and this is a file-level copy, so the
+    # database in a snapshot may be torn. A consistent dump needs a
+    # k8up.io/backupcommand, which comes separately.
+    k8up.io/backup-restic-args: '["--exclude=/data/open-webui-data/cache/embedding", "--exclude=/data/open-webui-data/cache/whisper"]'
   name: open-webui-data
   labels:
     app.kubernetes.io/name: open-webui


### PR DESCRIPTION
Fourth and last namespace from #1266. **File-level only, no hooks yet** — the SQLite dump follows separately.

### The volume is not what it looks like

`/app/backend/data` is **1.1G**. Checking before writing anything found that almost none of it is data:

| | | |
| --- | --- | --- |
| `cache/embedding/models` | **890M** | HuggingFace `sentence-transformers/all-MiniLM-L6-v2` blobs |
| `cache/whisper/models` | **142M** | `Systran/faster-whisper-base` |
| `webui.db` | 876K | the actual application database |
| `vector_db/chroma.sqlite3` | 184K | RAG vector store |
| `cache/audio/transcriptions` | 496K | |
| `uploads`, `cache/image` | 0 | |

Both model caches are re-downloaded on demand. Backing them up nightly over one 1GbE link would make this backup **larger than every other one in the cluster combined**, to protect nothing that cannot be fetched again — so they are excluded, leaving ~1M that genuinely matters.

`cache/audio/transcriptions` is deliberately kept despite living under `cache/`: it is small, and the uploads it was derived from are already gone, so unlike the models it is not reproducible.

### Caveat, same as karakeep

`webui.db` is live SQLite **in WAL mode** — `-wal` and `-shm` are both present — and this is a file-level copy, so the database in a snapshot may be torn. That is the accepted cost of landing file-level backups first. The dump script is written and was verified against this container: a tar of `webui.db` and `chroma.sqlite3`, each passing `PRAGMA integrity_check` after extraction. It comes in its own PR.

The two CNPG claims in this namespace need no annotation to stay out — `skipWithoutAnnotation` means opting in is explicit.

### Related

The cache arguably should not be on a 2Gi replicated volume at all — same family as the immich ML cache in #1266 and the mealie log in #1303. Filing that separately rather than widening this PR. Not urgent: the volume is 55.6% full with 881 MiB free, and `KubePersistentVolumeFillingUp` covers it.

Refs #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)