### PR TITLE
docs: write the tutorial, and link the docs site from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ankhmorpork
 
-<!-- [![document](https://img.shields.io/website?label=document&logo=gitbook&logoColor=white&url=https%3A%2F%2Fdocs.thaum.xyz)](https://docs.thaum.xyz) -->
+[![document](https://img.shields.io/website?label=document&logo=gitbook&logoColor=white&url=https%3A%2F%2Fdocs.thaum.xyz)](https://docs.thaum.xyz)
 [![license](https://img.shields.io/github/license/thaum-xyz/ankhmorpork?logo=mit&logoColor=white)](https://github.com/thaum-xyz/ankhmorpork/blob/master/LICENSE)
 [![validate](https://github.com/thaum-xyz/ankhmorpork/actions/workflows/validate.yml/badge.svg)](https://github.com/thaum-xyz/ankhmorpork/actions/workflows/validate.yml)
 

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -1,33 +1,323 @@
-# Tutorial { .quad-tutorial }
+# Deploy your first app { .quad-tutorial }
 
-!!! warning "Placeholder"
+By the end of this you will have deployed an application to the cluster, watched
+Flux pick it up, seen it answer over HTTPS on its own hostname, and removed it
+again — about twenty minutes, most of it waiting.
 
-    The site scaffold is in place; this section has no content yet.
+The app is `whoami`: a few megabytes, no storage, no configuration. It echoes back
+the request it received, which is exactly what you want the first time, because the
+page it returns is proof that every layer worked.
 
-## What belongs here
+You are not learning `whoami`. You are learning how anything gets into this
+cluster.
 
-A tutorial is a **lesson**. The reader is learning the cluster, and the app they
-deploy is a means to that end — they do not care about it and will delete it at
-the end.
+!!! note "This deploys to the real cluster"
 
-Admission test, all four must hold:
+    There is no staging environment. You will create a real namespace, a real DNS
+    record and a real certificate — then delete all of it in the last step. This
+    is safe: nothing else depends on what you are about to make.
 
-- [ ] It is safe to follow start to finish with no prior knowledge of this cluster.
-- [ ] It **succeeds every time**. No "depending on your setup", no branches.
-- [ ] It contains **no decisions**. Every choice is made for the reader, with the
-      reasoning deferred to [Explanation](../explanation/index.md) and the
-      alternatives to [Reference](../reference/index.md).
-- [ ] It ends with the reader having seen something work.
+## Before you start
 
-That last constraint is why there is only ever going to be one tutorial here.
-Decision tables — pick a StorageClass, pick an ingress class — are exactly what a
-tutorial must not contain. They are how-to and reference material.
+You need:
 
-## Planned
+- A clone of this repository, and permission to merge a pull request.
+- `kubectl` and `flux` on your PATH, with `KUBECONFIG=~/.kube/clusters/ankhmorpork`.
+- `kustomize` and `kubeconform`, used by `make validate`.
 
-- **Deploy your first app** — a throwaway app end to end: manifests under
-  `k8s/apps/`, a Flux Kustomization under `k8s/flux/apps/`, `make validate`,
-  merge, reconcile, watch it come up, delete it again.
+Check the connection:
 
-Individual applications (Plex, Immich, Mealie) will never have a tutorial. Nobody
-learns this cluster *through* Mealie. Those get reference and how-to instead.
+```bash
+export KUBECONFIG=~/.kube/clusters/ankhmorpork
+kubectl get nodes
+```
+
+You should see the cluster's nodes, all `Ready`. If that fails, stop here and fix
+it — nothing below will work.
+
+Start from a branch:
+
+```bash
+git switch master && git pull
+git switch -c tutorial-whoami
+```
+
+## Step 1 — Write the manifests
+
+An app is a directory of manifests plus a Flux Kustomization pointing at it.
+Nothing registers it anywhere else; the directory *is* the app.
+
+```bash
+mkdir -p k8s/apps/whoami
+```
+
+One Kubernetes object per file, named after the object type. Create these four.
+
+`k8s/apps/whoami/namespace.yaml`:
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: whoami
+```
+
+`k8s/apps/whoami/deployment.yaml`:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: whoami
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: whoami
+  template:
+    metadata:
+      labels:
+        app: whoami
+    spec:
+      containers:
+        - name: whoami
+          image: traefik/whoami:v1.12.0
+          ports:
+            - name: http
+              containerPort: 80
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+```
+
+`k8s/apps/whoami/service.yaml`:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami
+spec:
+  selector:
+    app: whoami
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+```
+
+`k8s/apps/whoami/ingress.yaml`:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: whoami
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: private
+  rules:
+    - host: whoami.ankhmorpork.thaum.xyz
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami
+                port:
+                  name: http
+  tls:
+    - hosts:
+        - whoami.ankhmorpork.thaum.xyz
+      secretName: whoami-tls
+```
+
+Finally, the kustomization that ties them together —
+`k8s/apps/whoami/kustomization.yaml`:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: whoami
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+```
+
+That `namespace:` line is doing real work: it is what puts every object above into
+the `whoami` namespace without any of them saying so individually.
+
+## Step 2 — Tell Flux about it
+
+Flux does not scan for new directories. Point it at the one you just made, in
+`k8s/flux/apps/whoami.yaml`:
+
+```yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: whoami
+  namespace: flux-system
+spec:
+  interval: 15m0s
+  path: ./k8s/apps/whoami
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: ankhmorpork
+```
+
+`prune: true` means deleting the directory later deletes the objects too, which is
+what makes the cleanup step at the end work.
+
+## Step 3 — Validate before pushing
+
+```bash
+git add k8s/apps/whoami k8s/flux/apps/whoami.yaml
+make validate
+```
+
+The `git add` is not optional. `make validate` reads **git-tracked** files, so an
+unstaged new directory validates as though it does not exist — it will report
+success while checking nothing.
+
+The last line should end `render and validate cleanly`, with a target count one
+higher than the run before you added the app:
+
+```text
+All 125 targets render and validate cleanly.
+```
+
+The absolute number grows as the cluster does, so compare it with your own
+previous run rather than with the number printed here.
+
+## Step 4 — Merge it
+
+```bash
+git commit -m "whoami: tutorial app"
+git push -u origin tutorial-whoami
+gh pr create --fill
+```
+
+Wait for the checks, then merge. Flux only reads `master`, so nothing happens
+until you do.
+
+## Step 5 — Make Flux notice
+
+Flux polls, so it will find this within a few minutes on its own. To watch it
+happen now, reconcile in this order:
+
+```bash
+flux reconcile source git ankhmorpork
+flux -n flux-system reconcile kustomization apps
+flux -n flux-system reconcile kustomization whoami
+```
+
+The order matters. The first command pulls the new commit; without it the other
+two can act on a revision from before your merge and report success having done
+nothing. The second makes the `apps` group notice that a new Kustomization exists
+at all — your `whoami` Kustomization does not exist in the cluster until then.
+
+Now watch the pod arrive:
+
+```bash
+kubectl -n whoami get pods -w
+```
+
+Wait for `Running`, then press ++ctrl+c++.
+
+## Step 6 — See it work
+
+The certificate takes a minute or two. Watch for it:
+
+```bash
+kubectl -n whoami get certificate -w
+```
+
+Wait until `READY` is `True`, then press ++ctrl+c++ and make a request:
+
+```bash
+curl https://whoami.ankhmorpork.thaum.xyz/
+```
+
+You should get something like:
+
+```text
+Hostname: whoami-6d7f9c8b4-xk2wq
+IP: 127.0.0.1
+IP: 10.42.3.17
+RemoteAddr: 10.42.0.9:41234
+GET / HTTP/1.1
+Host: whoami.ankhmorpork.thaum.xyz
+X-Forwarded-For: 192.168.50.42
+X-Forwarded-Proto: https
+```
+
+Read that output for a moment, because it is the whole point:
+
+- **`Hostname`** is your pod. Kubernetes scheduled it.
+- **`Host`** is your name. `external-dns` published it to the house resolver.
+- **`X-Forwarded-Proto: https`** means Traefik terminated a certificate that
+  `cert-manager` obtained for a hostname that did not exist ten minutes ago.
+
+Nothing in the manifests you wrote mentioned DNS or certificates. Both happened
+because the Ingress existed.
+
+It also works in a browser at
+<https://whoami.ankhmorpork.thaum.xyz>, from anywhere on the house network —
+`private` means exactly that, and nothing you made is reachable from outside.
+
+## Step 7 — Remove it
+
+Delete both pieces and merge again:
+
+```bash
+git switch -c tutorial-whoami-cleanup
+git rm -r k8s/apps/whoami k8s/flux/apps/whoami.yaml
+git commit -m "whoami: remove tutorial app"
+git push -u origin tutorial-whoami-cleanup
+gh pr create --fill
+```
+
+After merging:
+
+```bash
+flux reconcile source git ankhmorpork
+flux -n flux-system reconcile kustomization apps
+kubectl get namespace whoami
+```
+
+Once the `apps` Kustomization prunes it, that last command reports
+`NotFound`. The namespace, the pod, the certificate and the DNS record all go with
+it, because `prune: true` means Flux owns what it created.
+
+## What you just learned
+
+- An app is a **directory plus a Flux Kustomization**. There is no registry, no
+  install command, and nothing to click.
+- **Git is the interface.** Everything reached the cluster by being merged. You
+  never ran `kubectl apply`.
+- **`make validate` reads staged files**, so `git add` comes first.
+- **Reconcile source before Kustomization**, or you will get a confident success
+  message about a revision that predates your change.
+- **An Ingress buys more than routing** — DNS and a certificate arrived with it.
+
+## Where to go next
+
+This was a lesson, so it made every choice for you. Real work needs those choices
+back:
+
+- **[How-to](../how-to/index.md)** — the same steps for an app that needs
+  storage, a database, or a public hostname.
+- **[Reference](../reference/index.md)** — the storage classes, ingress classes
+  and admission policies you skipped past. The Ingress above satisfies
+  `validate-ingress-contract`, which *denies* anything missing TLS or using an
+  unapproved issuer; the resource requests satisfy `require-resource-requests`,
+  which only warns. Both were chosen for you here.
+- **[Explanation](../explanation/index.md)** — why the cluster is arranged this
+  way.


### PR DESCRIPTION
Fills in the Tutorial section, and uncomments the docs badge now that
<https://docs.thaum.xyz/> is live.

### The app is `traefik/whoami`, deliberately

A tutorial is a lesson about *the cluster*, not about the thing being deployed, so
the app should be as close to nothing as possible. `whoami` needs no storage, no
config and no database — and its response is the payoff:

```text
Hostname: whoami-6d7f9c8b4-xk2wq
Host: whoami.ankhmorpork.thaum.xyz
X-Forwarded-Proto: https
```

Three lines proving Kubernetes scheduled it, external-dns published the name, and
cert-manager obtained a certificate for a hostname that did not exist ten minutes
earlier. Nothing in the manifests mentions DNS or TLS — the page points that out,
because it is the thing worth noticing.

The learner deletes it in step 7, which also demonstrates what `prune: true` means.

### No decisions in it

Ingress class, issuer, resource requests, image tag — all chosen for the reader,
with alternatives deferred to Reference and reasoning to Explanation. Decision
tables are exactly what a tutorial must not contain, which is why the deployment
skill is a how-to and this is not.

It teaches the two traps that actually bite:

- **`make validate` reads git-tracked files**, so `git add` comes before it or a
  new app validates as though it does not exist.
- **Reconcile the source before the Kustomization**, and the `apps` group before
  the app, or Flux reports success against a pre-merge revision.

### The manifests were run, not written from memory

I extracted the YAML blocks from the page itself, put them in the tree, and:

- `make validate` → **124 → 125 targets**, clean
- `make validate-flux` → clean
- `kustomize build` → confirmed the `namespace:` line really does place the
  Service, Deployment and Ingress
- checked the rendered Ingress against all five `validate-ingress-contract` rules
  (class, no deprecated annotation, TLS present, approved issuer, `secretName`)

Then removed them again — this PR adds no manifests.

Worth noting `require-resource-requests` is `Warn`, not `Deny`, so the requests in
the tutorial are good practice rather than something the cluster enforces. The page
says so.

The printed target count appears as an example, with the text telling you to
compare against your own previous run — that number grows with the cluster, and
hardcoding it would be the same staleness trap as the `Consumed by` column in
thaum-xyz/helm-charts#18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)