### PR TITLE
paperless: move data and media off Longhorn

### DIFF
--- a/k8s/apps/paperless/manifests/app/pvcData.yaml
+++ b/k8s/apps/paperless/manifests/app/pvcData.yaml
@@ -10,6 +10,14 @@ spec:
   accessModes:
     - ReadWriteOnce
   resources:
+    # 364M in use, and 5Gi only ever made sense on Longhorn. Most of the
+    # contents are regenerable -- classification_model.pickle 255M, nltk 56M,
+    # the Whoosh index and celerybeat schedule -- so this is sized for the
+    # model growing with the corpus rather than for the documents, which live
+    # on paperless-media.
     requests:
-      storage: 5Gi
-  storageClassName: longhorn
+      storage: 2Gi
+  # piraeus-r2-roaming rather than piraeus-r2: allowRemoteVolumeAccess lets the
+  # Pod start on any node and attach diskless instead of waiting for one holding
+  # a replica, which matters when kured reboots nodes.
+  storageClassName: piraeus-r2-roaming

--- a/k8s/apps/paperless/manifests/app/pvcMedia.yaml
+++ b/k8s/apps/paperless/manifests/app/pvcMedia.yaml
@@ -12,4 +12,7 @@ spec:
   resources:
     requests:
       storage: 2Gi
-  storageClassName: longhorn
+  # piraeus-r2-roaming rather than piraeus-r2: allowRemoteVolumeAccess lets the
+  # Pod start on any node and attach diskless instead of waiting for one holding
+  # a replica, which matters when kured reboots nodes.
+  storageClassName: piraeus-r2-roaming


### PR DESCRIPTION
Last of the #1266 volume migrations — this is the one that empties Longhorn.

### Simpler than the others in one way

**No strategy change needed.** paperless is a single-replica **StatefulSet**, and StatefulSets never surge — the old Pod is deleted before the new one is created — so `ReadWriteOnce` is already safe. The five Deployments migrated earlier each needed `strategy: Recreate`; this does not.

The claims are standalone manifests rather than `volumeClaimTemplates`, so they can be recreated normally.

### Sizing

`paperless-data` **5Gi → 2Gi**. It holds 364M, and most of that is regenerable:

```
255M  classification_model.pickle   retrained by paperless
 56M  nltk                          downloaded corpora
 42M  log
  8M  index                         Whoosh, rebuildable
  4M  celerybeat-schedule.db
```

`paperless-media` **keeps 2Gi** — 964M of scanned documents at 49.5%, and the class supports online expansion when it needs it.

### Data moves by rsync, not backup/restore

paperless has no K8up backup to restore from, so the method used for the other five does not apply. Its `document_exporter` CronJob writes a full logical export to the NAS nightly, which is the real safety net, and the old Longhorn PVs are switched to `Retain` first as a second one.

**The name collision needs care.** rsync needs both old and new volumes mounted at once, but the new claims must take the git-declared names. So: retain the old PVs → delete the old claims → let Flux create the new empty ones → rebind the retained Longhorn PVs to temporary claims → rsync into the new ones → drop the temporaries. One copy, fallback intact throughout.

### Two things that will bite during the swap

- The nightly `paperless-backup` CronJob (22:36) mounts both volumes and must be suspended for the window.
- Its **completed** pods hold `pvc-protection` — the trap that hung three of today’s migrations. They have to be cleared before the claims will delete.

Refs #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)