### PR TITLE
karakeep: move the bookmark database off Longhorn

### DIFF
--- a/k8s/apps/karakeep/web/pvc.yaml
+++ b/k8s/apps/karakeep/web/pvc.yaml
@@ -12,7 +12,11 @@ metadata:
     k8up.io/backup: "true"
   name: data-pvc
 spec:
-  storageClassName: longhorn
+  # piraeus-r2-roaming rather than piraeus-r2: allowRemoteVolumeAccess lets the
+  # Pod start on any node and attach diskless instead of waiting for one holding
+  # a replica, which matters when kured reboots nodes. auto-diskful promotes it
+  # to a local replica after 5 minutes anyway. Well under the class's 32Gi cap.
+  storageClassName: piraeus-r2-roaming
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
Second #1266 migration, same method as #1322 — now verified end to end: meilisearch came back on `piraeus-r2-roaming` with all 26 documents and search returning 26 hits.

karakeep is scaled down, backed up **at rest**, the claim recreated on the new class and refilled by a K8up `Restore`. Because the app is stopped there is no live filesystem to read, so `db.db` cannot be caught mid-write — this migration does not even need the `backupcommand` hook from #1314.

Old Longhorn PV switched to `Retain` first, kept until the whole migration is verified.

**Operational note from #1322**: the claim delete hangs in `Terminating` because completed K8up backup Job pods still hold `pvc-protection`. Clearing the Jobs first releases it — worth folding into the runbook for the remaining volumes.

Refs #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)