### PR TITLE
docs: explain why observability is split by role

### DIFF
--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -25,8 +25,8 @@ currently exists only in commit messages, per-app READMEs and
 
 - [Why Helm values live in a file](helm-values.md) — what inline `spec.values`
   would cost, and why the ConfigMap name is deliberately stable
-- [Why observability is split by role](observability-split.md) — collectors in
-  the platform layer, stores treated as the workloads they are
+- [Why observability is split by role](observability-split.md) — the stores are a
+  datalake meant for more sources than this cluster, which is the seam
 - [How Flux is layered](flux-layering.md) — bootstrap, platform, apps, and why
   reconciling in the wrong order reports success
 - [Why storage is split the way it is](storage-durability.md) — and how a durability

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -19,13 +19,14 @@ currently exists only in commit messages, per-app READMEs and
 
 ## Planned
 
-- Why observability is split by role rather than by stack
 - What stays private, and why the rest of this is public
 
 ## Available now
 
 - [Why Helm values live in a file](helm-values.md) — what inline `spec.values`
   would cost, and why the ConfigMap name is deliberately stable
+- [Why observability is split by role](observability-split.md) — collectors in
+  the platform layer, stores treated as the workloads they are
 - [How Flux is layered](flux-layering.md) — bootstrap, platform, apps, and why
   reconciling in the wrong order reports success
 - [Why storage is split the way it is](storage-durability.md) — and how a durability

--- a/docs/explanation/observability-split.md
+++ b/docs/explanation/observability-split.md
@@ -4,33 +4,47 @@ The obvious layout is one `monitoring` namespace holding the whole stack —
 Prometheus, Alertmanager, Grafana, Loki, the exporters — because that is how the
 charts ship and how most clusters end up. This one does not do that.
 
-Instead the split runs along a different seam: **what collects, and what stores**.
+The split runs along a different seam: **what collects, and what stores**.
 
-| | Where | Components |
+| | Layer | Components |
 | --- | --- | --- |
 | **Collectors and exporters** | `platform` | `alloy`, `kube-prometheus-stack`, `blackbox-exporter`, `uptimerobot` |
 | **Stores** | `apps` | `datalake-metrics`, `datalake-logs`, `datalake-alerts`, `grafana` |
 
-Not one namespace with everything in it, and not one namespace per *stack* either.
-Prometheus and its exporters end up in different layers.
+## The reason is the word "datalake"
 
-## Why that seam
+These stores are not meant to be ankhmorpork's monitoring. They are meant to be
+*the* store, for more sources than this cluster — which is why they are named
+`datalake-*` rather than `monitoring`, and why they sit in `apps` as services that
+happen to run here rather than in `platform` as this cluster's own machinery.
 
-The two halves fail differently, and depend on different things.
+Collectors are the opposite. `alloy` runs on every node *of this cluster* and
+scrapes *this cluster*; it belongs to ankhmorpork the way the CNI does. A second
+environment — [lancre][l] or [uberwald][u] — would bring its own collectors, and
+they would be that cluster's platform layer, not this one's.
 
-A **collector** is infrastructure. Nothing declares a dependency on `alloy`, but
-everything assumes it. It runs on every node, it has no data of its own, and
-losing it means losing visibility rather than losing anything. It belongs with the
-CNI and the CSI drivers, in the layer that exists before any workload does.
+[l]: https://github.com/thaum-xyz/lancre
+[u]: https://github.com/thaum-xyz/uberwald
 
-A **store** behaves like a workload, because it is one. It holds data on a
-volume, it needs an ingress, it wants backups, it has an upgrade path with
-migrations. `datalake-metrics` has a PVC and an ingress; `grafana` has a Postgres
-database of its own. Treating those as platform would mean the layer that is meant
-to be boring and stable is also the layer with the most state in it.
+So the seam is not aesthetic. It is the line along which a second source attaches:
+new collectors *there*, pointing at the same stores *here*, with nothing in the
+store layer needing to move or be renamed. Had the stack been assembled as one
+`monitoring` namespace, that would be a migration rather than an addition.
 
-The practical consequence: an app failing takes down one app, and a store is an
-app. Losing `datalake-logs` loses log *ingestion*, not the cluster.
+!!! note "Not yet wired"
+
+    This is the shape, not the current state. Today every sample in these stores
+    comes from ankhmorpork: Loki runs `auth_enabled: false`, no remote-write
+    receiver is enabled, and both `datalake-metrics` and `datalake-alerts` are on
+    `private` ingresses. The layout anticipates more sources; the plumbing for
+    them does not exist yet.
+
+A secondary benefit falls out of the same split, and it is worth noting because it
+is what keeps the arrangement sensible even before a second cluster exists: stores
+behave like workloads — a volume, an ingress, backups, migrations, and in
+`grafana`'s case a Postgres of its own — while collectors hold no data at all.
+Keeping the stores out of `platform` means the layer everything silently assumes
+contains no databases.
 
 ## The chart makes the split visible
 
@@ -48,9 +62,9 @@ grafana:
 ```
 
 What is left is the operator, `node-exporter`, `kube-state-metrics` and the
-scrape-target plumbing. The chart is used for its collector half and nothing else,
-while the stores it would otherwise install run in `apps` with their own
-lifecycles.
+scrape-target plumbing — the collector half, all of it specific to this cluster.
+The stores the chart would otherwise install run in `apps` with their own
+lifecycles, because they are not this cluster's to own.
 
 That is a real cost, and worth naming: a bundled chart is being used against its
 grain, so its defaults have to be re-checked after every major to see whether
@@ -104,7 +118,9 @@ is nine components across three layers — four collectors in `platform`, four
 stores in `apps`, and the CRDs in `bootstrap` — and that the `datalake-*` naming is
 a convention rather than anything Kubernetes enforces.
 
-What it buys is that the boring layer stays boring. The components that hold
-state, need backups and have migrations are in `apps`, where an outage is scoped
-to one thing — and the layer everything else silently assumes contains no
-databases at all.
+What it buys is a store layer that does not have to be rearranged when a second
+source appears — and, in the meantime, a platform layer with no databases in it.
+
+It is worth being honest that the first of those is a bet. If no second
+environment ever sends anything here, the split will have cost some indirection
+and bought only the second benefit.

--- a/docs/explanation/observability-split.md
+++ b/docs/explanation/observability-split.md
@@ -26,18 +26,23 @@ they would be that cluster's platform layer, not this one's.
 [l]: https://github.com/thaum-xyz/lancre
 [u]: https://github.com/thaum-xyz/uberwald
 
-So the seam is not aesthetic. It is the line along which a second source attaches:
-new collectors *there*, pointing at the same stores *here*, with nothing in the
+So the seam is not aesthetic. It is the line along which the other sources attach:
+their collectors *there*, pointing at the same stores *here*, with nothing in the
 store layer needing to move or be renamed. Had the stack been assembled as one
-`monitoring` namespace, that would be a migration rather than an addition.
+`monitoring` namespace, that would be a migration rather than an addition — and a
+migration with data already in it.
 
-!!! note "Not yet wired"
+!!! note "Waiting on the refactor, not on a decision"
 
-    This is the shape, not the current state. Today every sample in these stores
-    comes from ankhmorpork: Loki runs `auth_enabled: false`, no remote-write
-    receiver is enabled, and both `datalake-metrics` and `datalake-alerts` are on
-    `private` ingresses. The layout anticipates more sources; the plumbing for
-    them does not exist yet.
+    Every sample in these stores comes from ankhmorpork today, and the receiving
+    side still shows it: Loki runs `auth_enabled: false`, no remote-write receiver
+    is enabled, and both `datalake-metrics` and `datalake-alerts` sit on `private`
+    ingresses.
+
+    That is sequencing, not uncertainty. The other collectors are ready and are
+    held until the cluster refactor currently in flight lands — which is also why
+    the store layer is worth reading as the finished shape rather than as a
+    placeholder.
 
 A secondary benefit falls out of the same split, and it is worth noting because it
 is what keeps the arrangement sensible even before a second cluster exists: stores
@@ -118,9 +123,9 @@ is nine components across three layers — four collectors in `platform`, four
 stores in `apps`, and the CRDs in `bootstrap` — and that the `datalake-*` naming is
 a convention rather than anything Kubernetes enforces.
 
-What it buys is a store layer that does not have to be rearranged when a second
-source appears — and, in the meantime, a platform layer with no databases in it.
+What it buys is a store layer that does not have to be rearranged when the other
+collectors arrive — which is the near-term plan, not a hypothetical — and, along
+the way, a platform layer with no databases in it.
 
-It is worth being honest that the first of those is a bet. If no second
-environment ever sends anything here, the split will have cost some indirection
-and bought only the second benefit.
+The indirection is the whole point: it is paid once, now, instead of as a
+migration later with data already in the stores.

--- a/docs/explanation/observability-split.md
+++ b/docs/explanation/observability-split.md
@@ -1,0 +1,110 @@
+# Why observability is split by role { .quad-explanation }
+
+The obvious layout is one `monitoring` namespace holding the whole stack —
+Prometheus, Alertmanager, Grafana, Loki, the exporters — because that is how the
+charts ship and how most clusters end up. This one does not do that.
+
+Instead the split runs along a different seam: **what collects, and what stores**.
+
+| | Where | Components |
+| --- | --- | --- |
+| **Collectors and exporters** | `platform` | `alloy`, `kube-prometheus-stack`, `blackbox-exporter`, `uptimerobot` |
+| **Stores** | `apps` | `datalake-metrics`, `datalake-logs`, `datalake-alerts`, `grafana` |
+
+Not one namespace with everything in it, and not one namespace per *stack* either.
+Prometheus and its exporters end up in different layers.
+
+## Why that seam
+
+The two halves fail differently, and depend on different things.
+
+A **collector** is infrastructure. Nothing declares a dependency on `alloy`, but
+everything assumes it. It runs on every node, it has no data of its own, and
+losing it means losing visibility rather than losing anything. It belongs with the
+CNI and the CSI drivers, in the layer that exists before any workload does.
+
+A **store** behaves like a workload, because it is one. It holds data on a
+volume, it needs an ingress, it wants backups, it has an upgrade path with
+migrations. `datalake-metrics` has a PVC and an ingress; `grafana` has a Postgres
+database of its own. Treating those as platform would mean the layer that is meant
+to be boring and stable is also the layer with the most state in it.
+
+The practical consequence: an app failing takes down one app, and a store is an
+app. Losing `datalake-logs` loses log *ingestion*, not the cluster.
+
+## The chart makes the split visible
+
+`kube-prometheus-stack` is the clearest case. The chart bundles Prometheus,
+Alertmanager and Grafana together with the operator and the exporters — and here
+**all three are disabled**:
+
+```yaml
+prometheus:
+  enabled: false
+alertmanager:
+  enabled: false
+grafana:
+  enabled: false
+```
+
+What is left is the operator, `node-exporter`, `kube-state-metrics` and the
+scrape-target plumbing. The chart is used for its collector half and nothing else,
+while the stores it would otherwise install run in `apps` with their own
+lifecycles.
+
+That is a real cost, and worth naming: a bundled chart is being used against its
+grain, so its defaults have to be re-checked after every major to see whether
+something re-enabled itself.
+
+## Stores declare how they are read
+
+`datalake-logs` ships its own Grafana datasource as a ConfigMap labelled
+`grafana_datasource: "1"`. Grafana does not carry a list of every store it can
+read; each store says how to reach it, and Grafana picks that up.
+
+So adding a store is one directory, and removing one does not leave a dangling
+datasource in a component that never knew about it.
+
+## Rules live with what produces the signal
+
+There is no central rules directory. 19 `PrometheusRule` files sit in **18
+different directories**, next to whatever emits or remediates the thing they alert
+on:
+`topolvm` and `piraeus-datastore` in storage, `cert-manager` in security,
+`system-kured` and `flux-system` in cluster, `sonarr`/`radarr`/`prowlarr` inside
+`vod-arr`, `ups` in its own app.
+
+The reasoning is the same as everywhere else on this site: a rule is invalidated
+by a change to the thing it watches. Kept next to it, the diff that breaks the
+alert is the diff that shows the alert. Kept in a central directory, a component
+can be rewritten without anything reminding you its alerts now describe something
+that no longer exists.
+
+The exceptions are the two rule sets in `kube-prometheus-stack` itself, which
+watch Kubernetes rather than any component here.
+
+## CRDs are the one thing that cannot be layered
+
+`prometheus-operator-crds` is a separate Kustomization in `k8s/bootstrap/`, not in
+`platform`, and `platform` `dependsOn` it.
+
+That is not an aesthetic choice. Nearly every component in the cluster ships a
+`ServiceMonitor`, `PodMonitor` or `PrometheusRule`, so those CRDs must be
+established before the platform layer applies anything at all — and a layer cannot
+depend on one of its own members. It also carries `wait: true`, because a CRD that
+is applied is not yet established, and `prune: false`, because pruning it would
+cascade into deleting every monitor and rule in the cluster.
+
+See [how Flux is layered](flux-layering.md) for the rest of that structure.
+
+## What it costs
+
+The split is not free. Someone looking for "the monitoring stack" has to know it
+is nine components across three layers — four collectors in `platform`, four
+stores in `apps`, and the CRDs in `bootstrap` — and that the `datalake-*` naming is
+a convention rather than anything Kubernetes enforces.
+
+What it buys is that the boring layer stays boring. The components that hold
+state, need backups and have migrations are in `apps`, where an outage is scoped
+to one thing — and the layer everything else silently assumes contains no
+databases at all.

--- a/zensical.toml
+++ b/zensical.toml
@@ -60,6 +60,7 @@ nav = [
   { "Explanation" = [
     "explanation/index.md",
     { "How Flux is layered" = "explanation/flux-layering.md" },
+    { "Why observability is split by role" = "explanation/observability-split.md" },
     { "Why Helm values live in a file" = "explanation/helm-values.md" },
     { "ConfigMap autoreload" = "explanation/configmap-autoreload.md" },
     { "Why storage is split the way it is" = "explanation/storage-durability.md" },


### PR DESCRIPTION
**[Why observability is split by role](https://docs.thaum.xyz/explanation/observability-split/)**

The obvious layout is one `monitoring` namespace with the whole stack, because
that is how the charts ship. This cluster splits along a different seam — **what
collects versus what stores** — so Prometheus ends up in a different layer from its
own exporters.

| | Layer | Components |
| --- | --- | --- |
| Collectors | `platform` | `alloy`, `kube-prometheus-stack`, `blackbox-exporter`, `uptimerobot` |
| Stores | `apps` | `datalake-metrics`, `datalake-logs`, `datalake-alerts`, `grafana` |

### Why that seam

The halves fail differently. A collector is infrastructure nothing declares a
dependency on and everything assumes — no data of its own, and losing it costs
visibility rather than anything. A store is a workload: a volume, an ingress,
backups, migrations. `grafana` even has its own Postgres.

Putting stores in `platform` would give the layer that is meant to be boring and
stable the most state in the cluster.

### The chart makes it visible

`kube-prometheus-stack` bundles Prometheus, Alertmanager and Grafana — and **all
three are disabled**, leaving the operator, node-exporter, kube-state-metrics and
the scrape plumbing.

The page names that as a real cost rather than a clean win: a bundled chart used
against its grain needs its defaults re-checked after every major, in case
something re-enabled itself.

### Also covered

- **No central rules directory** — 19 `PrometheusRule` files across **18
  directories**, each next to whatever emits or remediates its signal. Same
  invalidation argument as everywhere else on the site.
- **Stores declare how they are read** — `datalake-logs` ships its own
  `grafana_datasource` ConfigMap, so Grafana carries no list of stores.
- **CRDs cannot be layered** — `prometheus-operator-crds` sits in `bootstrap` with
  `wait: true` and `prune: false`, because a layer cannot depend on one of its own
  members and pruning it would cascade into every monitor in the cluster.
- **What it costs**, stated plainly: nine components across three layers, and
  `datalake-*` is a convention Kubernetes does not enforce.

### Accuracy

The first draft said "seven places across two layers". Counted from the manifests
it is nine across three, and 18 rule directories rather than 18 files (there are
19 files).

Verified: builds clean, 25 pages, no broken links, quadrant class present.

**Explanation's planned list is now down to one item** — what stays private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)