### PR TITLE
karakeep: move the meilisearch index off Longhorn

### DIFF
--- a/k8s/apps/karakeep/search/pvc.yaml
+++ b/k8s/apps/karakeep/search/pvc.yaml
@@ -17,7 +17,11 @@ metadata:
     k8up.io/backup: "true"
   name: meilisearch-pvc
 spec:
-  storageClassName: longhorn
+  # piraeus-r2-roaming rather than piraeus-r2: allowRemoteVolumeAccess lets the
+  # Pod start on any node and attach diskless instead of waiting for one holding
+  # a replica, which matters when kured reboots nodes. auto-diskful promotes it
+  # to a local replica after 5 minutes anyway. Well under the class's 32Gi cap.
+  storageClassName: piraeus-r2-roaming
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
First of the #1266 volume migrations. Deliberately the least dangerous one first: the index is recoverable from restic and losing it costs search, not data.

### Method: the backups, not pv-migrate

Per volume: **scale the app down → back it up with the app stopped → delete the claim → Flux recreates it on the new class → `Restore` into it → scale up.**

Why not `pv-migrate`: no new tooling or privileged migration pods, and — more importantly — the app is *stopped* when the backup is taken, so the SQLite/LMDB consistency problem simply does not arise. An rsync from a live filesystem has exactly the problem the hooks in #1314/#1316 exist to solve. It also makes the migration the strongest possible proof of the thing #1266 gates on: "Prove a restore. Untested backups are not backups."

This path is already warm — I restored this exact volume from restic earlier today after the reindex test, recovering all 26 documents with search working.

**Safety**: the old Longhorn PV is patched to `persistentVolumeReclaimPolicy: Retain` before the claim is deleted, so it survives as a fallback even though restic is the primary. Cleaned up once verified.

**Sequencing**: `storageClassName` is immutable, so the app's Kustomization is suspended for the swap and resumed after, rather than leaving Flux failing to apply an immutable field.

### Why roaming

| | `piraeus-r2` | `piraeus-r2-roaming` |
| --- | --- | --- |
| `allowRemoteVolumeAccess` | false | **true** |

Roaming lets the Pod start on any node and attach diskless rather than waiting for one holding a replica — which is what matters when kured reboots nodes. `auto-diskful=5` promotes it to a local replica after 5 minutes anyway. 1Gi is far under the class's 32Gi admission cap.

RWO is unchanged; this claim was already RWO.

Refs #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)