### PR TITLE
slo: fix two probe alert names, and point photos at immich's API

### DIFF
--- a/k8s/apps/atuin/app/slo-probe-success.yaml
+++ b/k8s/apps/atuin/app/slo-probe-success.yaml
@@ -21,8 +21,8 @@ spec:
   description: >-
     Fraction of successful blackbox probes against atuin.thaum.xyz.
   alerting:
-    name: AtuinProbeProbeBudgetBurn
-    absentName: AtuinProbeProbeMetricAbsent
+    name: AtuinProbeBudgetBurn
+    absentName: AtuinProbeMetricAbsent
     severities:
       fastBurn: info
       mediumBurn: info

--- a/k8s/apps/photos/app/values.yaml
+++ b/k8s/apps/photos/app/values.yaml
@@ -90,6 +90,17 @@ server:
       enabled: true
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt-prod
+        # Without this the probe hits `/` and gets 10.5KB of Svelte shell, which
+        # the web container serves from static assets -- it returns 200 with the
+        # API dead, and /health and /healthz fall through to the same catch-all.
+        # Not /api/server/ping either: ServerService.ping() is `return { res:
+        # 'pong' }`, a literal that cannot fail while the process can route a
+        # request, which is what `up` already tells us. getSystemConfig() behind
+        # /api/server/config makes three uncached reads -- the config repository,
+        # an admin-user lookup for isInitialized, and system_metadata for
+        # isOnboarded -- so it answers 372 bytes of JSON and fails when Postgres
+        # is unreachable. It is also what the login page itself fetches.
+        ingress.thaum.xyz/probe-uri: /api/server/config
         item.homer.rajsingh.info/name: "Immich"
         item.homer.rajsingh.info/subtitle: "Photo & Video Library"
         item.homer.rajsingh.info/logo: "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/refs/heads/main/assets/immich.svg"

--- a/k8s/apps/pocket-id/app/slo-probe-success.yaml
+++ b/k8s/apps/pocket-id/app/slo-probe-success.yaml
@@ -21,8 +21,8 @@ spec:
   description: >-
     Fraction of successful blackbox probes against login.krupa.net.pl.
   alerting:
-    name: PocketIDProbeProbeBudgetBurn
-    absentName: PocketIDProbeProbeMetricAbsent
+    name: PocketIDProbeBudgetBurn
+    absentName: PocketIDProbeMetricAbsent
     severities:
       fastBurn: info
       mediumBurn: info


### PR DESCRIPTION
Two small corrections found while checking what was left of the SLI/SLO plan. Both are worth landing during the burn-in rather than after it, because both change how the October review reads.

### `AtuinProbeProbeBudgetBurn`

Pyrra copies `alerting.name` verbatim, and the two probe objectives written by hand — atuin and pocket-id, the only services with more than one objective each — carry a doubled word. The eleven that #1336 decomposed out of the shared blackbox SLO are all correct.

Renamed to `AtuinProbeBudgetBurn` / `PocketIDProbeBudgetBurn`, matching both the other eleven and the `Availability` / `Latency` / `Probe` triple each of those two services now has.

No evidence is lost: neither has fired, and the burn-in is read back through the `slo` label, which does not change.

### photos probes the page immich serves when it is broken

The plan's inventory recorded `photos` as probing `/api/server/config`. **It never has** — `git log -S"probe-uri" -- k8s/apps/photos/app/values.yaml` returns nothing. The Ingress carries the probe label and no `probe-uri`, so the relabeling's `(.+);(.+);(.+)` never matches and the operator's default target stands: the bare host.

That measures **10,566 bytes of Svelte shell**, served from static assets by the web container, which answers 200 with the API dead. Same defect #1308 fixed on `keep`, `seek`, `papers` and `grafana` — still open only because a table said it was handled.

Rejected alternatives, checked live:

| path | result | why not |
|---|---|---|
| `/health`, `/healthz` | 200, **10,566 B** | same catch-all, byte-identical to `/` |
| `/api/server/ping` | 200, 14 B | `return { res: 'pong' }` — a literal, same reason `/api/v1/info/status` was rejected on stirling-pdf |
| `/api/server/about`, `/storage`, `/statistics` | 401 | auth required |
| **`/api/server/config`** | **200, 372 B, 0 redirects** | ✅ |

`getSystemConfig()` makes three uncached reads before it can answer — `getConfig({ withCache: false })`, an admin-user lookup behind `isInitialized`, and `system_metadata` for `isOnboarded` — so it fails when Postgres is unreachable rather than only when immich is. It is also the request the login page itself makes.

`photos-probe-success` needs no change: it selects on the host, not the full URL, which is exactly what that design was for.

### Verified

- `make validate` — 123 targets render and validate cleanly
- rendered Ingress carries `ingress.thaum.xyz/probe-uri: /api/server/config`
- swept every other probe-labelled Ingress: `homer` is the only other one without a `probe-uri`, and there `/` is the whole service

🤖 Generated with [Claude Code](https://claude.com/claude-code)