### PR TITLE
changedetection: move the datastore off Longhorn

### DIFF
--- a/k8s/apps/changedetection/app/values.yaml
+++ b/k8s/apps/changedetection/app/values.yaml
@@ -20,6 +20,12 @@ resources:
     memory: 128Mi
 
 persistence:
-  storageClass: "longhorn-r2"
+  # piraeus-r2-roaming rather than piraeus-r2: allowRemoteVolumeAccess lets the
+  # Pod start on any node and attach diskless instead of waiting for one holding
+  # a replica, which matters when kured reboots nodes.
+  storageClass: "piraeus-r2-roaming"
   size: 1Gi
-  accessMode: ReadWriteMany
+  # RWX was never required here. Piraeus offers none, and the chart runs one
+  # replica with strategy Recreate, so two Pods never hold this at once --
+  # which is the usual reason a single-replica Deployment ends up declaring it.
+  accessMode: ReadWriteOnce


### PR DESCRIPTION
Third #1266 migration, and the first to drop RWX.

### RWX was never required

Piraeus offers no RWX, so this had to be checked rather than assumed. Measured: **1 replica, `strategy: Recreate` already, 1 mounter**. Recreate means two Pods never hold the volume at once — which is the usual reason a single-replica Deployment ends up declaring RWX, per #1266. So `ReadWriteOnce` costs nothing here.

### Method

Same as #1322 and #1325, with the sequence corrected after #1325: scale down → back up **at rest** → delete Jobs (they hold `pvc-protection`) → delete claim → Flux/Helm recreate it on the new class → `Restore` → **verify contents in a throwaway Pod** → only then scale up.

That last step is not ceremony. In #1325 I scaled up before the restore finished; the restore pod hit a Multi-Attach error and karakeep initialised a fresh empty database in the meantime. No data was lost — restic and the retained PV both held it — but the app must not touch the volume until the restore is verified.

Old Longhorn PV switched to `Retain` first, kept until the whole migration is done.

Refs #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)