### PR TITLE
open-webui: dump both SQLite databases through SQLite

### DIFF
--- a/k8s/apps/mended-drum/open-webui/deployment.yaml
+++ b/k8s/apps/mended-drum/open-webui/deployment.yaml
@@ -13,6 +13,14 @@ spec:
       app.kubernetes.io/name: open-webui
   template:
     metadata:
+      annotations:
+        # webui.db and the chroma vector store are live SQLite in WAL mode, and
+        # K8up reads the running filesystem, so the file-level copies of them
+        # can tear. This streams copies taken through SQLite's own API into the
+        # repository as one tar; that is what to restore from. The file-level
+        # copies stay as a fallback.
+        k8up.io/backupcommand: python3 /backup/dump.py
+        k8up.io/file-extension: .tar
       labels:
         app.kubernetes.io/name: open-webui
     spec:
@@ -73,7 +81,13 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /app/backend/data
+            - name: backup-script
+              mountPath: /backup
+              readOnly: true
       volumes:
         - name: data
           persistentVolumeClaim:
             claimName: open-webui-data
+        - name: backup-script
+          configMap:
+            name: backup-script

--- a/k8s/apps/mended-drum/open-webui/kustomization.yaml
+++ b/k8s/apps/mended-drum/open-webui/kustomization.yaml
@@ -8,3 +8,14 @@ resources:
   - ingress.yaml
   - ingress-cloudflare.yaml
   - deployment.yaml
+configMapGenerator:
+  # The dump script is a real file so it stays readable and lintable. Inlining
+  # it in the k8up.io/backupcommand annotation is not an option: K8up tokenises
+  # that string with qsplit, whose quotes neither nest nor escape.
+  - name: backup-script
+    files:
+      - scripts/dump.py
+generatorOptions:
+  # Stable name. The script is read at exec time from the mounted ConfigMap, so
+  # a change reaches the next backup without rolling the pod.
+  disableNameSuffixHash: true

--- a/k8s/apps/mended-drum/open-webui/scripts/dump.py
+++ b/k8s/apps/mended-drum/open-webui/scripts/dump.py
@@ -1,0 +1,47 @@
+"""Stream a consistent tar of open-webui's SQLite databases to stdout.
+
+Invoked by K8up via the k8up.io/backupcommand annotation. Both databases run in
+WAL mode, so copying the files off a live volume can tear. sqlite3's online
+backup API takes the read lock and hands back a coherent copy instead.
+
+Exiting non-zero fails the K8up Job, which is what K8upJobFailed alerts on.
+That is the point of doing this here rather than trusting the file-level copy:
+a broken dump is loud, where a torn webui.db is silent until a restore.
+"""
+
+import io
+import sqlite3
+import sys
+import tarfile
+
+DATABASES = (
+    ("webui.db", "/app/backend/data/webui.db"),
+    ("chroma.sqlite3", "/app/backend/data/vector_db/chroma.sqlite3"),
+)
+
+
+def snapshot(path):
+    """Return a consistent copy of the database at path as bytes."""
+    source = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    try:
+        memory = sqlite3.connect(":memory:")
+        try:
+            source.backup(memory)
+            return memory.serialize()
+        finally:
+            memory.close()
+    finally:
+        source.close()
+
+
+def main():
+    with tarfile.open(fileobj=sys.stdout.buffer, mode="w|") as tar:
+        for name, path in DATABASES:
+            data = snapshot(path)
+            entry = tarfile.TarInfo(name)
+            entry.size = len(data)
+            tar.addfile(entry, io.BytesIO(data))
+            print(f"{name}: {len(data)} bytes", file=sys.stderr)
+
+
+main()


### PR DESCRIPTION
The hook half of #1309, and the last piece of the four-namespace backup work in #1266.

K8up reads the running filesystem, so the file-level copies of `webui.db` and the chroma vector store can tear. `webui.db` runs **in WAL mode** — `-wal` and `-shm` are both present — which makes it the more exposed of the two SQLite apps here; karakeep's has no WAL sidecar files.

**Verified against the running container**: `webui.db` 897024 bytes and `chroma.sqlite3` 188416 bytes, both passing `PRAGMA integrity_check` after extraction, 15 chats present.

### One tar, two databases

K8up allows one `backupcommand` per pod, so the script emits a tar of both rather than two snapshots. `sqlite3`'s online backup API takes the read lock and hands back a coherent copy of each.

### The file-level copies stay

Not excluded, same reasoning as karakeep (#1314): they are usually fine, and the failure is silent — a torn database looks like a database until you open it. The dump is what to restore from; the file copy is a fallback. Conversely a broken dump fails the Job and surfaces as `K8upJobFailed`, so the hook failing is loud.

### Why a ConfigMap, again

`qsplit` tokenising means an inline multi-line script with mixed quotes cannot be expressed safely in the annotation. As a file it is also readable and reviewable. `disableNameSuffixHash: true` is deliberate — the script is read at exec time, so an edit reaches the next backup without rolling the pod.

Uses the `python3` the image already ships, since there is no `sqlite3` binary.

### After merge

I will run a backup, confirm a `.tar` snapshot appears alongside the PVC one, restore it and check both databases open — as done for karakeep, where the restored dump came back with `integrity_check ok`, 26 bookmarks and 130 tables.

Refs #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)