### PR TITLE
probes: split the objective, and qualify the probe keys under ingress.thaum.xyz

### DIFF
--- a/docs/reference/annotations.md
+++ b/docs/reference/annotations.md
@@ -43,6 +43,52 @@ For a process that reads its configuration once at startup. See
 value is overwritten on the next apply. Its presence is how you confirm the
 policy matched.
 
+### `ingress.thaum.xyz/probe`
+
+| | |
+| --- | --- |
+| **Type** | Label |
+| **Set on** | `Ingress` |
+| **Value** | `enabled` — the only value the selector matches |
+| **Read by** | the `ingress` `Probe` (blackbox-exporter) |
+| **Effect** | blackbox probes the host, and the target joins `blackbox-probe-success` |
+
+Pairs with `ingress.thaum.xyz/probe-uri`; a label without the annotation probes
+the bare host, which is rarely what you want.
+
+!!! warning "On the Ingress that declares TLS"
+
+    blackbox derives the scheme from whether the Ingress declares `spec.tls`. On a
+    host with both a traefik and a cloudflare Ingress, labelling the cloudflare one
+    builds an `http://` target the tunnel never answers. Label the one with TLS.
+
+Charts that expose `ingress.annotations` but no `ingress.labels` need this
+patched on through `postRenderers` — see pocket-id and atuin.
+
+### `ingress.thaum.xyz/probe-uri`
+
+| | |
+| --- | --- |
+| **Type** | Annotation |
+| **Set on** | `Ingress`, alongside the label above |
+| **Value** | A path, e.g. `/api/health` |
+| **Read by** | the `ingress` `Probe`, as `__meta_kubernetes_ingress_annotation_ingress_thaum_xyz_probe_uri` |
+| **Effect** | Appended to `scheme://host` to form the probe target |
+
+**Probe an endpoint the application serves, not its front door.** The
+`http_2xx` module follows redirects and asserts nothing about the body, so `/`
+on an SPA returns 200 from static assets with the backend dead — and on a host
+behind an oauth2 proxy it can return 200 from the *identity provider's* login
+page, which is how the `pdf` probe stayed green while measuring pocket-id.
+
+Prefer what the app's own readiness probe uses. Good examples in tree:
+`/api/health` (karakeep, grafana — the latter also reports database status),
+`/api/v1/status` (seerr), `/healthz` (atuin), `/actuator/health` (stirling-pdf),
+`/.well-known/openid-configuration` (pocket-id).
+
+Omitting the annotation is not a way to opt out — the relabeling then builds the
+bare host, silently. Remove the label instead.
+
 ## Upstream keys, local contract
 
 Keys owned by other projects, where what they mean *here* is a local decision.

--- a/k8s/apps/ai-gateway/app/values.yaml
+++ b/k8s/apps/ai-gateway/app/values.yaml
@@ -47,7 +47,7 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     #cert-manager.io/cluster-issuer: letsencrypt-prod
-    #probe-uri: /-/healthy
+    #ingress.thaum.xyz/probe-uri: /-/healthy
     item.homer.rajsingh.info/name: "Litellm"
     item.homer.rajsingh.info/logo: "https://cdn.jsdelivr.net/npm/@loganmarchione/homelab-svg-assets@latest/assets/openai-white.svg"
     item.homer.rajsingh.info/order: "40"

--- a/k8s/apps/atuin/app/ingress.yaml
+++ b/k8s/apps/atuin/app/ingress.yaml
@@ -9,13 +9,13 @@ metadata:
     # from whether the Ingress declares TLS, and the cloudflare twin declares
     # none, so probing that one would build an http:// target the tunnel never
     # answers.
-    probe: enabled
+    ingress.thaum.xyz/probe: enabled
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-dns01
     # / is the root handler -- 200 with a 234-byte Discworld homage, which
     # proves the HTTP server is up and nothing else. /healthz answers
     # {"status":"healthy"} in 20 bytes.
-    probe-uri: /healthz
+    ingress.thaum.xyz/probe-uri: /healthz
   name: atuin
 spec:
   ingressClassName: public

--- a/k8s/apps/datalake-alerts/alertmanager/ingress.yaml
+++ b/k8s/apps/datalake-alerts/alertmanager/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     ignore-check.kube-linter.io/dangling-service: Check is incompatible with prometheus-operator CRDs
-    probe-uri: /-/healthy
+    ingress.thaum.xyz/probe-uri: /-/healthy
     traefik.ingress.kubernetes.io/service.sticky.cookie: "true"
   labels:
     app.kubernetes.io/component: alert-router

--- a/k8s/apps/datalake-metrics/prometheus/ingress.yaml
+++ b/k8s/apps/datalake-metrics/prometheus/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     ignore-check.kube-linter.io/dangling-service: Check is incompatible with prometheus-operator CRDs
-    probe-uri: /-/healthy
+    ingress.thaum.xyz/probe-uri: /-/healthy
     traefik.ingress.kubernetes.io/service.sticky.cookie: "true"
   labels:
     app.kubernetes.io/component: prometheus

--- a/k8s/apps/datalake-metrics/pyrra/values.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/values.yaml
@@ -11,7 +11,7 @@ ingress:
   className: public
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    probe-uri: /-/healthy
+    ingress.thaum.xyz/probe-uri: /-/healthy
     item.homer.rajsingh.info/name: "Pyrra"
     item.homer.rajsingh.info/logo: "https://avatars.githubusercontent.com/u/87393422?s=200&v=4"
     item.homer.rajsingh.info/order: "30"

--- a/k8s/apps/grafana/grafana/values.yaml
+++ b/k8s/apps/grafana/grafana/values.yaml
@@ -15,7 +15,7 @@ podDisruptionBudget:
 # *.cfargotunnel.com resolves nowhere outside Cloudflare's edge, so the host was
 # unreachable from the tailnet.
 #
-# probe-uri and the probe label are restored along with it: blackbox takes its
+# The ingress.thaum.xyz/probe* keys are restored along with it: blackbox takes its
 # scheme from whether the Ingress declares TLS, so only the traefik route is
 # probeable.
 ingress:
@@ -29,7 +29,7 @@ ingress:
     # /api/health is Grafana's own, answers in 101 bytes without a redirect, and
     # reports {"database": "ok"} -- so unlike the alternatives it fails when
     # Grafana's database is unreachable rather than only when the process is.
-    probe-uri: /api/health
+    ingress.thaum.xyz/probe-uri: /api/health
     item.homer.rajsingh.info/name: "Grafana"
     item.homer.rajsingh.info/logo: "https://grafana.com/static/img/logos/grafana_logo_swirl-events.svg"
     item.homer.rajsingh.info/order: "50"
@@ -38,7 +38,7 @@ ingress:
     service.homer.rajsingh.info/order: "10"
   labels:
     homer.rajsingh.info/enabled: "true"
-    probe: enabled
+    ingress.thaum.xyz/probe: enabled
   hosts:
     - "grafana.krupa.net.pl"
   tls:

--- a/k8s/apps/homer/app/ingress.yaml
+++ b/k8s/apps/homer/app/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: homer
     app.kubernetes.io/part-of: homer
-    probe: enabled
+    ingress.thaum.xyz/probe: enabled
   name: homer
   namespace: homer
 spec:

--- a/k8s/apps/karakeep/web/ingress.yaml
+++ b/k8s/apps/karakeep/web/ingress.yaml
@@ -9,7 +9,7 @@
 # record internally and discards the CNAME, as it already does for the other ten
 # cloudflare-exposed hosts.
 #
-# The probe label belongs here rather than on the cloudflare twin: blackbox
+# ingress.thaum.xyz/probe belongs here rather than on the cloudflare twin: blackbox
 # derives its scheme from whether the Ingress declares TLS, so probing that one
 # built an http:// target the tunnel never answers.
 apiVersion: networking.k8s.io/v1
@@ -18,14 +18,14 @@ metadata:
   name: karakeep
   labels:
     app.kubernetes.io/name: karakeep
-    probe: enabled
+    ingress.thaum.xyz/probe: enabled
     homer.rajsingh.info/enabled: "true"
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     # /  redirects to /signin, a 28KB Next.js shell that renders from static
     # assets -- it returns 200 with the backend dead. /api/health is served by
     # the app itself and answers {"status":"ok"} in 46 bytes.
-    probe-uri: /api/health
+    ingress.thaum.xyz/probe-uri: /api/health
     item.homer.rajsingh.info/name: "Karakeep"
     item.homer.rajsingh.info/subtitle: "Bookmarks hoarder"
     item.homer.rajsingh.info/logo: "https://avatars.githubusercontent.com/u/202258986?s=60&v=4"

--- a/k8s/apps/mealie/app/ingress.yaml
+++ b/k8s/apps/mealie/app/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    probe-uri: /api/app/about
+    ingress.thaum.xyz/probe-uri: /api/app/about
     item.homer.rajsingh.info/name: "Mealie"
     item.homer.rajsingh.info/subtitle: "Our recipes"
     item.homer.rajsingh.info/logo: "https://cdn.jsdelivr.net/npm/@loganmarchione/homelab-svg-assets@latest/assets/mealie.svg"
@@ -13,7 +13,7 @@ metadata:
     service.homer.rajsingh.info/order: "30"
   labels:
     homer.rajsingh.info/enabled: "true"
-    probe: enabled
+    ingress.thaum.xyz/probe: enabled
     app.kubernetes.io/name: mealie
   name: mealie
 spec:

--- a/k8s/apps/mended-drum/open-webui/ingress.yaml
+++ b/k8s/apps/mended-drum/open-webui/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    probe-uri: /health
+    ingress.thaum.xyz/probe-uri: /health
     item.homer.rajsingh.info/name: "Mended Drum"
     item.homer.rajsingh.info/subtitle: "Bar assistant"
     item.homer.rajsingh.info/logo: "https://cdn.jsdelivr.net/npm/@loganmarchione/homelab-svg-assets@latest/assets/openai-white.svg"
@@ -13,7 +13,7 @@ metadata:
     service.homer.rajsingh.info/order: "30"
   labels:
     homer.rajsingh.info/enabled: "true"
-    probe: enabled
+    ingress.thaum.xyz/probe: enabled
     app.kubernetes.io/name: open-webui
   name: open-webui
 spec:

--- a/k8s/apps/mended-drum/tools/ingress.yaml
+++ b/k8s/apps/mended-drum/tools/ingress.yaml
@@ -3,9 +3,9 @@ kind: Ingress
 metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    probe-uri: /healthz
+    ingress.thaum.xyz/probe-uri: /healthz
   labels:
-    probe: enabled
+    ingress.thaum.xyz/probe: enabled
     app.kubernetes.io/name: mended-drum-tools
   name: mended-drum-tools
 spec:

--- a/k8s/apps/paperless/manifests/app/ingress.yaml
+++ b/k8s/apps/paperless/manifests/app/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     # chose. Same page, named explicitly and without the hop -- it is also what
     # paperless's own readiness probe uses, and Django renders it server-side,
     # so unlike an SPA shell a 200 does mean the application is running.
-    probe-uri: /accounts/login/
+    ingress.thaum.xyz/probe-uri: /accounts/login/
     item.homer.rajsingh.info/name: "Paperless"
     item.homer.rajsingh.info/subtitle: "Document management system"
     item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/refs/heads/main/assets/paperlessng.svg"
@@ -20,7 +20,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webservice
     app.kubernetes.io/name: paperless
-    probe: enabled
+    ingress.thaum.xyz/probe: enabled
     homer.rajsingh.info/enabled: "true"
   name: paperless
   namespace: paperless

--- a/k8s/apps/photos/app/values.yaml
+++ b/k8s/apps/photos/app/values.yaml
@@ -98,7 +98,7 @@ server:
         service.homer.rajsingh.info/icon: "fa fa-cloud"
         service.homer.rajsingh.info/order: "30"
       labels:
-        probe: enabled
+        ingress.thaum.xyz/probe: enabled
         homer.rajsingh.info/enabled: "true"
       hosts:
         - host: photos.krupa.net.pl

--- a/k8s/apps/plex/app/ingress.yaml
+++ b/k8s/apps/plex/app/ingress.yaml
@@ -4,12 +4,12 @@ metadata:
   name: plex
   labels:
     app.kubernetes.io/name: plex
-    probe: enabled
+    ingress.thaum.xyz/probe: enabled
     homer.rajsingh.info/enabled: "true"
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     # / answers 401 to a non-browser UA; /identity needs no token.
-    probe-uri: /identity
+    ingress.thaum.xyz/probe-uri: /identity
     #traefik.ingress.kubernetes.io/router.middlewares: plex-no-x-forwarded-for@kubernetescrd
     item.homer.rajsingh.info/name: "Plex"
     item.homer.rajsingh.info/subtitle: "Video on demand"

--- a/k8s/apps/pocket-id/app/release.yaml
+++ b/k8s/apps/pocket-id/app/release.yaml
@@ -69,5 +69,6 @@ spec:
               name: pocket-id
             patch: |-
               - op: add
-                path: /metadata/labels/probe
+                # ~1 is JSON Pointer's escape for / in a key name.
+                path: /metadata/labels/ingress.thaum.xyz~1probe
                 value: enabled

--- a/k8s/apps/pocket-id/app/values.yaml
+++ b/k8s/apps/pocket-id/app/values.yaml
@@ -87,7 +87,7 @@ ingress:
     # party must fetch, so it fails when SSO is actually unusable. Matches the
     # house style of probing a real app endpoint (mealie /api/app/about,
     # immich /api/server/config) rather than a liveness path.
-    probe-uri: /.well-known/openid-configuration
+    ingress.thaum.xyz/probe-uri: /.well-known/openid-configuration
   className: private
   host: login.krupa.net.pl
   tls:

--- a/k8s/apps/stirling-pdf/values.yaml
+++ b/k8s/apps/stirling-pdf/values.yaml
@@ -20,7 +20,7 @@ ingress:
     # into pocket-id -- see the --skip-auth-route note below for why that made
     # the probe measure the wrong service entirely, and why this is
     # /actuator/health rather than the app's own status endpoint.
-    probe-uri: /actuator/health
+    ingress.thaum.xyz/probe-uri: /actuator/health
     item.homer.rajsingh.info/name: "Stirling PDF"
     item.homer.rajsingh.info/subtitle: "PDF manipulation tool"
     item.homer.rajsingh.info/logo: "https://cdn.jsdelivr.net/npm/@loganmarchione/homelab-svg-assets@latest/assets/stirlingpdf.svg"
@@ -29,7 +29,7 @@ ingress:
     service.homer.rajsingh.info/icon: "fa fa-cloud"
     service.homer.rajsingh.info/order: "30"
   labels:
-    probe: enabled
+    ingress.thaum.xyz/probe: enabled
     homer.rajsingh.info/enabled: "true"
   hosts:
     - name: pdf.krupa.net.pl

--- a/k8s/apps/vod-arr/seerr/ingress.yaml
+++ b/k8s/apps/vod-arr/seerr/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
     # /  redirects to /login, a 297KB SPA bundle that renders from static
     # assets whether or not the backend is alive. /api/v1/status is what seerr's
     # own readiness probe uses, and answers in 98 bytes.
-    probe-uri: /api/v1/status
+    ingress.thaum.xyz/probe-uri: /api/v1/status
     item.homer.rajsingh.info/name: "Seerr"
     item.homer.rajsingh.info/subtitle: "Request movies and shows"
     item.homer.rajsingh.info/logo: "https://cdn.jsdelivr.net/npm/@loganmarchione/homelab-svg-assets@latest/assets/jellyseerr.svg"
@@ -20,7 +20,7 @@ metadata:
   labels:
     app.kubernetes.io/name: seerr
     homer.rajsingh.info/enabled: "true"
-    probe: enabled
+    ingress.thaum.xyz/probe: enabled
   name: seerr
 spec:
   ingressClassName: public

--- a/k8s/platform/observability/blackbox-exporter/exporter/kustomization.yaml
+++ b/k8s/platform/observability/blackbox-exporter/exporter/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - networkpolicy.yaml
   - prometheusrule.yaml
   - slo-blackbox-probe-success.yaml
+  - slo-external-probe-success.yaml

--- a/k8s/platform/observability/blackbox-exporter/exporter/slo-blackbox-probe-success.yaml
+++ b/k8s/platform/observability/blackbox-exporter/exporter/slo-blackbox-probe-success.yaml
@@ -3,6 +3,20 @@ kind: ServiceLevelObjective
 metadata:
   name: blackbox-probe-success
 spec:
+  # The thirteen endpoints this cluster serves. Split from the two it merely
+  # watches (slo-external-probe-success.yaml) so one target does not have to fit
+  # both -- 95%/7d permits 8h24m of downtime a week, which is defensible for
+  # somebody else's registry and not for anything here.
+  #
+  # The split is about the target, not about budget isolation: grouping by
+  # instance already gives every target its own burn rate and its own alert, so
+  # registry.avsystem.com was never consuming anyone else's budget.
+  #
+  # target is a PLACEHOLDER, unchanged from the combined SLO so the burn-in is
+  # not disturbed mid-flight. Both numbers get set from data around 2026-10-06,
+  # and the point of splitting now is that they can then differ.
+  description: >-
+    Fraction of successful blackbox probes against services this cluster serves.
   alerting:
     name: ProbeBudgetBurn
     absentName: ProbeMetricAbsent
@@ -16,6 +30,6 @@ spec:
     bool_gauge:
       grouping:
         - instance
-      metric: probe_success
+      metric: probe_success{environment="ankhmorpork"}
   target: "95.0"
   window: 7d

--- a/k8s/platform/observability/blackbox-exporter/exporter/slo-external-probe-success.yaml
+++ b/k8s/platform/observability/blackbox-exporter/exporter/slo-external-probe-success.yaml
@@ -1,0 +1,38 @@
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: external-probe-success
+spec:
+  # Endpoints this cluster watches but does not run: registry.avsystem.com
+  # (environment=avs, somebody else's entirely) and zmc.krupa.net.pl
+  # (environment=lancre, yours but at another site). Neither is something an
+  # operator here can commit to, which is the whole reason they are not in the
+  # objective next door.
+  #
+  # Selecting on environment!="ankhmorpork" rather than naming the two hosts, so
+  # a new external probe joins this SLO by default rather than silently
+  # inflating the one for services we actually serve.
+  #
+  # target is a PLACEHOLDER carried over unchanged. When the numbers are set
+  # around 2026-10-06 this one should end up looser than its neighbour, not
+  # because the endpoints are less important but because nothing here can fix
+  # them.
+  description: >-
+    Fraction of successful blackbox probes against endpoints outside this
+    cluster.
+  alerting:
+    name: ExternalProbeBudgetBurn
+    absentName: ExternalProbeMetricAbsent
+    severities:
+      fastBurn: info
+      mediumBurn: info
+      slowBurn: none
+      longTermBurn: none
+      absent: warning
+  indicator:
+    bool_gauge:
+      grouping:
+        - instance
+      metric: probe_success{environment!="ankhmorpork"}
+  target: "95.0"
+  window: 7d

--- a/k8s/platform/observability/blackbox-exporter/probes/probe-ingress.yaml
+++ b/k8s/platform/observability/blackbox-exporter/probes/probe-ingress.yaml
@@ -25,7 +25,7 @@ spec:
           sourceLabels:
             - __meta_kubernetes_ingress_scheme
             - __tmp_ingress_address
-            - __meta_kubernetes_ingress_annotation_probe_uri
+            - __meta_kubernetes_ingress_annotation_ingress_thaum_xyz_probe_uri
           targetLabel: __param_target
         - action: replace
           sourceLabels:
@@ -42,6 +42,6 @@ spec:
           replacement: ankhmorpork
       selector:
         matchLabels:
-          probe: enabled
+          ingress.thaum.xyz/probe: enabled
   tlsConfig:
     insecureSkipVerify: true

--- a/k8s/platform/observability/blackbox-exporter/probes/probe-ingress.yaml
+++ b/k8s/platform/observability/blackbox-exporter/probes/probe-ingress.yaml
@@ -31,6 +31,15 @@ spec:
           sourceLabels:
             - __param_target
           targetLabel: instance
+        # The other two Probes set environment through staticConfig labels;
+        # ingress discovery has no equivalent, so it is set here. It is what the
+        # two probe SLOs split on: this cluster serves these, and merely watches
+        # everything else. A replace with no sourceLabels concatenates to the
+        # empty string, which the default (.*) matches, so the label is set
+        # unconditionally.
+        - action: replace
+          targetLabel: environment
+          replacement: ankhmorpork
       selector:
         matchLabels:
           probe: enabled


### PR DESCRIPTION
Two commits: 6c item 1, and the key rename that came out of looking at it.

## 1. Split the probe objective

`blackbox-probe-success` covered all fifteen targets at **95%/7d** — which permits **8h24m of downtime a week**. Defensible for somebody else's registry; not for anything this cluster serves.

| SLO | selector | targets |
|---|---|---|
| `blackbox-probe-success` | `environment="ankhmorpork"` | 13 |
| `external-probe-success` | `environment!="ankhmorpork"` | 2 |

The two outside are `registry.avsystem.com` (`environment=avs`, somebody else's) and `zmc.krupa.net.pl` (`environment=lancre`, yours but at another site).

**What it does not change:** grouping by `instance` already gave every target its own burn rate and its own alert — 15 distinct `probe_success:burnrate1h30m` series, alert expression with no aggregation. `registry` was never consuming anyone else's budget. The split is about the *target*.

`probe-ingress` gains `environment: ankhmorpork` so the split keys on a label rather than a list of hostnames — a new external probe then joins the external SLO by default instead of silently inflating the one for services we serve.

Both targets stay at the placeholder 95% so the burn-in is not disturbed mid-flight; they get grounded around 2026-10-06, and the point of splitting now is that they can then differ.

## 2. Qualify the keys

`probe` and `probe-uri` were unqualified names any chart or controller could claim. Now `ingress.thaum.xyz/probe` and `ingress.thaum.xyz/probe-uri`, matching the `autoreloader.thaum.xyz` convention and the reasoning already written down for it. 13 labels, 15 annotations, plus the Probe's own selector.

**Two places a search-and-replace does not reach**, both of which would have failed silently:

The relabeling reads the annotation as a Kubernetes SD meta label, and SD sanitises the key by replacing every character outside `[a-zA-Z0-9_]` with `_`. The source becomes `__meta_kubernetes_ingress_annotation_ingress_thaum_xyz_probe_uri`. **Verified against a live target rather than assumed** — `cert-manager.io/cluster-issuer` already appears as `..._annotation_cert_manager_io_cluster_issuer`.

pocket-id sets the label through a postRenderer JSON6902 patch, whose `path` is a JSON Pointer — the `/` in the key needs escaping as `~1`:
`/metadata/labels/ingress.thaum.xyz~1probe`. A plain rename would have left pocket-id setting the old label and **silently unprobed**. Confirmed the escaped pointer still produces the label through `kustomize build`.

**Series identity is unaffected** — the annotation's *value* is unchanged, so probe targets and their `instance` labels stay exactly as they were. (The `environment` label from commit 1 does change them; that is one day of burn-in, and the reason to do both now.)

## 3. Reference docs

`docs/reference/annotations.md` had no entry for either key. Both are now under **Defined here**, with the value, what reads them, and the two traps that cost real time this week: labelling the Ingress that does *not* declare TLS, and probing a front door that answers 200 from static assets — or, as `pdf` did, from somebody else's login page.

## Verification

- `make validate` — 125 targets clean. `make docs-reference-check` — generated pages unchanged.
- Sweep for stale references (`annotation_probe_uri`, bare `probe:`/`probe-uri:`, `labels/probe`) across `k8s/`, `docs/`, `.claude/` — **clean**.
- `!=` matches series lacking the label, confirmed live: `environment!="avs"` → 14, `environment="avs"` → 1.
- Server-side dry-run: Pyrra accepts a selector on `bool_gauge.metric`.

## After merge

```
flux reconcile source git ankhmorpork
flux -n flux-system reconcile kustomization platform
flux -n flux-system reconcile kustomization apps
flux -n pocket-id reconcile helmrelease pocket-id
```

Then confirm **13** targets at `environment="ankhmorpork"` and **2** outside, that `login.krupa.net.pl` is still among them (the pointer-escape case), and that the probe count is still 15 overall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)