### PR TITLE
docs: explain how Flux is layered

### DIFF
--- a/docs/explanation/flux-layering.md
+++ b/docs/explanation/flux-layering.md
@@ -1,0 +1,126 @@
+# How Flux is layered { .quad-explanation }
+
+Nothing reaches this cluster except by being merged to `master`. There is no
+`kubectl apply` step, and no way to install something by hand that survives the
+next reconcile. What that costs is a structure that has to encode ordering,
+blast radius and failure isolation in configuration, because there is no operator
+present to sequence anything.
+
+That structure is three layers deep, and the shape is not arbitrary.
+
+## The three layers
+
+```
+k8s/bootstrap/     4 objects, applied once by hand
+  └── platform     24 components — the cluster's machinery
+        └── apps   22 components — the workloads
+```
+
+**`k8s/bootstrap/`** is the seed: a `GitRepository` pointing at this repo, and
+three umbrella `Kustomization`s. It is the only thing ever applied manually, and
+it exists solely so that everything after it can be applied by Flux.
+
+**`platform`** is what a workload assumes is already there — CNI, storage drivers,
+ingress controllers, cert-manager, admission control, the observability
+collectors. Breaking something here breaks things that do not mention it.
+
+**`apps`** is the workloads. An app can fail entirely without taking anything else
+with it, which is the property the split exists to preserve.
+
+`apps` `dependsOn` `platform`, so on a cold start nothing tries to claim a volume
+before there is a CSI driver to answer.
+
+## Why the Kustomizations live apart from the manifests
+
+Each component appears in two places: its manifests under `k8s/platform/…` or
+`k8s/apps/…`, and a Flux `Kustomization` under `k8s/flux/platform/` or
+`k8s/flux/apps/` that points at them.
+
+The indirection looks redundant until you notice what the umbrella
+Kustomizations actually apply: `path: ./k8s/flux/apps` — a **directory of
+Kustomizations**, not of workloads. Adding an app means dropping one file into
+that directory; the umbrella picks it up on its next reconcile and no existing
+file changes.
+
+It also means the thing that decides *how* a component is reconciled — its
+interval, its dependencies, whether it prunes — is separate from *what* the
+component is. Those change for different reasons.
+
+## Ordering, where it genuinely matters
+
+Seven of the 49 Kustomizations declare `dependsOn`, and two of those are the
+umbrellas themselves. Everything else is order-independent by construction; the
+exceptions are all cases where an object cannot be *accepted* by the API server
+until something else exists:
+
+| Component | Waits for | Why |
+| --- | --- | --- |
+| `platform` | `prometheus-operator-crds` | nearly everything ships a ServiceMonitor or PrometheusRule |
+| `kyverno-policies`, `cnpg-system`, `csi-nfs` | `kyverno` | policies need their CRDs; the others are validated by them |
+| `piraeus-datastore` | `topolvm`, `kyverno` | its storage pool *is* a topolvm thin pool |
+| `homer-services` | `homer` | it adds entries to a dashboard that must exist |
+
+`prometheus-operator-crds` sits in `k8s/bootstrap/` rather than in `platform`
+precisely because `platform` depends on it — a layer cannot depend on one of its
+own members.
+
+`prometheus-operator-crds` and `kyverno` are the only two with `wait: true`, and
+for the same reason: a dependency that is merely *applied* is not yet *usable*. A
+CRD has to be established before an object of that kind will be accepted, and
+admission control that is applied but not yet enforcing lets anything reconciled
+into the gap slip past the policies unchecked.
+
+## Pruning, and the eight exceptions
+
+`prune: true` is the default here — 41 of 49 Kustomizations have it, which is what
+makes deleting a directory delete the objects, and what makes the tutorial's
+cleanup step work.
+
+The exceptions divide into two kinds.
+
+**The three umbrellas** (`platform`, `apps`, `prometheus-operator-crds`) do not
+prune because a transient failure to render one of them would otherwise be read as
+"these components are gone" and cascade into deleting every component in the
+layer.
+
+**Five platform components** — `cilium`, `flux-system`, `topolvm`,
+`piraeus-datastore`, `traefik` — do not prune because pruning them destroys
+something unrecoverable: cluster networking, Flux itself, the PVs holding every
+volume, or the ingress path to everything.
+
+Only `flux-system` records the reason in a comment. The other four share an
+obvious property, but that is inference from what they are, not something the
+repository states — worth knowing before assuming any of them can safely be
+switched back.
+
+## What reconciliation actually costs
+
+The `GitRepository` polls every 60 seconds, and a GitHub webhook `Receiver`
+triggers it on push, so a merge normally lands in seconds rather than a minute.
+
+The trap is that reconciling in the wrong order reports success while doing
+nothing. `flux reconcile kustomization <name>` acts on whatever revision the
+source currently holds — which, minutes after a merge, may still be the one before
+it. The source has to be refreshed first:
+
+```bash
+flux reconcile source git ankhmorpork
+flux -n flux-system reconcile kustomization <component>
+```
+
+For a component whose values come from a `configMapGenerator`, there is a third
+step, and it is not optional. Values are fed in through a ConfigMap with
+`disableNameSuffixHash: true`, so editing `values.yaml` changes the ConfigMap's
+*contents* but not its name — and therefore nothing in the HelmRelease spec
+changes, and helm-controller sees no event to act on. It notices via
+`status.lastAttemptedConfigDigest` on its next interval, which is why every
+HelmRelease here is kept at a 5 minute interval, and why a values-only change
+needs its release reconciled explicitly:
+
+```bash
+flux -n <namespace> reconcile helmrelease <release>
+```
+
+The stable ConfigMap name is a deliberate trade — a hash suffix would trigger the
+upgrade immediately, at the cost of a new ConfigMap on every edit. Reconciling the
+release is the price of not accumulating those.

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -20,12 +20,13 @@ currently exists only in commit messages, per-app READMEs and
 ## Planned
 
 - Why observability is split by role rather than by stack
-- How Flux is layered: bootstrap, platform, apps
 - Why Helm values live in `values.yaml` rather than inline in a HelmRelease
 - What stays private, and why the rest of this is public
 
 ## Available now
 
+- [How Flux is layered](flux-layering.md) — bootstrap, platform, apps, and why
+  reconciling in the wrong order reports success
 - [Why storage is split the way it is](storage-durability.md) — and how a durability
   claim was tested rather than trusted
 - [Why a Kyverno policy rolls Pods on ConfigMap changes](configmap-autoreload.md)

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -325,5 +325,7 @@ back:
   `validate-ingress-contract`, which *denies* anything missing TLS or using an
   unapproved issuer; the resource requests satisfy `require-resource-requests`,
   which only warns. Both were chosen for you here.
+- **[How Flux is layered](../explanation/flux-layering.md)** — why step 5's
+  reconcile order is what it is, and why getting it wrong reports success.
 - **[Explanation](../explanation/index.md)** — why the cluster is arranged this
   way.

--- a/zensical.toml
+++ b/zensical.toml
@@ -59,6 +59,7 @@ nav = [
   ] },
   { "Explanation" = [
     "explanation/index.md",
+    { "How Flux is layered" = "explanation/flux-layering.md" },
     { "ConfigMap autoreload" = "explanation/configmap-autoreload.md" },
     { "Why storage is split the way it is" = "explanation/storage-durability.md" },
     { "Rule linting with pint" = "explanation/pint-rule-linting.md" },


### PR DESCRIPTION
**[How Flux is layered](https://docs.thaum.xyz/explanation/flux-layering/)** —
bootstrap → platform → apps, and the two things in that structure that are
load-bearing and easy to get wrong.

### Why the indirection exists

Each component appears twice: its manifests, and a Flux Kustomization pointing at
them. That looks redundant until you notice the umbrellas apply
`path: ./k8s/flux/apps` — a **directory of Kustomizations**, not of workloads. Adding
an app means dropping in one file; no existing file changes.

### Ordering and pruning, counted rather than asserted

- **7 of 49** Kustomizations declare `dependsOn`, two being the umbrellas. Every
  exception is a case where an object cannot be *accepted* until something else
  exists.
- **`prune: true` is the default** (41 of 49). The 8 exceptions fall into two
  distinct classes: the umbrellas, where a transient render failure would otherwise
  read as "these components are gone" and cascade; and five platform components
  whose deletion is unrecoverable — networking, Flux itself, the PVs, the ingress
  path.
- **`wait: true` on exactly two**, for the same reason: a CRD that is applied is
  not yet established, and admission control that is applied is not yet enforcing.

Only `flux-system` records why it does not prune. The other four share an obvious
property, but the page says explicitly that this is *inference*, not something the
repository states — someone will eventually consider switching one back.

### The reconcile trap, explained rather than listed

The tutorial teaches the order; this explains why. `flux reconcile kustomization`
acts on whatever revision the source currently holds, which minutes after a merge
may predate it. And a values-only change moves no field in the HelmRelease spec at
all, because `disableNameSuffixHash: true` keeps the ConfigMap name stable — so
helm-controller has no event to act on and notices only via
`status.lastAttemptedConfigDigest` on its next interval.

### A note on accuracy

Three numbers in my first draft were wrong: *41 of 48* rather than 49, *six
components* declaring `dependsOn` rather than seven Kustomizations, and `kyverno`
called the only `wait: true` when `prometheus-operator-crds` has it too. All three
are now counted from the manifests.

Linked from the tutorial's next steps, since step 5 teaches the reconcile order
without saying why.

Verified: builds clean, 23 pages, no broken links, quadrant class present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)