### PR TITLE
immich: move the machine-learning cache off Longhorn

### DIFF
--- a/k8s/apps/photos/app/values.yaml
+++ b/k8s/apps/photos/app/values.yaml
@@ -121,9 +121,10 @@ machine-learning:
   controllers:
     main:
       replicas: 1
-      strategy: RollingUpdate
-      rollingUpdate:
-        unavailable: 1
+      # Recreate since the cache became ReadWriteOnce: RollingUpdate's default
+      # maxSurge would start the replacement before this Pod releases the
+      # volume, and deadlock if it landed on another node.
+      strategy: Recreate
       containers:
         main:
           env:
@@ -138,5 +139,11 @@ machine-learning:
       enabled: true
       size: 3Gi
       type: persistentVolumeClaim
-      accessMode: ReadWriteMany
-      storageClass: longhorn-r2
+      # RWX was never required -- one replica, one mounter -- and Piraeus offers
+      # none. Recreate above keeps two Pods from ever holding it at once.
+      accessMode: ReadWriteOnce
+      # Kept on replicated storage rather than emptyDir. It is a genuine
+      # download cache, but a measured 786M of it (CLIP 583M, buffalo_l 183M,
+      # OCR 21M), so emptyDir would mean re-fetching that from HuggingFace after
+      # every kured reboot with smart search degraded until it finished.
+      storageClass: piraeus-r2-roaming


### PR DESCRIPTION
Last of the #1266 volume migrations apart from paperless, which stays on Longhorn for now.

### Deliberately not `emptyDir`, contrary to #1266

The issue proposes `emptyDir` for this on the grounds that it is regenerable — which it is. But measured, it is **786M**:

| | |
| --- | --- |
| `clip/ViT-B-32__openai` | 583M |
| `facial-recognition/buffalo_l` | 183M |
| `ocr` | 21M |

`emptyDir` would re-fetch all of that from HuggingFace after **every kured reboot**, with smart search and face detection degraded until it finished. 3Gi of replicated storage is the cheaper trade. It still gets off Longhorn, which is what actually blocks #1266, and it stays out of backups either way since nothing annotates it for K8up.

### No data is moved

The claim is recreated empty and immich re-downloads once. That is also the *check* that it regenerates rather than an assumption — the lesson from meilisearch (#1320), where an index that looked derived turned out never to be rebuilt. Here the mechanism is `huggingface_hub` fetching on cache-miss, and we watched open-webui do exactly that at startup an hour ago.

### RWX dropped

One replica, one mounter, and Piraeus offers none. `strategy` becomes `Recreate`: the previous `RollingUpdate` set `unavailable: 1` but left `maxSurge` at its default, so it could still have started a second Pod against an RWO volume.

Refs #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)