### PR TITLE
mealie: move the recipe assets off Longhorn

### DIFF
--- a/k8s/apps/mealie/app/deployment.yaml
+++ b/k8s/apps/mealie/app/deployment.yaml
@@ -5,6 +5,12 @@ metadata:
   labels:
     app.kubernetes.io/name: mealie
 spec:
+  # data is ReadWriteOnce since it moved to piraeus, which offers no RWX. A
+  # rolling update would start the replacement before the old Pod releases the
+  # volume and deadlock if it landed on another node -- the same trap karakeep
+  # documents. Recreate takes the old Pod down first.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: mealie

--- a/k8s/apps/mealie/app/pvc.yaml
+++ b/k8s/apps/mealie/app/pvc.yaml
@@ -15,9 +15,14 @@ metadata:
   labels:
     app.kubernetes.io/name: mealie
 spec:
-  storageClassName: longhorn
+  # piraeus-r2-roaming rather than piraeus-r2: allowRemoteVolumeAccess lets the
+  # Pod start on any node and attach diskless instead of waiting for one holding
+  # a replica, which matters when kured reboots nodes.
+  storageClassName: piraeus-r2-roaming
+  # RWX was never required. Piraeus offers none, one replica mounts this, and
+  # the Deployment now uses strategy Recreate so two Pods never hold it at once.
   accessModes:
-  - ReadWriteMany
+  - ReadWriteOnce
   resources:
     requests:
       storage: 1Gi


### PR DESCRIPTION
Fourth #1266 migration. Two changes, both needed together.

### RWX dropped, and `strategy: Recreate` added

mealie declared neither `replicas` nor `strategy`, so it defaulted to **RollingUpdate** — which on an RWO volume starts the replacement before the old Pod releases it and deadlocks if it lands on another node. That is the trap `karakeep/web` already carries a comment about. `Recreate` takes the old Pod down first.

RWX itself was never required: one replica, one mounter, and Piraeus offers no RWX anyway.

### A restore that is deliberately smaller than the volume

Worth flagging so it is not mistaken for data loss: `mealie/data` is 26M, of which **23M is `mealie.log` and its rotations** (#1303). The backup excludes those, so the restore brings back ~2.1M of recipes. That is the intended outcome — the log is already in Loki, and this is exactly why the exclude exists.

It also means this migration moves 2.1M instead of 26M.

### Method

As the three before it, with the sequence corrected after #1325: suspend the Kustomization (so Flux does not scale the app back up mid-migration) → scale down → back up **at rest** → clear K8up Jobs → delete claim → resume → `Restore` → **verify contents in a throwaway Pod** → only then scale up.

One extra lesson from #1327, where the app got restarted by a Helm reconcile before the restore and wrote a fresh datastore: the orphaned directories it created had to be identified against `url-watches.json` and removed. Suspending the release, not just scaling, is what prevents that.

Refs #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)