### PR TITLE
docs: drop a stale version claim, and fix the section colours

### DIFF
--- a/docs/explanation/configmap-autoreload.md
+++ b/docs/explanation/configmap-autoreload.md
@@ -1,4 +1,4 @@
-# Why a Kyverno policy rolls Pods on ConfigMap changes
+# Why a Kyverno policy rolls Pods on ConfigMap changes { .quad-explanation }
 
 A Pod mounting a ConfigMap sees the file change — the kubelet syncs the volume
 within a minute — but a process that reads its configuration once at startup

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -1,9 +1,5 @@
 # Explanation { .quad-explanation }
 
-!!! warning "Placeholder"
-
-    The site scaffold is in place; this section has mostly no content yet.
-
 ## What belongs here
 
 Explanation is **discussion**. It is the only section that may argue, compare,

--- a/docs/explanation/pint-rule-linting.md
+++ b/docs/explanation/pint-rule-linting.md
@@ -1,4 +1,4 @@
-# Why the rule linter alerts on change, not on count
+# Why the rule linter alerts on change, not on count { .quad-explanation }
 
 [pint](https://cloudflare.github.io/pint/) lints the alerting and recording rules
 this cluster runs. It found six alerts that could never have fired, some of them

--- a/docs/how-to/reload-on-configmap-change.md
+++ b/docs/how-to/reload-on-configmap-change.md
@@ -1,4 +1,4 @@
-# Roll a workload when its ConfigMap changes
+# Roll a workload when its ConfigMap changes { .quad-howto }
 
 Mounting a ConfigMap as a volume does **not** restart the Pod. The kubelet syncs
 the file within a minute or so, but a process that reads its configuration once

--- a/docs/postgres/fleet-upgrade-plan.md
+++ b/docs/postgres/fleet-upgrade-plan.md
@@ -1,4 +1,4 @@
-# PostgreSQL fleet: state and upgrade plan
+# PostgreSQL fleet: state and upgrade plan { .quad-explanation }
 
 Surveyed 2026-08-23. Eleven CNPG clusters on operator 1.30.0, chart
 `cnpg-database`.
@@ -9,7 +9,15 @@ Nine clusters never set `imageName`. CloudNativePG defaults it at creation and
 **writes that value into the spec permanently** — it does not re-default when the
 operator is upgraded. So each cluster froze whatever shipped on the day it was
 created, and nobody ever chose a version. Every cluster now pins its image
-explicitly, and the chart defaults new ones to 18.6.
+explicitly.
+
+The default for *new* clusters is set by the `cnpg-database` chart, and is not
+restated here: it is invalidated by a change in
+[thaum-xyz/helm-charts](https://github.com/thaum-xyz/helm-charts), which no diff
+in this repository would reveal. A version written down here said 18.6 long after
+the chart had moved to 17.11. See the chart's
+[generated values reference](https://github.com/thaum-xyz/helm-charts/tree/main/charts/cnpg-database)
+for the current `cluster.imageName`.
 
 ## Current state
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,9 +1,5 @@
 # Reference { .quad-reference }
 
-!!! warning "Placeholder"
-
-    The site scaffold is in place; this section has mostly no content yet.
-
 ## What belongs here
 
 Reference is a **map**, consulted mid-task and never read through. It describes

--- a/docs/ups/modbus-register-map.md
+++ b/docs/ups/modbus-register-map.md
@@ -1,4 +1,4 @@
-# PowerWalker VFI 1500 LICR IoT — Modbus TCP register map
+# PowerWalker VFI 1500 LICR IoT — Modbus TCP register map { .quad-reference }
 
 `192.168.1.141:502`, function code 3, unit id ignored (1, 2, 3 and 255 all
 answer identically). Reads only — do not write, these are live UPS settings.


### PR DESCRIPTION
Three fixes from an audit of the docs site. Items 1–3 of what I found; the orphaned
`docs/runbooks/README.md` is deliberately left alone.

### 1. A page contradicted the code

`docs/postgres/fleet-upgrade-plan.md` said the `cnpg-database` chart "defaults new
ones to 18.6". It defaults to `17.11-standard-bookworm`, and has since helm-charts
`8a3f3b5` *"lock the image to PostgreSQL 17.11 on bookworm"* — which landed **after**
this page was last edited on 2026-08-23.

Nothing in a diff in this repository could have revealed that, which is exactly the
argument for not restating a chart's defaults here. The number is replaced by a link
to the chart's [generated values reference](https://github.com/thaum-xyz/helm-charts/tree/main/charts/cnpg-database),
plus a short note saying why it is not repeated — so the next person is discouraged
from pasting a version back in.

The rest of the page is untouched: the per-cluster table describes what is *running*
in this cluster, which a diff here does invalidate, so it belongs here.

### 2. The Diátaxis colours were not firing on four pages

The section hue comes from a class on the `<h1>`. It was missing from both new
explanation pages, the new how-to, and the UPS register map, so those rendered with
no coloured rule under the title and untinted admission-test checkboxes.

It fails **silently** — no warning, no build error, just a page that looks slightly
plainer than its neighbours. That is why all four slipped through. The postgres page
gains one as well.

Now classed on every content page. The landing page correctly has none, and
`docs/runbooks/README.md` is left as-is.

### 3. Two stale placeholder banners

Reference and Explanation still said "this section has mostly no content yet" while
each listed three pages.

### Verified

- site builds clean; all 14 pages render
- rendered `<h1>` carries the right `quad-*` class on every content page
- internal link check across all pages: none broken
- checked visually in light mode that the rules and sidebar highlights pick up the
  section colour

### Worth considering separately

Item 2 was invisible until someone went looking. A build check — every page under
`docs/` except a small exclusion list must carry a `quad-*` class — would turn it
into a failed build instead of a page that quietly looks wrong. Happy to add it if
you want; left out here to keep this to the fixes you asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)