### PR TITLE
karakeep: meilisearch does not rebuild itself, so keep the volume

### DIFF
--- a/k8s/apps/karakeep/search/pvc.yaml
+++ b/k8s/apps/karakeep/search/pvc.yaml
@@ -5,11 +5,15 @@ metadata:
     # Opt in to K8up. The operator runs with skipWithoutAnnotation, so a claim
     # without this is not backed up.
     #
-    # The meilisearch index is derived data -- karakeep can rebuild it from
-    # db.db -- but #1266 has not yet confirmed it reindexes from empty, so it
-    # is backed up until that is settled. It is also a live LMDB store copied
-    # at the file level, so treat a restored index as a convenience, not a
-    # guarantee.
+    # The meilisearch index looks like derived data, but karakeep does not
+    # rebuild it. Measured 2026-09-06: emptying /meili_data and restarting both
+    # meilisearch and karakeep leaves /stats reporting `"indexes":{}` -- the
+    # worker logs "Starting search indexing worker" and never backfills.
+    # Repopulating needs someone to run admin.reindex from the web UI.
+    #
+    # So this is not emptyDir material, and the backup is what actually gets it
+    # back: restoring the snapshot returned all 26 documents with search
+    # working, where nothing would have alerted that the index was empty.
     k8up.io/backup: "true"
   name: meilisearch-pvc
 spec:


### PR DESCRIPTION
Comment-only. Settles the first checkbox in #1266 and replaces a conditional comment with a measured statement.

The question was whether karakeep reindexes meilisearch from empty — if it did, the index could be `emptyDir` and dropped from backups entirely.

**It does not.**

| stage | `/stats` |
| --- | --- |
| before | `bookmarks`, 26 documents |
| meilisearch restarted on an emptied volume | `"indexes":{}` |
| 90s later, karakeep untouched | `"indexes":{}` |
| after a full `rollout restart` of karakeep web | `"indexes":{}` |

The worker starts cleanly (`Starting search indexing worker ...`) and never backfills. The code agrees: `createIndex`/`updateSettings` mean the index *structure* heals on the next indexing job, but nothing enumerates existing bookmarks at startup. Repopulating needs `admin.reindex` from the web UI — a human clicking a button.

So with `emptyDir`, search would break on every kured reboot and stay broken until somebody noticed, and **nothing alerts on an empty index**.

### The backup is the recovery path

I recovered from the test by restoring the restic snapshot rather than clicking reindex: 13 files / 5.989 MiB, back to `documents=26` with search returning 26 hits. That also gives karakeep a second proven restore, on a live LMDB store — a volume type the earlier proof in #1305 did not cover.

A fresh backup was taken before emptying anything.

Refs #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)