### PR TITLE
traefik: pin the private service to externalTrafficPolicy Cluster

### DIFF
--- a/k8s/platform/network/traefik/private/values.yaml
+++ b/k8s/platform/network/traefik/private/values.yaml
@@ -13,4 +13,11 @@ providers:
 service:
   spec:
     loadBalancerIP: "192.168.50.130"
-    #externalTrafficPolicy: Local
+    # Cluster deliberately, and set explicitly so Helm owns the field: with
+    # Local, only nodes running a private-traefik pod serve and BGP-advertise
+    # the VIP. Two replicas with required per-hostname anti-affinity can never
+    # cover all schedulable nodes, so a rollout can leave the Tailscale subnet
+    # router (beelink01/beelink02) without a backend and every remote client
+    # loses the private ingress. Nothing here needs the real client IP, and the
+    # SNAT'd node address still lands in 192.168.50.0/24.
+    externalTrafficPolicy: Cluster


### PR DESCRIPTION
## What broke

`vod.krupa.net.pl` and every other host behind the private ingress (`192.168.50.130`) started timing out from Tailscale roughly 90 minutes after the Renovate bump `102b1f29 chore(deps): update helm release traefik to v41.4.0`.

Traefik itself was healthy the whole time. So was Cilium BGP — all four sessions established for 8 days — and the LB pool, and all four nodes. The private VIP was the *only* thing broken:

| Target | Result |
|---|---|
| `.129` public traefik, `.134` karakeep, `.135` plex | reachable |
| `.130` private traefik | **timed out** |
| private-traefik nodePorts (`.32:31736`, `.37:31736`) | reachable |

## Root cause

The live Service carried `externalTrafficPolicy: Local`. That value was **drift**: this file had it commented out, the chart renders no `externalTrafficPolicy` in either revision 29 (41.3.0) or 30 (41.4.0), and no Kyverno or admission policy sets it. It had been hand-patched, and because Helm never owned the field no upgrade would ever reconcile it away.

Under `Local`, only nodes running a private-traefik pod serve and BGP-advertise the VIP. The deployment runs 2 replicas with *required* per-hostname anti-affinity, and `master01` has been cordoned since Aug 30 — so two replicas can only ever cover two of the three schedulable nodes, always leaving one uncovered. The v41.4.0 rollout reshuffled them onto `master02` + `beelink02`, leaving `beelink01` empty.

`beelink01` is the primary Tailscale subnet router, so every remote client entered the LAN at the one node that could not serve the VIP. Cilium's service table confirmed it:

```
beelink01:  192.168.50.130:443/TCP   LoadBalancer   (no backends)
beelink02:  192.168.50.130:443/TCP   LoadBalancer   1 => 10.42.3.179:8443 (active)
master02:   192.168.50.130:443/TCP   LoadBalancer   1 => 10.42.1.196:8443 (active)
```

A 1-in-3 dice roll on every restart. Nothing in config changed, which is why it looked like it broke out of nowhere.

## The fix

Set `externalTrafficPolicy: Cluster` **explicitly** rather than just uncommenting the old line, so Helm owns the field and the drift cannot silently return. All four nodes then serve and advertise the VIP, independent of scheduling.

Nothing behind this ingress depends on the preserved client IP: there are no `IPAllowList` or `trustedIPs` settings on it, and the SNAT'd node address still lands inside `192.168.50.0/24`, so qbittorrent's `AuthSubnetWhitelist` still matches.

## Status

The live Service has already been patched to `Cluster` out-of-band to restore service; `vod.krupa.net.pl` is confirmed working. This PR makes that state declarative so it survives the next reconcile.

## Two notes worth separate follow-up

- **`master01` has been cordoned since Aug 30.** That is what shrank the scheduling pool to three nodes and made this reachable. Worth checking whether the cordon was deliberate.
- Diagnosing this had two traps: pinging a Cilium BGP VIP never works even when healthy (the BPF LB only answers declared service ports), and `curl` from a node succeeds even on a node with no backend, because host-originated traffic uses the `/i` socket-LB frontend that ignores `Local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)