### PR TITLE
topolvm: alert on thin pool metadata, not just data

### DIFF
--- a/k8s/platform/storage/topolvm-system/topolvm/prometheusrules.yaml
+++ b/k8s/platform/storage/topolvm-system/topolvm/prometheusrules.yaml
@@ -46,3 +46,28 @@ spec:
       for: 5m
       labels:
         severity: critical
+    # Metadata exhaustion fails a thin pool exactly as hard as data exhaustion,
+    # and the four rules above only watch data.
+    #
+    # 80% rather than the 90% used for data, for two reasons. Measured
+    # 2026-09-06, metadata usage fits 17.35 MiB fixed + ~19 B per allocated
+    # chunk, so filling every pool here to 100% data lands metadata at 8-34%
+    # (beelink01 8%, beelink02 12%, master01 34%, master02 32%). Anything
+    # sustained above 80% therefore is not ordinary growth -- it means thin
+    # snapshots have appeared, whose divergence multiplies mappings, or the
+    # metadata LV is undersized for its pool. Second, there is no predict_linear
+    # companion here as there is for data, because no metric exposes the
+    # metadata LV size or the chunk size, so an earlier absolute threshold is
+    # what buys the lead time instead.
+    #
+    # The fix is an online lvextend --poolmetadatasize, so a warning with plenty
+    # of runway is more useful than a critical with none.
+    - alert: TopoLVMThinPoolMetadataAlmostFull
+      annotations:
+        description: The metadata in LVM thin pool connected to device class {{$labels.device_class}} on node {{$labels.node}} reached {{$value}}% occupancy. Ordinary data growth tops out near 34% here, so this means snapshots have appeared or the metadata LV is undersized. If it reaches 100% every LogicalVolume in the pool starts misbehaving, exactly as with data exhaustion.
+        runbook_url: https://runbooks.thaum.xyz/runbooks/thaum-xyz/TopoLVMThinPoolMetadataAlmostFull
+        summary: LVM thin pool metadata has less than 20% free space.
+      expr: topolvm_thinpool_metadata_percent > 80
+      for: 15m
+      labels:
+        severity: warning


### PR DESCRIPTION
Closes the gap in #1350. Metadata exhaustion fails a thin pool exactly as hard as data exhaustion, and the four existing rules only watch `topolvm_thinpool_data_percent`.

```yaml
- alert: TopoLVMThinPoolMetadataAlmostFull
  expr: topolvm_thinpool_metadata_percent > 80
  for: 15m
  labels:
    severity: warning
```

## Why 80%, where the data alerts use 90%

Measured across all four nodes, metadata usage fits **17.35 MiB fixed + ~19 bytes per allocated chunk** (fit within 0.7 MiB on every point). Projecting each pool to 100% data allocation:

| node | pool | chunk | metadata at full data |
| --- | --- | --- | --- |
| beelink01 | 300g | 256k | 8% |
| beelink02 | 300g | 128k | 12% |
| master01 | 340g | 64k | 34% |
| master02 | 300g | 64k | 32% |

So ordinary growth cannot push metadata past ~34% here. **Anything sustained above 80% is not growth** — it means thin snapshots have appeared, whose divergence multiplies mappings, or the metadata LV is undersized for its pool.

The earlier threshold also compensates for a missing companion: the data alerts pair a threshold with `predict_linear`, and there is no equivalent here. No metric exposes the metadata LV size or the chunk size, so the headroom ratio that would catch an undersized pool *directly* is not expressible — only the percentage is available. `topolvm_thinpool_size_bytes` and `topolvm_thinpool_overprovisioned_available` are the only other thin-pool series, and neither helps.

## Warning, not critical

The remedy is an online `lvextend --poolmetadatasize` with no downtime, so lead time is worth more than urgency. `for: 15m` because metadata is a slow-moving signal — a longer window costs nothing and avoids flapping.

Deliberately no critical tier: one alert was asked for, and a second threshold is easy to add later if escalation turns out to be wanted.

## Verified against live data

- The metric has **4 series**, carrying the same `node` and `device_class` labels the existing rules template on.
- The expression matches **nothing** today, with occupancy at 3.6–5.9%.
- Dropping the threshold below current values matches **all four nodes**, confirming the series and comparison actually work — rather than assuming, which is how #1288 happened.
- `pint` online `promql/series` passes; the whole ruleset is clean.

Refs #1350, #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)
