### PR TITLE
metal: drop the longhorn LV and its mount

### DIFF
--- a/metal/01_system.yml
+++ b/metal/01_system.yml
@@ -62,8 +62,13 @@
       state: present
       reload: yes
 
-# Multipathd needs to be configured to prevent colisions with longhorn
+# Multipathd was configured to prevent collisions with longhorn, whose iSCSI
+# volumes appeared as /dev/sd* and got claimed by multipathd.
 # More in https://longhorn.io/kb/troubleshooting-volume-with-multipath/
+#
+# Longhorn is gone, so nothing needs this any more. Kept because the blacklist
+# is inert on single-path disks and dropping it would let multipathd start
+# managing the real /dev/sd* devices -- a behaviour change with no upside.
 - name: Configure multipathd
   hosts: all
   become: true

--- a/metal/host_vars/beelink01.yaml
+++ b/metal/host_vars/beelink01.yaml
@@ -4,9 +4,3 @@ system_mountpoints:
     device: "/dev/ubuntu-vg/rancher"
     mountpoint: "/var/lib/rancher"
     type: "xfs"
-  - description: longhorn storage
-    after: "var-lib-rancher.mount"
-    before: "k3s.service"
-    device: "/dev/ubuntu-vg/longhorn"
-    mountpoint: "/var/lib/rancher/longhorn"
-    type: "xfs"

--- a/metal/host_vars/beelink02.yaml
+++ b/metal/host_vars/beelink02.yaml
@@ -4,9 +4,3 @@ system_mountpoints:
     device: "/dev/ubuntu-vg/rancher"
     mountpoint: "/var/lib/rancher"
     type: "xfs"
-  - description: longhorn storage
-    after: "var-lib-rancher.mount"
-    before: "k3s.service"
-    device: "/dev/ubuntu-vg/longhorn"
-    mountpoint: "/var/lib/rancher/longhorn"
-    type: "xfs"

--- a/metal/host_vars/master01.yaml
+++ b/metal/host_vars/master01.yaml
@@ -4,9 +4,3 @@ system_mountpoints:
     device: "/dev/ubuntu-vg/rancher"
     mountpoint: "/var/lib/rancher"
     type: "ext4"
-  - description: longhorn storage
-    after: "var-lib-rancher.mount"
-    before: "k3s.service"
-    device: "/dev/secondary-vg/longhorn"
-    mountpoint: "/var/lib/rancher/longhorn"
-    type: "xfs"

--- a/metal/host_vars/master02.yaml
+++ b/metal/host_vars/master02.yaml
@@ -4,9 +4,3 @@ system_mountpoints:
     device: "/dev/ubuntu-vg/rancher"
     mountpoint: "/var/lib/rancher"
     type: "ext4"
-  - description: longhorn storage
-    after: "var-lib-rancher.mount"
-    before: "k3s.service"
-    device: "/dev/secondary-vg/longhorn"
-    mountpoint: "/var/lib/rancher/longhorn"
-    type: "xfs"


### PR DESCRIPTION
Last of the #1266 cleanup. Frees **100g per node** across all four hosts.

Safe to do now because the volumes were reclaimed by Longhorn's own CSI driver *before* the uninstall — `/var/lib/rancher/longhorn` is **4.0K** on every node: an empty `replicas/` (timestamped the moment the PVs were deleted), a leftover `storage-bench-scratch/`, and `longhorn-disk.cfg`.

## The space is deliberately left unallocated

The obvious move is to fold it into `thin-pool0`. Measured, there is no reason to:

| node | pool | data used | provisioned into it | VG free |
| --- | --- | --- | --- | --- |
| beelink01 | 300g | 8.7% | 263g | 328g |
| **beelink02** | **200g** | 14.7% | **500g** | 428g |
| master02 | 300g | 2.3% | 177g | 65g |

Pools are 2–15% used with hundreds of GB already unallocated beside them. Committing the space now buys nothing and closes options; leaving it free keeps both on the table — growing the shared pool later, or carving a separate one for piraeus, which its storage pool name **`temporary-topolvm`** rather suggests was always the intent.

## One thing the numbers did surface

**beelink02 carries 500g of provisioned volumes on a 200g pool — 2.5×, where its peers sit under 1×.** Thin over-provisioning is normal, but a full thin pool fails *every* volume in it, and that pool is shared by piraeus replicas and CNPG postgres. It is grown 200g → 300g to match its peers, separately from this PR since it is an `lvextend`, not a git change.

That shared-pool coupling is the real structural question. Separating it means a new LINSTOR storage pool, a new StorageClass, and re-migrating the six volumes just moved — worth its own issue rather than riding along here.

## Kept deliberately

The **multipathd blacklist** in `01_system.yml` exists because Longhorn's iSCSI volumes surfaced as `/dev/sd*` and got claimed by multipathd. Longhorn is gone, but the blacklist is inert on single-path disks and dropping it would let multipathd start managing the real ones — a behaviour change with no upside. The comment is corrected to say so.

## Rollout

Ansible only stops *managing* the mount; it does not remove it. Per node:

```bash
systemctl disable --now var-lib-rancher-longhorn.mount
rm /etc/systemd/system/var-lib-rancher-longhorn.mount
systemctl daemon-reload
lvremove -y /dev/<vg>/longhorn      # ubuntu-vg on beelinks, secondary-vg on masters
rmdir /var/lib/rancher/longhorn
```

No fstab entries involved — these are systemd `.mount` units, currently enabled and active. k3s is unaffected: the unit is ordered `before: k3s.service` but nothing reads the path any more.

Refs #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)