### PR TITLE
mealie: stop writing a log file onto the data volume

### DIFF
--- a/k8s/apps/mealie/app/configmap.yaml
+++ b/k8s/apps/mealie/app/configmap.yaml
@@ -1,0 +1,82 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: logging
+  labels:
+    app.kubernetes.io/name: mealie
+data:
+  # mealie's own logconf.prod.json, minus the "file" handler that writes
+  # ${DATA_DIR}/mealie.log. Fed in through LOG_CONFIG_OVERRIDE, which
+  # mealie/core/logger/config.py loads instead of the built-in config after
+  # substituting ${LOG_LEVEL} and ${DATA_DIR} -- so ${LOG_LEVEL} below is
+  # mealie's placeholder, not a shell or kustomize one, and must stay literal.
+  #
+  # Nothing is lost by dropping the handler: the file was a strict duplicate of
+  # stdout, which alloy already ships to Loki. In the upstream config the file
+  # handler sits at DEBUG but every logger sits at ${LOG_LEVEL}, so the two
+  # captured exactly the same records. mealie itself never reads the file back
+  # either -- routes/admin/admin_maintenance.py still defines tail_log(), but as
+  # of v3.22.0 nothing calls it and no route serves the file.
+  #
+  # A bad path here is a startup crash, not a silent fall back to the built-in
+  # config, so this cannot quietly resume writing to the volume.
+  logconf.json: |
+    {
+      "version": 1,
+      "disable_existing_loggers": false,
+      "formatters": {
+        "simple": {
+          "format": "%(levelname)-8s %(asctime)s - %(message)s",
+          "datefmt": "%Y-%m-%dT%H:%M:%S"
+        },
+        "access": {
+          "()": "uvicorn.logging.AccessFormatter",
+          "fmt": "%(levelname)-8s %(asctime)s - [%(client_addr)s] %(status_code)s \"%(request_line)s\"",
+          "datefmt": "%Y-%m-%dT%H:%M:%S"
+        }
+      },
+      "handlers": {
+        "stderr": {
+          "class": "logging.StreamHandler",
+          "level": "WARNING",
+          "formatter": "simple",
+          "stream": "ext://sys.stderr"
+        },
+        "stdout": {
+          "class": "logging.StreamHandler",
+          "level": "${LOG_LEVEL}",
+          "formatter": "simple",
+          "stream": "ext://sys.stdout"
+        },
+        "access": {
+          "class": "logging.StreamHandler",
+          "level": "${LOG_LEVEL}",
+          "formatter": "access",
+          "stream": "ext://sys.stdout"
+        }
+      },
+      "loggers": {
+        "root": {
+          "level": "${LOG_LEVEL}",
+          "handlers": [
+            "stderr",
+            "stdout"
+          ]
+        },
+        "uvicorn.error": {
+          "handlers": [
+            "stderr",
+            "stdout"
+          ],
+          "level": "${LOG_LEVEL}",
+          "propagate": false
+        },
+        "uvicorn.access": {
+          "handlers": [
+            "access"
+          ],
+          "level": "${LOG_LEVEL}",
+          "propagate": false
+        }
+      }
+    }

--- a/k8s/apps/mealie/app/deployment.yaml
+++ b/k8s/apps/mealie/app/deployment.yaml
@@ -37,6 +37,12 @@ spec:
           value: '1000'
         - name: TZ
           value: Europe/Warsaw
+        # Loads the logging ConfigMap in place of mealie's built-in
+        # logconf.prod.json, whose "file" handler wrote ${DATA_DIR}/mealie.log --
+        # a duplicate of this container's stdout, which alloy already ships to
+        # Loki, growing ~1M/day on a replicated volume holding 2.1M of recipes.
+        - name: LOG_CONFIG_OVERRIDE
+          value: /etc/mealie/logconf.json
         - name: BASE_URL
           value: https://recipes.krupa.net.pl
         - name: ALLOW_PASSWORD_LOGIN
@@ -94,7 +100,16 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /app/data/
+        # Its own directory, so no subPath is needed. mealie reads this once
+        # while building the root logger, so editing the ConfigMap alone changes
+        # nothing until the Pod restarts.
+        - name: logging
+          mountPath: /etc/mealie
+          readOnly: true
       volumes:
       - name: data
         persistentVolumeClaim:
           claimName: data
+      - name: logging
+        configMap:
+          name: logging

--- a/k8s/apps/mealie/app/kustomization.yaml
+++ b/k8s/apps/mealie/app/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - service.yaml
+  - configmap.yaml
   - ingress.yaml
   - pvc.yaml
   - deployment.yaml

--- a/k8s/apps/mealie/app/pvc.yaml
+++ b/k8s/apps/mealie/app/pvc.yaml
@@ -6,10 +6,16 @@ metadata:
     # without this is not backed up -- which is what keeps the three CNPG
     # claims in this namespace out, since they self-backup via barman.
     k8up.io/backup: "true"
-    # 22.6M of the 25M on this volume is mealie.log and its rotations; the
-    # recipes are 2.1M. Backing up a log that churns daily costs a fresh copy
-    # in every snapshot for something Loki already collects and nobody would
-    # restore.
+    # Kept even though LOG_CONFIG_OVERRIDE on the Deployment stopped mealie
+    # writing mealie.log at all. Dropping the file handler does not delete the
+    # files already on the volume, so without this the next nightly run would
+    # pull the historical log into the repository and retention would hold it
+    # for months -- the exact copies this was added to keep out, admitted on the
+    # way out rather than on the way in.
+    #
+    # It also stays cheap insurance afterwards. Removing the env var, or an
+    # image that stops honouring it, brings the file back silently; an exclude
+    # matching nothing costs nothing.
     k8up.io/backup-restic-args: '["--exclude=mealie.log*"]'
   name: data
   labels:


### PR DESCRIPTION
Closes #1303. Extracted from #1342, where it landed by accident — that PR is now docs-only.

`mealie/data` is a replicated volume whose real contents are 2.1M of recipes; the rest was `mealie.log`, a file already duplicated into Loki.

## Verified, not assumed

- **The file is a strict duplicate.** Upstream `logconf.prod.json` gives the `file` handler level `DEBUG`, but every logger sits at `${LOG_LEVEL}`, so the file and stdout captured exactly the same records. Nothing was only in the file.
- **Loki has it.** `{namespace="mealie"} |= "api/app/about"` returns the same lines with `stream="stdout"`.
- **Nothing reads it back.** `tail_log()` still exists in `routes/admin/admin_maintenance.py`, but no route calls it in v3.22.0 — the file is write-only.
- **The override works in the real image.** Ran mealie's own `configured_logger()` against this exact config inside the running container:

  ```
  root           [StreamHandler <stderr>, StreamHandler <stdout>]
  uvicorn.error  [StreamHandler <stderr>, StreamHandler <stdout>]
  uvicorn.access [StreamHandler <stdout>]
  ```

  No `FileHandler`, and `uvicorn.logging.AccessFormatter` still resolves.

## Why this option

Of the four in the issue, `LOG_CONFIG_OVERRIDE` is the only one that removes the file rather than hiding it. `emptyDir` cannot work — `mealie.log` sits directly in `/app/data` and would shadow `recipes/`. Raising `LOG_LEVEL` treats the symptom, and the probes are not noise to be silenced: `app/slo-probe-success.yaml` makes that blackbox check load-bearing for a Pyrra SLO, so it stays exactly as it is.

A bad path in `LOG_CONFIG_OVERRIDE` raises at startup rather than falling back to the built-in config, so the file handler cannot come back that way.

## The backup exclude stays

`k8up.io/backup-restic-args: '["--exclude=mealie.log*"]'` is **kept**, and only its comment changes.

An earlier revision of this PR dropped it on the grounds that #1303 was filed so it would not become permanent by default. That was wrong, and the ordering is why: not writing the file does not delete the copies already on the volume. The exclude would come off at merge while the cleanup below is manual, so the nightly 21:15 run could admit the historical log into the restic repository — and `keepDaily: 14` / `keepWeekly: 8` / `keepMonthly: 6` would then hold it for months. Exactly the copies the exclude exists to prevent, let in on the way out instead of the way in.

It also stays cheap insurance afterwards: removing the env var, or an image that stops honouring it, brings the file back silently, and an exclude matching nothing costs nothing. Its old comment cited volumes that this commit makes untrue, so that is rewritten to say why it is still there.

## Not the same answer as #1311

That one closed as *keep the data on the PVC*, and the difference is real: open-webui's cache is something you would have to re-download, while this log is a second copy of something already stored elsewhere. Different question, different answer.

## Checks

Rebased onto `master` after #1341 landed — that commit touched only `mealie/backup/schedule.yaml`, a comment, so no overlap. `make validate` (123 targets) and `make validate-flux` (49 paths) pass on the rebased branch, and a server-side dry-run applies cleanly with no Kyverno rejections.

## One manual step after merge

The config stops new writes but does not delete the existing file:

```
kubectl -n mealie exec deploy/mealie -- rm -f /app/data/mealie.log /app/data/mealie.log.1 /app/data/mealie.log.2 /app/data/mealie.log.3
```

Left as an exec rather than an initContainer — permanent cruft for a one-time cleanup is not worth it. No longer time-sensitive now that the exclude stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)