### PR TITLE
docs: ingress, certificates and requiring a login

### DIFF
--- a/docs/how-to/expose-an-app.md
+++ b/docs/how-to/expose-an-app.md
@@ -1,0 +1,128 @@
+# Expose an app on an ingress { .quad-howto }
+
+Decide who should reach it, then write the Ingress. Classes, issuers and DNS
+behaviour are in [ingress classes and certificates](../reference/ingress.md).
+
+## 1. Who should reach it?
+
+| Audience | What to create |
+| --- | --- |
+| Only the house LAN | one `private` Ingress |
+| Anyone, from anywhere | a `public` Ingress **and** a `cloudflare` Ingress, same host |
+
+There is no single "public" Ingress that works both inside and outside. The pair
+is required, and section 3 explains why.
+
+## 2. LAN only
+
+Host it under `ankhmorpork.thaum.xyz`:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: myapp
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: private
+  rules:
+    - host: myapp.ankhmorpork.thaum.xyz
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: myapp
+                port:
+                  name: http
+  tls:
+    - hosts:
+        - myapp.ankhmorpork.thaum.xyz
+      secretName: myapp-tls
+```
+
+That is the whole job. `external-dns` publishes the name to UniFi's resolver and
+`cert-manager` obtains the certificate; neither is mentioned in the manifest.
+
+## 3. Reachable from outside
+
+Use a `krupa.net.pl` host, and write **two** Ingresses for it. The second differs
+only in class, and carries no TLS block or issuer:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: myapp-cloudflare
+spec:
+  ingressClassName: cloudflare
+  rules:
+    - host: myapp.krupa.net.pl
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: myapp
+                port:
+                  name: http
+```
+
+Both are needed, for opposite reasons:
+
+- **Without the `cloudflare` one**, off-LAN clients still resolve the name — the
+  `*.krupa.net.pl` wildcard sends them to Cloudflare — but the tunnel has no route
+  for it, so they get nothing.
+- **Without the `public` one**, external-dns publishes only the tunnel CNAME
+  (`*.cfargotunnel.com`), which resolves nowhere internally. The house resolver
+  hands out a name with no usable address.
+
+Keep the two names distinct (`myapp` and `myapp-cloudflare`). If a Helm chart also
+renders an Ingress, set `ingress.enabled: false` in its values and own both here —
+a chart upgrade that disables its Ingress will otherwise delete any Ingress
+sharing that name.
+
+## 4. Validate
+
+```bash
+git add k8s/apps/myapp
+make validate
+```
+
+`validate-ingress-contract` **denies** on apply, so a mistake here is a failed
+reconcile rather than a warning. The four that catch people:
+
+- `ingressClassName` missing — the default class exists but the policy still
+  requires the field
+- the deprecated `kubernetes.io/ingress.class` **annotation** used instead
+- a `public` or `private` Ingress with no `spec.tls`
+- a TLS entry with no `secretName`
+
+## 5. After it rolls out
+
+The certificate takes a minute or two:
+
+```bash
+kubectl -n myapp get certificate -w
+```
+
+Once `READY` is `True`, the host answers. If it does not:
+
+```bash
+# Did external-dns publish it?
+kubectl -n network logs deploy/external-dns | grep myapp
+
+# Did the ingress controller accept it?
+kubectl -n myapp describe ingress myapp
+```
+
+A name that resolves but times out from off-LAN is almost always the missing
+`cloudflare` Ingress from section 3.
+
+## Requiring a login
+
+Neither class authenticates anything. To put a login in front, see
+[require a login](require-a-login.md).

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -20,13 +20,16 @@ section once migrated.
 
 ## Available now
 
+- [Expose an app on an ingress](expose-an-app.md) — which class, and why a public
+  host needs two Ingresses
+- [Require a login](require-a-login.md) — pocket-id, natively or through
+  oauth2-proxy
 - [Choose a storage class](choose-a-storage-class.md) — which class a workload
   belongs on, in the order the questions actually matter
 - [Roll a workload when its ConfigMap changes](reload-on-configmap-change.md)
 
 ## Planned
 
-- Expose an app on an ingress
 - Rotate a secret
 - Recover a Postgres cluster from backup
 - Drain and reboot a node outside the kured cycle

--- a/docs/how-to/require-a-login.md
+++ b/docs/how-to/require-a-login.md
@@ -1,0 +1,151 @@
+# Require a login { .quad-howto }
+
+Every ingress class in this cluster is unauthenticated. `private` limits *where* a
+request can come from, not *who* is making it — anything on the house network
+reaches it. Authentication is a separate decision, and it is
+[pocket-id](https://login.krupa.net.pl) in both cases below.
+
+## First: does the app have its own OIDC support?
+
+That decides everything. Check its documentation before writing any manifests —
+the two paths differ completely and only one is worth the effort.
+
+## Path A — the app supports OIDC
+
+Create the client in pocket-id, put its credentials in Doppler as
+`<APP>_OIDC_CLIENT_ID` / `<APP>_OIDC_CLIENT_SECRET`, and pull them in:
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: oidc-client
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-auth-api
+  data:
+    - remoteRef:
+        key: MYAPP_OIDC_CLIENT_ID
+      secretKey: clientID
+    - remoteRef:
+        key: MYAPP_OIDC_CLIENT_SECRET
+      secretKey: clientSecret
+```
+
+Then wire it into the app however it expects. The issuer is
+`https://login.krupa.net.pl`, and most apps want its discovery document at
+`https://login.krupa.net.pl/.well-known/openid-configuration`.
+
+Nothing else is needed — no proxy, no extra Ingress. `mealie`, `grafana` and
+`open-webui` all work this way.
+
+## Path B — the app has no login of its own
+
+Put **oauth2-proxy** in front of it and point the Ingress at the proxy, never at
+the app's Service. The proxy becomes the authentication boundary; the app stays
+unauthenticated and unreachable except through it.
+
+Two shapes, both in use here:
+
+- **A sidecar** in the app's Pod, with the app bound to localhost so it is never
+  published — `stirling-pdf`.
+- **A standalone Deployment**, when the chart offers no `extraContainers` and
+  hardcodes its Service target — `changedetection`.
+
+Prefer the sidecar. It removes any way to reach the app without passing the proxy.
+
+### The proxy
+
+```yaml
+containers:
+  - name: oauth2-proxy
+    image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3
+    args:
+      - --provider=oidc
+      - --oidc-issuer-url=https://login.krupa.net.pl
+      - --redirect-url=https://myapp.krupa.net.pl/oauth2/callback
+      - --http-address=0.0.0.0:4180
+      - --upstream=http://127.0.0.1:8080
+      - --email-domain=*
+      - --scope=openid email profile
+      - --code-challenge-method=S256
+      - --reverse-proxy=true
+      - --cookie-secure=true
+      - --skip-provider-button=true
+    env:
+      - name: OAUTH2_PROXY_CLIENT_ID
+        valueFrom:
+          secretKeyRef: { name: myapp-oidc, key: clientID }
+      - name: OAUTH2_PROXY_CLIENT_SECRET
+        valueFrom:
+          secretKeyRef: { name: myapp-oidc, key: clientSecret }
+      - name: OAUTH2_PROXY_COOKIE_SECRET
+        valueFrom:
+          secretKeyRef: { name: myapp-oauth2-cookie, key: password }
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+```
+
+Four of those arguments are not obvious:
+
+- **`--email-domain=*`** is mandatory, not permissive sloppiness. Left unset it
+  defaults to allowing *nothing* and rejects every address.
+- **`--reverse-proxy=true`** — Traefik and cloudflared are both in front, so
+  `X-Forwarded-*` must be trusted or redirects break.
+- **`--code-challenge-method=S256`** — pocket-id advertises PKCE and oauth2-proxy
+  warns when it is off.
+- **`--skip-provider-button=true`** sends users straight to pocket-id instead of an
+  interstitial page with one button on it.
+
+### The cookie secret
+
+It only needs to be 32 stable bytes, so generate it in-cluster rather than storing
+it anywhere. `refreshInterval: "0"` mints it once — a refresh would invalidate
+every live session:
+
+```yaml
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+metadata:
+  name: myapp-oauth2-cookie
+spec:
+  length: 32
+  digits: 8
+  symbols: 0
+  noUpper: false
+  allowRepeat: true
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: myapp-oauth2-cookie
+spec:
+  refreshInterval: "0"
+  target:
+    name: myapp-oauth2-cookie
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: myapp-oauth2-cookie
+```
+
+### Point the Ingress at the proxy
+
+Change the backend to the proxy's port — `4180` for a standalone Deployment, or
+the sidecar's port on the app's own Service. Both the `public` and `cloudflare`
+Ingresses must point there. An Ingress still aimed at the app bypasses
+authentication entirely, and nothing will warn you.
+
+## Authorisation stays in pocket-id
+
+Restrict the **client** to groups in pocket-id. It then refuses to issue a token
+for anyone outside them, and the proxy never sees those users at all.
+
+Do not add a second allow-list in oauth2-proxy. It is one more thing to drift, and
+the one that is easy to forget is the one that is too permissive.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -20,16 +20,14 @@ Admission test:
     The app inventory, ingress hosts, namespaces and storage classes are all
     derivable from the manifests — generate them in CI rather than typing them.
 
-## Planned
-
-- Ingress classes and certificate issuers
-
 ## Available now
 
 - [Applications](apps.md) — every app, its namespace, its Flux Kustomization and
   its hostnames *(generated)*
 - [Admission policies](admission-policies.md) — what Kyverno enforces, and which
   rules only warn *(generated)*
+- [Ingress and certificates](ingress.md) — the three classes, the two issuers,
+  and what external-dns publishes
 - [Storage classes](storage-classes.md) — capabilities, access modes, node
   affinity and measured ceilings
 - [Annotations and labels](annotations.md) — keys this cluster gives meaning to,

--- a/docs/reference/ingress.md
+++ b/docs/reference/ingress.md
@@ -1,0 +1,75 @@
+# Ingress classes and certificates { .quad-reference }
+
+Three ingress classes, two certificate issuers. To put an app on one, use
+[expose an app](../how-to/expose-an-app.md).
+
+## Classes
+
+| Class | Controller | Reaches | Address |
+| --- | --- | --- | --- |
+| `public` | Traefik | LAN, and off-LAN only via a paired `cloudflare` Ingress | `192.168.50.129` |
+| `private` | Traefik | LAN only | `192.168.50.130` |
+| `cloudflare` | `strrl.dev/cloudflare-tunnel-ingress-controller` | the internet, through the `ankhmorpork-tunnel` | tunnel CNAME |
+
+`public` is the cluster's **default** IngressClass (`isDefaultClass: true`), so an
+Ingress that omits `ingressClassName` gets it. Do not rely on that — the admission
+policy requires the field to be set explicitly.
+
+Both Traefik instances are separate HelmReleases with their own LoadBalancer IP,
+not one controller with two entrypoints.
+
+## Certificate issuers
+
+| Issuer | Use |
+| --- | --- |
+| `letsencrypt-prod` | the default; HTTP-01 |
+| `letsencrypt-dns01` | when HTTP-01 cannot work — wildcards, or a name not yet reachable |
+
+Both are accepted by the admission policy; anything else is rejected. Set one with
+the `cert-manager.io/cluster-issuer` annotation.
+
+`cloudflare` Ingresses need no issuer and no TLS block: the tunnel terminates TLS
+at Cloudflare's edge.
+
+## What admission enforces
+
+`validate-ingress-contract` **denies** an Ingress that fails any of these. Full
+rule text in [admission policies](admission-policies.md).
+
+- `spec.ingressClassName` is one of `public`, `private`, `cloudflare`
+- the deprecated `kubernetes.io/ingress.class` **annotation** is absent
+- `public` and `private` Ingresses set `spec.tls`
+- `public` and `private` Ingresses use an approved `cert-manager.io/cluster-issuer`
+- every TLS entry sets a non-empty `secretName`
+
+## DNS
+
+`external-dns` writes records into **UniFi's resolver** — the house's internal
+DNS, not a public zone.
+
+| Setting | Value |
+| --- | --- |
+| Domains it will touch | `thaum.xyz`, `krupa.net.pl` |
+| Policy | `sync` — it deletes records it owns when the Ingress goes |
+| Ownership | TXT registry, `txtOwnerId: thaum.xyz`, `txtPrefix: k8s.` |
+| Fallback name | `{{.Name}}.{{.Namespace}}.ankhmorpork.thaum.xyz` |
+
+From a `cloudflare` Ingress, external-dns publishes the **tunnel CNAME**
+(`*.cfargotunnel.com`), which resolves nowhere on the LAN. This is why a
+`cloudflare` Ingress alone leaves a name that the internal resolver hands out with
+no usable address.
+
+Public names resolve off-LAN through the `*.krupa.net.pl` wildcard CNAME pointing
+at Cloudflare. That means an off-LAN client reaching a `private`-only host will
+resolve it, arrive at Cloudflare, and get nothing — the tunnel has no route for
+it.
+
+## Host naming
+
+| Pattern | Meaning |
+| --- | --- |
+| `<name>.ankhmorpork.thaum.xyz` | internal, `private` class |
+| `<name>.krupa.net.pl` | external, `public` + `cloudflare` pair |
+
+Every hostname currently served is listed in [applications](apps.md), generated
+from the manifests.

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -312,6 +312,9 @@ it, because `prune: true` means Flux owns what it created.
 This was a lesson, so it made every choice for you. Real work needs those choices
 back:
 
+- **[Expose an app on an ingress](../how-to/expose-an-app.md)** — you wrote one
+  in step 1 and every choice in it was made for you. This explains them, and why
+  a host reachable from outside the house needs two.
 - **[Choose a storage class](../how-to/choose-a-storage-class.md)** — the first
   real decision most apps hit. `whoami` had no storage; almost nothing else is so
   lucky, and the choice is hard to reverse.

--- a/zensical.toml
+++ b/zensical.toml
@@ -42,6 +42,8 @@ nav = [
   ] },
   { "How-to" = [
     "how-to/index.md",
+    { "Expose an app on an ingress" = "how-to/expose-an-app.md" },
+    { "Require a login" = "how-to/require-a-login.md" },
     { "Choose a storage class" = "how-to/choose-a-storage-class.md" },
     { "Roll a workload on ConfigMap change" = "how-to/reload-on-configmap-change.md" },
   ] },
@@ -51,6 +53,7 @@ nav = [
     { "Admission policies" = "reference/admission-policies.md" },
     { "Annotations and labels" = "reference/annotations.md" },
     { "Charts and images" = "reference/charts.md" },
+    { "Ingress and certificates" = "reference/ingress.md" },
     { "Storage classes" = "reference/storage-classes.md" },
     { "UPS Modbus register map" = "ups/modbus-register-map.md" },
   ] },


### PR DESCRIPTION
Three pages covering the one thing every app touches — and which the tutorial
creates without explaining any of.

- **[Expose an app on an ingress](https://docs.thaum.xyz/how-to/expose-an-app/)**
- **[Require a login](https://docs.thaum.xyz/how-to/require-a-login/)**
- **[Ingress and certificates](https://docs.thaum.xyz/reference/ingress/)**

### The pairing rule leads, because it is not guessable

A host reachable from outside needs **both** a `public` and a `cloudflare`
Ingress, and each is useless without the other for opposite reasons:

- **No `cloudflare` one** → off-LAN clients still resolve via the
  `*.krupa.net.pl` wildcard, reach Cloudflare, and hit a tunnel with no route.
- **No `public` one** → external-dns publishes only the `*.cfargotunnel.com`
  CNAME, which resolves nowhere on the LAN, so the house resolver hands out a name
  with no usable address.

Both failures look like DNS and neither produces an error, so this is written up
before the YAML rather than as a footnote.

### OIDC is its own how-to

Not a section, because the first question — *does the app support OIDC natively* —
leads to two paths with nothing in common: an ExternalSecret and some env vars, or
an oauth2-proxy that becomes the authentication boundary.

It records the arguments that look arbitrary and are not:

- **`--email-domain=*` is mandatory.** Left unset it defaults to allowing *nothing*
  and rejects every address.
- **The cookie secret is minted in-cluster with `refreshInterval: "0"`** because a
  refresh would invalidate every live session.
- `--reverse-proxy=true` and `--code-challenge-method=S256` both exist for specific
  reasons (Traefik/cloudflared in front; pocket-id advertises PKCE).

Authorisation is stated as belonging in **pocket-id**, with the client restricted
to groups, rather than duplicated into an oauth2-proxy allow-list — the one that
drifts is the one that ends up too permissive.

It also flags the failure mode with no warning attached: an Ingress still pointing
at the app rather than the proxy bypasses authentication entirely.

### Also

- The tutorial's next steps now point here first — it writes an Ingress in step 1
  and explains none of the choices.
- The **Reference "Planned" list is now empty** and the heading is gone.
- Reference leans on the generated `apps.md` for the host list rather than
  restating it.

Verified: builds clean, 22 pages, no broken links, all three carry their quadrant
class, generated reference still current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)