### PR TITLE
open-webui: move its data off Longhorn

### DIFF
--- a/k8s/apps/mended-drum/open-webui/pvc.yaml
+++ b/k8s/apps/mended-drum/open-webui/pvc.yaml
@@ -23,7 +23,13 @@ metadata:
   labels:
     app.kubernetes.io/name: open-webui
 spec:
-  storageClassName: longhorn
+  # piraeus-r2-roaming rather than piraeus-r2: allowRemoteVolumeAccess lets the
+  # Pod start on any node and attach diskless instead of waiting for one holding
+  # a replica, which matters when kured reboots nodes.
+  #
+  # 2Gi is kept even though the migrated contents are ~1.5M: the model caches
+  # under cache/ re-download into this volume unless #1311 moves them off it.
+  storageClassName: piraeus-r2-roaming
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
Fifth #1266 migration. Already RWO with `strategy: Recreate`, so only the storage class changes.

### One consequence worth stating plainly

The volume is **1.1G on disk**, but the backup excludes `cache/embedding` and `cache/whisper` — 1.03G of HuggingFace blobs. So the restore brings back roughly **1.5M**: `webui.db`, the chroma vector store, and `cache/audio/transcriptions`.

**The model caches are therefore not migrated.** open-webui re-downloads `all-MiniLM-L6-v2` and `faster-whisper-base` the first time embeddings or transcription are used after this — a slow first request, then back to normal.

That is deliberate rather than an oversight: it follows the exclude already in place, the files are re-downloadable by design, and it is the direction #1311 argues for. It also means this migration moves 1.5M instead of 1.1G.

If you would rather keep them warm, say so before I run it and I will copy `cache/` across separately — it is the only volume where the backup and the disk contents differ this much.

The claim stays **2Gi**: the models land back in this volume on re-download unless #1311 moves them off it.

### Method

As the four before it: suspend the Kustomization → scale down → back up **at rest** → clear K8up Jobs → delete claim → resume → `Restore` → **verify contents in a throwaway Pod** → only then scale up.

Refs #1266, #1311

🤖 Generated with [Claude Code](https://claude.com/claude-code)