### PR TITLE
changedetection: probe the app, not the login page it redirects to

### DIFF
--- a/docs/how-to/require-a-login.md
+++ b/docs/how-to/require-a-login.md
@@ -142,6 +142,42 @@ the sidecar's port on the app's own Service. Both the `public` and `cloudflare`
 Ingresses must point there. An Ingress still aimed at the app bypasses
 authentication entirely, and nothing will warn you.
 
+### Probing an app behind the proxy
+
+Adding `ingress.thaum.xyz/probe: enabled` and stopping there produces a probe
+that cannot fail. The blackbox target becomes the bare host, the proxy redirects
+it into pocket-id, `--skip-provider-button` sends it straight to `/interaction`,
+and pocket-id answers 200. blackbox follows redirects and `http_2xx` asserts
+nothing about the body, so the probe's success criterion is *pocket-id is up* —
+it stays green with the app it names completely down. That is worse than no
+probe, because it looks like coverage.
+
+Both proxied apps here were caught by it: `pdf` had the defect for real, and
+`change` would have inherited it.
+
+So pick a path the app serves itself and exempt it:
+
+```yaml
+- --skip-auth-route=GET=^/actuator/health$
+```
+
+Three things to check before choosing one:
+
+- **It must be answered by the app process**, not by a static asset and not by
+  the proxy. `/ping` and `/ready` are oauth2-proxy's own endpoints, so probing
+  them measures the proxy.
+- **It must be safe to serve unauthenticated**, because exempting it publishes
+  it. Prefer counts and status over anything that lists content — `/` is usually
+  the app's data.
+- **It must not change anything.** changedetection's `/worker-health` restarts
+  dead workers; a probe must not repair what it measures.
+
+The exemption matches `req.URL.Path`, not the request URI, so a query string in
+`ingress.thaum.xyz/probe-uri` is not part of the regex.
+
+Verify with `probe_http_redirects == 0` on the new target — a probe still
+redirecting is a probe still landing on the login page.
+
 ## Authorisation stays in pocket-id
 
 Restrict the **client** to groups in pocket-id. It then refuses to issue a token

--- a/k8s/apps/changedetection/proxy/deployment.yaml
+++ b/k8s/apps/changedetection/proxy/deployment.yaml
@@ -45,6 +45,36 @@ spec:
             - --cookie-secure=true
             # Straight to pocket-id rather than an interstitial sign-in page.
             - --skip-provider-button=true
+            # Let the blackbox probe reach changedetection itself without auth.
+            #
+            # Without it the probe requests `/`, this proxy redirects to
+            # login.krupa.net.pl (--skip-provider-button sends it straight to the
+            # IdP rather than rendering a sign-in page), and pocket-id answers
+            # /interaction with 200. blackbox follows redirects and the http_2xx
+            # module asserts nothing about the body, so the probe's success
+            # criterion would be "pocket-id's login page returned 200" -- green
+            # with changedetection completely down. Same defect stirling-pdf had.
+            #
+            # /queue-status, not /worker-health or `/`:
+            #  - `/` is the watch list, 59KB and every watched URL in it. Never
+            #    exempt that.
+            #  - /worker-health calls worker_pool.check_worker_health(), which
+            #    *restarts* dead workers. A probe must not repair what it
+            #    measures, and it answers 200 whether the result is healthy or
+            #    degraded, so exposing it buys nothing.
+            #  - /queue-status is a read under the queue lock and returns 135
+            #    bytes. Exempted it is reachable unauthenticated, but its whole
+            #    output is queue counts and opaque watch UUIDs -- no URLs, no
+            #    titles, no content.
+            #
+            # changedetection has no endpoint that reports its own health, so
+            # this is a reachability check: the Flask process answered. That is
+            # all any path here can prove.
+            #
+            # Path only -- oauth2-proxy matches skip-auth-route against
+            # GetRequestPath, not the request URI, so the ?summary=true the
+            # probe-uri carries is not part of the match.
+            - --skip-auth-route=GET=^/queue-status$
           env:
             - name: OAUTH2_PROXY_CLIENT_ID
               valueFrom:

--- a/k8s/apps/changedetection/proxy/ingress.yaml
+++ b/k8s/apps/changedetection/proxy/ingress.yaml
@@ -11,9 +11,19 @@ metadata:
   name: changedetection-public
   labels:
     app.kubernetes.io/name: changedetection
+    # On this Ingress rather than the cloudflare twin: blackbox derives its
+    # scheme from whether the Ingress declares TLS, so probing that one builds
+    # an http:// target the tunnel never answers.
+    ingress.thaum.xyz/probe: enabled
     homer.rajsingh.info/enabled: "true"
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    # Everything here is behind the oauth2-proxy, so the default bare-host probe
+    # would land on pocket-id's /interaction page and report changedetection
+    # healthy whenever pocket-id is. /queue-status is exempted from auth in
+    # proxy/deployment.yaml and answered by changedetection itself; summary=true
+    # keeps the response to counts and a fixed size however deep the queue is.
+    ingress.thaum.xyz/probe-uri: /queue-status?summary=true
     item.homer.rajsingh.info/name: "Change Detection"
     item.homer.rajsingh.info/subtitle: "Website change detection"
     item.homer.rajsingh.info/logo: "https://user-images.githubusercontent.com/275001/231676626-7d768df9-be4c-4187-a573-aba640b826d3.svg"

--- a/k8s/apps/changedetection/proxy/kustomization.yaml
+++ b/k8s/apps/changedetection/proxy/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - cookie-secret.yaml
   - ingress.yaml
   - ingress-cloudflare.yaml
+  - slo-probe-success.yaml

--- a/k8s/apps/changedetection/proxy/slo-probe-success.yaml
+++ b/k8s/apps/changedetection/proxy/slo-probe-success.yaml
@@ -1,0 +1,39 @@
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: changedetection-probe-success
+spec:
+  # Availability as a person experiences it: the blackbox probe, end to end
+  # through DNS, TLS, the ingress and the oauth2-proxy. Kept beside the Ingress
+  # and the proxy that carry the probe configuration, since the three have to
+  # move together -- the probe only reaches changedetection because
+  # --skip-auth-route exempts the path this measures.
+  #
+  # Matches on the host rather than the full probe URL, so changing
+  # ingress.thaum.xyz/probe-uri retunes the check without silently emptying the
+  # SLO behind it.
+  #
+  # changedetection exports no metrics of its own and has no endpoint that
+  # reports its own health, so this probe is its only availability signal -- and
+  # it is a reachability check, not a statement about whether watches are
+  # actually being fetched.
+  #
+  # target is a PLACEHOLDER, matching the other probe objectives. This service
+  # has never been measured, so there is no history to pick a number from; set
+  # it once there is a window of data.
+  description: >-
+    Fraction of successful blackbox probes against change.krupa.net.pl.
+  alerting:
+    name: ChangedetectionProbeBudgetBurn
+    absentName: ChangedetectionProbeMetricAbsent
+    severities:
+      fastBurn: info
+      mediumBurn: info
+      slowBurn: none
+      longTermBurn: none
+      absent: warning
+  indicator:
+    bool_gauge:
+      metric: probe_success{instance=~"https://change\\.krupa\\.net\\.pl(/.*)?"}
+  target: "95.0"
+  window: 4w


### PR DESCRIPTION
Closes #1338.

changedetection had no scrape target and no blackbox probe, so there was nothing to build an objective on. The cheap answer — annotate the Ingress — would have produced the exact defect #1306 fixed on `pdf`.

## The trap, confirmed

```
https://change.krupa.net.pl/
  -> 200, 2 redirects
  -> final: https://login.krupa.net.pl/interaction?interaction=...
  -> 5174 bytes
```

Byte-for-byte the page `pdf` was terminating on. `http_2xx` asserts nothing about the body and blackbox follows redirects, so `probe-uri: /` here would have meant "pocket-id returned 200" — green with changedetection completely down.

## Picking a path

changedetection has **no health endpoint**. Measured against the live pod:

| path | result |
|---|---|
| `/healthcheck`, `/health`, `/-/healthy` | 404 |
| `/api/v1/systeminfo` | 403 — its own API key auth |
| `/rss` | 403 — needs the RSS token |
| `/` | 200, **59KB**, the watch list with every watched URL in it |
| `/worker-health` | 200, 255B |
| `/queue-status?summary=true` | 200, **135B** |

The last two are undocumented, `@login_optionally_required`, and unauthenticated here because changedetection's own password is unset — auth is the proxy's job.

**`/worker-health` is a second trap, not the answer.** It calls `worker_pool.check_worker_health()`, which *restarts dead workers*, and it `jsonify`s a 200 whether the health check returns `healthy` or `degraded`. Probed every 30s by two Prometheus replicas it would repair the condition it measures and never once report it. A probe must not be the thing keeping its own subject alive.

So `/queue-status?summary=true`: a read under the queue lock (`get_queue_summary`, no mutation), 135 bytes, and fixed-size however deep the queue gets — the non-summary form paginates UUIDs and grows.

```
- --skip-auth-route=GET=^/queue-status$
```

Same shape as stirling-pdf's `^/actuator/health$`. Verified against v7.15.3 source that `--skip-auth-route` matches `requestutil.GetRequestPath(req)`, not the request URI, so the `?summary=true` the annotation carries is deliberately not part of the regex.

**Honest about what it measures:** changedetection exports no metrics and has no endpoint that reports its own health, so this is a reachability check — the Flask process answered. The SLO comment says exactly that rather than implying more. No path here can prove more.

## What this publishes

Exempting the path makes `https://change.krupa.net.pl/queue-status` reachable unauthenticated. Its entire output is queue counts plus, when watches are actively queued, `{uuid, position, priority}` — opaque identifiers, no URLs, no titles, no content, and knowing one grants nothing since every other path still passes through the proxy. Called out in the manifest comment rather than left to be rediscovered.

## The sweep

#1338 asked for it before adding probes anywhere else. All 25 non-cloudflare hosts, curled from inside the cluster:

**Exactly two redirect to `login.krupa.net.pl` — `pdf` and `change`.** Nothing else sits behind the oauth2-proxy, so there is no third case waiting. `pdf` was fixed in #1306; `change` is fixed here.

The generalisation is written up in `docs/how-to/require-a-login.md` under **Probing an app behind the proxy** — the failure mode, the three tests a candidate path has to pass (served by the app, safe to publish, no side effects), and `probe_http_redirects == 0` as the check. The how-to already tells you to put oauth2-proxy in front of an app; now it tells you what that does to the probe.

## Verification

- `make validate` — 123 targets render and validate cleanly
- `make validate-flux` — 49 live paths exist
- `https://pdf.krupa.net.pl/actuator/health` is `probe_success 1` in Prometheus today, which is this exact pattern already working in production

`target: "95.0"` is the placeholder the other probe objectives carry. This service has never been measured, so there is no history to pick a real number from.

## After merge

```
flux reconcile source git ankhmorpork
flux -n flux-system reconcile kustomization apps
```

Then confirm `probe_success{instance="https://change.krupa.net.pl/queue-status?summary=true"}` appears with `probe_http_redirects == 0`. A probe still redirecting is a probe still landing on the login page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
