### PR TITLE
karakeep: dump db.db through SQLite rather than copying it live

### DIFF
--- a/k8s/apps/karakeep/web/deployment.yaml
+++ b/k8s/apps/karakeep/web/deployment.yaml
@@ -16,6 +16,13 @@ spec:
       app: karakeep-web
   template:
     metadata:
+      annotations:
+        # db.db is live SQLite and K8up reads the running filesystem, so the
+        # file-level copy of it can tear. This streams a copy taken through
+        # SQLite's own API into the repository as its own snapshot; that is the
+        # one to restore from. The file-level copy stays as a fallback.
+        k8up.io/backupcommand: node /backup/dump.js
+        k8up.io/file-extension: .sqlite
       labels:
         app: karakeep-web
     spec:
@@ -48,6 +55,9 @@ spec:
           volumeMounts:
             - mountPath: /data
               name: data
+            - mountPath: /backup
+              name: backup-script
+              readOnly: true
           envFrom:
             - secretRef:
                 name: karakeep-secrets
@@ -61,3 +71,6 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: data-pvc
+        - name: backup-script
+          configMap:
+            name: backup-script

--- a/k8s/apps/karakeep/web/kustomization.yaml
+++ b/k8s/apps/karakeep/web/kustomization.yaml
@@ -7,3 +7,14 @@ resources:
   - ingress-cloudflare.yaml
   - pvc.yaml
   - podmonitor.yaml
+configMapGenerator:
+  # The dump script is a real file so it stays readable and lintable. Inlining
+  # it in the k8up.io/backupcommand annotation is not an option: K8up tokenises
+  # that string with qsplit, whose quotes neither nest nor escape.
+  - name: backup-script
+    files:
+      - scripts/dump.js
+generatorOptions:
+  # Stable name. The script is read at exec time from the mounted ConfigMap, so
+  # a change reaches the next backup without rolling the pod.
+  disableNameSuffixHash: true

--- a/k8s/apps/karakeep/web/scripts/dump.js
+++ b/k8s/apps/karakeep/web/scripts/dump.js
@@ -1,0 +1,30 @@
+// Stream a consistent copy of karakeep's SQLite database to stdout.
+//
+// Invoked by K8up via the k8up.io/backupcommand annotation. Copying the file
+// off a live volume can tear; serialize() reads it through SQLite itself and
+// hands back a coherent image instead.
+//
+// The image ships no sqlite3 binary, so this goes through the better-sqlite3
+// the application itself uses. The path is absolute because this script lives
+// outside /app and node resolves modules relative to the file.
+//
+// queue.db is deliberately not included. It is a liteque job queue, not data:
+// restoring a stale one would replay or block jobs that have long since been
+// handled. K8up's file-level backup of the PVC still captures it.
+//
+// Throwing fails the K8up Job, which is what K8upJobFailed alerts on. That is
+// the point of doing this here rather than trusting the file-level copy: a
+// broken dump is loud, where a torn db.db is silent until a restore.
+
+const Database = require("/app/node_modules/better-sqlite3");
+
+const path = `${process.env.DATA_DIR || "/data"}/db.db`;
+const db = new Database(path, { readonly: true });
+
+try {
+  const image = db.serialize();
+  process.stderr.write(`${path}: ${image.length} bytes\n`);
+  process.stdout.write(image);
+} finally {
+  db.close();
+}


### PR DESCRIPTION
The hook half of #1305. K8up reads the running filesystem, so the file-level copy of `db.db` in a snapshot can be torn. This adds a `k8up.io/backupcommand` that streams a copy taken through SQLite's own `serialize()` into the repository as its own snapshot.

**Verified against the running container**: 626688 bytes out, `PRAGMA integrity_check` **ok**, 26 bookmarks present.

### The file-level copy stays

It is not excluded. It is usually fine — `db.db` was last written 2026-07-30, and the restore proof in #1305 found it intact — but "usually" is exactly the property a backup should not have, and the failure mode is silent: a torn database looks like a database until you try to open it. So the dump is the artefact to restore from, and the file copy is a fallback.

The inverse matters too: if the dump ever breaks, the Job fails and `K8upJobFailed` reports it. A silently-torn file copy would not.

### Why a ConfigMap and not an inline annotation

K8up tokenises `backupcommand` with `qsplit`, whose quotes neither nest nor escape — a multi-line script with both quote styles cannot be expressed there safely. As a file it also stays readable and reviewable.

The script uses the `better-sqlite3` the app already bundles, since the image ships no `sqlite3` binary. The `require` path is absolute because the script lives outside `/app` and node resolves modules relative to the file.

`disableNameSuffixHash: true` is deliberate: the script is read at exec time from the mounted ConfigMap, so editing it reaches the next backup without rolling the pod.

### queue.db is deliberately not dumped

It is a liteque job queue, not data. Restoring a stale one would replay or block jobs long since handled. The file-level backup still captures it.

### Checked before writing

- `pod-executor` ServiceAccount and its binding to ClusterRole `k8up-executor` exist in the namespace, and `kubectl auth can-i create pods --subresource=exec` as that SA returns **yes** — so the exec will be permitted.
- `node` and `/app/node_modules/better-sqlite3` still present on image `0.32.0`.

Refs #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)