### PR TITLE
docs: land the review follow-ups

### DIFF
--- a/.claude/skills/docs-authoring/SKILL.md
+++ b/.claude/skills/docs-authoring/SKILL.md
@@ -18,9 +18,10 @@ One home per fact. Every other page links to it.
 | what admission does, and to what | `docs/reference/admission-policies.md` *(generated)* | link |
 | Kustomization interval, prune, wait, dependsOn | `docs/reference/flux-kustomizations.md` *(generated)* | link |
 | which chart, from where, values source, interval | `docs/reference/helm-releases.md` *(generated)* | link |
+| ingress classes and their addresses, issuers, external-dns settings | `docs/reference/ingress.md` *(generated blocks)* | link |
 | chart or image **version** | the manifest itself | link to the file, never quote it |
 | storage class capabilities and measured numbers | `docs/reference/storage-classes.md` | link |
-| ingress classes, issuers, DNS behaviour | `docs/reference/ingress.md` | link |
+| how the storage numbers were measured | `hack/bench/storage/` | link |
 | annotation and label contracts | `docs/reference/annotations.md` | link |
 | the reconcile order and why it matters | `docs/explanation/flux-layering.md` | one sentence + link |
 | per-app quirks | `k8s/apps/<app>/README.md` | link |
@@ -63,8 +64,12 @@ are not fine as a substitute for keeping a claim current.
 
 ## Generated pages
 
-Four reference pages are written by `hack/generate-docs-reference.py` and
-carry a banner saying so. Never edit them; edit the script.
+Four reference pages are written whole by `hack/generate-docs-reference.py` and
+carry a banner saying so. Never edit them; edit the script. A hand-written page
+can also carry a generated *block*: the tables in `docs/reference/ingress.md` sit
+between `<!-- generated:NAME -->` markers and are overwritten on every run, while
+the prose around them is yours. Use a block when a page mixes derivable facts
+with judgment.
 
 ```bash
 make docs-reference          # regenerate

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ tmp/
 # Rendered documentation site (see zensical.toml)
 site/
 .venv/
+
+# Storage benchmark runs write here (hack/bench/storage/run.sh); the method is
+# committed, the results are not.
+hack/bench/storage/results/

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ docs-reference:  ## Regenerate the derivable reference pages under docs/referenc
 docs-reference-check: docs-reference  ## Fail if the generated reference pages are stale
 	@# git-status, not git-diff: diff ignores untracked files, so a page that was
 	@# never generated would pass silently.
-	@out="$$(git status --porcelain -- docs/reference/apps.md docs/reference/admission-policies.md docs/reference/flux-kustomizations.md docs/reference/helm-releases.md)"; \
+	@out="$$(git status --porcelain -- docs/reference/apps.md docs/reference/admission-policies.md docs/reference/flux-kustomizations.md docs/reference/helm-releases.md docs/reference/ingress.md)"; \
 	if [ -n "$$out" ]; then \
 		echo "$$out"; \
 		echo; \

--- a/docs/explanation/flux-layering.md
+++ b/docs/explanation/flux-layering.md
@@ -117,18 +117,11 @@ flux -n flux-system reconcile kustomization <component>
 ```
 
 For a component whose values come from a `configMapGenerator`, there is a third
-step, and it is not optional. Values are fed in through a ConfigMap with
-`disableNameSuffixHash: true`, so editing `values.yaml` changes the ConfigMap's
-*contents* but not its name — and therefore nothing in the HelmRelease spec
-changes, and helm-controller sees no event to act on. It notices via
-`status.lastAttemptedConfigDigest` on its next interval, which is why every
-HelmRelease here is kept at a 5 minute interval, and why a values-only change
-needs its release reconciled explicitly:
+step, and it is not optional: a values edit changes the ConfigMap's contents but
+not its name, so nothing in the HelmRelease spec moves and helm-controller has no
+event to act on. [Why Helm values live in a file](helm-values.md) has the
+mechanism and the trade; the step is:
 
 ```bash
 flux -n <namespace> reconcile helmrelease <release>
 ```
-
-The stable ConfigMap name is a deliberate trade — a hash suffix would trigger the
-upgrade immediately, at the cost of a new ConfigMap on every edit. Reconciling the
-release is the price of not accumulating those.

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -13,13 +13,10 @@ Admission test:
 - [ ] It can be read in any order relative to the rest of the site.
 
 This is where hard-won knowledge goes to stay found: measurements, trade-offs,
-and the reasoning behind conventions that otherwise look arbitrary. Most of it
-currently exists only in commit messages, per-app READMEs and
-`.claude/skills/app-deployment/SKILL.md`.
-
-## Planned
-
-- What stays private, and why the rest of this is public
+and the reasoning behind conventions that otherwise look arbitrary. Some of it
+is only in commit messages, per-app READMEs and
+`.claude/skills/app-deployment/SKILL.md`. Pages still to write are tracked as
+[issues labelled `documentation`](https://github.com/thaum-xyz/ankhmorpork/issues?q=is%3Aissue+is%3Aopen+label%3Adocumentation).
 
 ## Available now
 
@@ -33,4 +30,5 @@ currently exists only in commit messages, per-app READMEs and
   claim was tested rather than trusted
 - [Why a Kyverno policy rolls Pods on ConfigMap changes](configmap-autoreload.md)
 - [Why the rule linter alerts on change, not on count](pint-rule-linting.md)
-- [Postgres fleet upgrade plan](../postgres/fleet-upgrade-plan.md)
+- [The Postgres fleet upgrade](postgres-fleet-upgrade.md) — a record: why the fleet
+  was scattered, and the two traps that decided the order

--- a/docs/explanation/postgres-fleet-upgrade.md
+++ b/docs/explanation/postgres-fleet-upgrade.md
@@ -1,15 +1,17 @@
-# PostgreSQL fleet: state and upgrade plan { .quad-explanation }
+# The PostgreSQL fleet upgrade { .quad-explanation }
 
-Surveyed 2026-08-23. Eleven CNPG clusters on operator 1.30.0, chart
-`cnpg-database`.
+A record of the upgrade carried out in August 2026: what the fleet looked like
+when it was surveyed on 2026-08-23, why it was scattered, and the two traps that
+decided the order. The databases as they are now are in
+[Helm releases](../reference/helm-releases.md) and the manifests it links.
 
 ## Why the fleet is scattered
 
 Nine clusters never set `imageName`. CloudNativePG defaults it at creation and
 **writes that value into the spec permanently** — it does not re-default when the
 operator is upgraded. So each cluster froze whatever shipped on the day it was
-created, and nobody ever chose a version. Every cluster now pins its image
-explicitly.
+created, and nobody ever chose a version. At the time of the survey every
+cluster pinned its image explicitly.
 
 The default for *new* clusters is set by the `cnpg-database` chart, and is not
 restated here: it is invalidated by a change in
@@ -19,7 +21,7 @@ the chart had moved to 17.11. See the chart's
 [generated values reference](https://github.com/thaum-xyz/helm-charts/tree/main/charts/cnpg-database)
 for the current `cluster.imageName`.
 
-## Current state
+## State when surveyed
 
 | Cluster | Running | OS base | Latest in series | Behind |
 |---------|---------|---------|------------------|--------|
@@ -66,10 +68,10 @@ which compares by byte order and does not depend on glibc, so moving between
 Debian bases needs no `REINDEX`. Confirmed on mealie: `datcollversion` is null
 and the only index collations are `default` (inheriting C) and `C`.
 
-### State
+### State after
 
-Complete. Eight of eleven clusters follow the chart; the three that do not are
-recorded below with the reason.
+Eight clusters follow the chart; the three that do not are recorded below with
+the reason.
 
     atuin        17.11   follows chart   (was 16.11, two steps)
     grafana      17.11   follows chart   (was 17.5)

--- a/docs/explanation/storage-durability.md
+++ b/docs/explanation/storage-durability.md
@@ -119,5 +119,5 @@ that same LV, but is only approximate for `lvm-thin` and `piraeus-r2`, which use
 thin pool in the same volume group. And `piraeus-r2`'s sequential read exceeding
 the bare device remains unexplained.
 
-Method and raw results are not in the repository; they live in the operator's
-local `bench/storage-2026-09/` and re-run with `./full05.sh 4`.
+Method: [`hack/bench/storage/`](https://github.com/thaum-xyz/ankhmorpork/tree/master/hack/bench/storage),
+re-run with `./full05.sh 4`. Raw results are not in the repository.

--- a/docs/how-to/choose-a-storage-class.md
+++ b/docs/how-to/choose-a-storage-class.md
@@ -49,15 +49,12 @@ on `piraeus-r2` in step 6.
 **This is the default for ordinary application data**, and the most used class in
 the cluster. Two synchronous replicas, and the Pod is free to schedule anywhere.
 
-Performance is **the same as `piraeus-r2`** — same pool, same replicas, same DRBD
-tuning. The single difference: if a Pod lands on a node holding no replica, it
-reads and writes over the network until LINSTOR replicates the data there.
-`auto-diskful` starts that conversion after five minutes. Degraded while it runs,
-identical afterwards.
-
-That resync is also why PVCs here are **capped at 32 GiB** and denied above it: a
-full 32 GiB is roughly five more minutes over the node network at 1 Gb/s, and
-requested size is the only proxy admission has.
+Performance is **the same as `piraeus-r2`**. The single difference: a Pod that
+lands on a node holding no replica runs over the network until LINSTOR has
+replicated the data there — degraded for a few minutes, identical afterwards.
+That resync is also why PVCs here are **capped at 32 GiB** and denied above it.
+The mechanism and the numbers are in the
+[class comparison](../reference/storage-classes.md#piraeus-r2-and-piraeus-r2-roaming).
 
 ## 6. When to use `piraeus-r2` instead
 

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -28,17 +28,10 @@ section once migrated.
   belongs on, in the order the questions actually matter
 - [Roll a workload when its ConfigMap changes](reload-on-configmap-change.md)
 
-## Planned
+## Not written yet
 
-- Rotate a secret
-- Recover a Postgres cluster from backup
-- Drain and reboot a node outside the kured cycle
-- Debug a Flux reconcile that reports success but changes nothing
-
-## The existing runbooks
-
-[runbooks.thaum.xyz](https://runbooks.thaum.xyz/) serves from
-[thaum-xyz/runbooks](https://github.com/thaum-xyz/runbooks), whose last commit was
-2021-11-05. Its content predates most of this cluster. Two alerts in this repository
-still carry `runbook_url` annotations pointing at it; those runbooks migrate here
-first, and the old site retires when the last link is gone.
+Open documentation work is tracked as
+[issues labelled `documentation`](https://github.com/thaum-xyz/ankhmorpork/issues?q=is%3Aissue+is%3Aopen+label%3Adocumentation).
+Two runbooks are served from [runbooks.thaum.xyz](https://runbooks.thaum.xyz/), a
+site whose repository was last touched in 2021; bringing them here is
+[#1364](https://github.com/thaum-xyz/ankhmorpork/issues/1364).

--- a/docs/how-to/reload-on-configmap-change.md
+++ b/docs/how-to/reload-on-configmap-change.md
@@ -88,15 +88,9 @@ first reconcile stamps the version that is still current at that moment and
 nothing changes. The next one picks up the new value and rolls the Pods.
 
 With a 5m Kustomization interval that is **up to ten minutes** between merging a
-ConfigMap change and seeing new Pods. Measured on a real change:
-
-```
-configmap written by kustomize-controller   05:50:41
-deployment written by kustomize-controller  05:43:34   <- skipped this reconcile
-pod rolled                                  05:57
-```
-
-To skip the wait, reconcile explicitly:
+ConfigMap change and seeing new Pods —
+[measured](../explanation/configmap-autoreload.md#what-it-trades). To skip the
+wait, reconcile explicitly:
 
 ```bash
 flux reconcile source git ankhmorpork
@@ -108,7 +102,7 @@ flux -n flux-system reconcile kustomization <component>
 ## Limits
 
 - **ConfigMaps only.** Secrets would need the Kyverno admission controller to
-  hold read on every Secret in the cluster; it currently has none. See
+  hold read on every Secret in the cluster, which it does not. See
   [the explanation](../explanation/configmap-autoreload.md#why-not-secrets).
 - **One ConfigMap per workload.** The annotation takes a single name.
 - **Deployments and StatefulSets only.** DaemonSets are not matched.

--- a/docs/reference/annotations.md
+++ b/docs/reference/annotations.md
@@ -24,12 +24,6 @@ For a process that reads its configuration once at startup. See
 [the how-to](../how-to/reload-on-configmap-change.md) and
 [the reasoning](../explanation/configmap-autoreload.md).
 
-!!! danger "On the workload, not the Pod template"
-
-    The policy matches `object.metadata.annotations`. An opt-in placed in
-    `spec.template.metadata.annotations` never matches, and because the policy is
-    `failurePolicy: Ignore` it produces no stamp, no error and no rollout.
-
 ### `autoreloader.thaum.xyz/version`
 
 | | |

--- a/docs/reference/apps.md
+++ b/docs/reference/apps.md
@@ -8,29 +8,30 @@ keeps a README next to its manifests, the app name links to it.
 
 !!! note
 
-    Hostnames are read from Ingress **manifests**. An Ingress rendered by a
-    Helm chart from `values.yaml` does not appear here, so an app with no
-    hostname listed is not necessarily unreachable.
+    Hostnames come from Ingress manifests and from the `ingress` section of
+    chart values; the latter are marked *values*. A host whose class reads
+    *default class* is rendered by a chart that sets no class and lands on
+    the cluster default — see [ingress classes](ingress.md).
 
 | App | Namespace | Flux Kustomization | Hostnames |
 | --- | --- | --- | --- |
-| `ai-gateway` | `ai-gateway` | `ai-gateway` | `ai-gateway.krupa.net.pl` (cloudflare) |
+| `ai-gateway` | `ai-gateway` | `ai-gateway` | `ai-gateway.krupa.net.pl` (cloudflare)<br>`ai-gateway.krupa.net.pl` (public, *values*) |
 | `atuin` | `atuin` | `atuin` | `atuin.thaum.xyz` (cloudflare)<br>`atuin.thaum.xyz` (public) |
 | `changedetection` | `changedetection` | `changedetection` | `change.krupa.net.pl` (cloudflare)<br>`change.krupa.net.pl` (public) |
 | `datalake-alerts` | `datalake-alerts` | `datalake-alerts` | `alertmanager.ankhmorpork.thaum.xyz` (private) |
 | `datalake-logs` | `datalake-logs` | `datalake-logs` | — |
-| `datalake-metrics` | `datalake-metrics` | `datalake-metrics` | `prometheus.ankhmorpork.thaum.xyz` (private) |
+| `datalake-metrics` | `datalake-metrics` | `datalake-metrics` | `prometheus.ankhmorpork.thaum.xyz` (private)<br>`pyrra.ankhmorpork.thaum.xyz` (public, *values*) |
 | `dlna-local` | `dlna-local` | `dlna-local` | — |
-| `grafana` | `grafana` | `grafana` | `grafana.krupa.net.pl` (cloudflare) |
+| `grafana` | `grafana` | `grafana` | `grafana.krupa.net.pl` (cloudflare)<br>`grafana.krupa.net.pl` (public, *values*) |
 | `homer` | `homer` | `homer`, `homer-services` | `ankhmorpork.thaum.xyz` (cloudflare)<br>`ankhmorpork.thaum.xyz` (public) |
 | `karakeep` | `karakeep` | `karakeep` | `keep.krupa.net.pl` (cloudflare)<br>`keep.krupa.net.pl` (public) |
 | `mealie` | `mealie` | `mealie` | `recipes.krupa.net.pl` (cloudflare)<br>`recipes.krupa.net.pl` (public) |
 | `mended-drum` | `mended-drum` | `mended-drum` | `drum-tools.krupa.net.pl` (cloudflare)<br>`drum-tools.krupa.net.pl` (public)<br>`drum.krupa.net.pl` (cloudflare)<br>`drum.krupa.net.pl` (public) |
 | [`paperless`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/apps/paperless/README.md) | `paperless` | `paperless` | `papers.krupa.net.pl` (cloudflare)<br>`papers.krupa.net.pl` (public) |
-| `photos` | `photos` | `photos` | `photos.krupa.net.pl` (cloudflare) |
+| `photos` | `photos` | `photos` | `photos.krupa.net.pl` (cloudflare)<br>`photos.krupa.net.pl` (default class, *values*) |
 | [`plex`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/apps/plex/README.md) | `plex` | `plex` | `vod.krupa.net.pl` (private) |
-| `pocket-id` | `pocket-id` | `pocket-id` | `login.krupa.net.pl` (cloudflare) |
-| `stirling-pdf` | `stirling-pdf` | `stirling-pdf` | `pdf.krupa.net.pl` (cloudflare) |
+| `pocket-id` | `pocket-id` | `pocket-id` | `login.krupa.net.pl` (cloudflare)<br>`login.krupa.net.pl` (private, *values*) |
+| `stirling-pdf` | `stirling-pdf` | `stirling-pdf` | `pdf.krupa.net.pl` (cloudflare)<br>`pdf.krupa.net.pl` (public, *values*) |
 | `unifi` | `unifi` | `unifi` | — |
 | `ups` | `ups` | `ups` | — |
 | `valheim` | `valheim` | `valheim` | — |

--- a/docs/reference/charts.md
+++ b/docs/reference/charts.md
@@ -72,6 +72,6 @@ for a gateway chart should use upstream's.
 `cnpg-database` writes backups to the versitygw gateway in `cnpg-system` —
 `http://versitygw.cnpg-system.svc.cluster.local:7070`, from the upstream chart —
 which stores objects on a `unifi-nas` volume. Restoring any database depends on
-that gateway and that volume as well as on CloudNativePG. See
-[Postgres fleet upgrade plan](../postgres/fleet-upgrade-plan.md) for the state
-of the fleet itself.
+that gateway and that volume as well as on CloudNativePG. Every database and
+its chart is in [Helm releases](helm-releases.md); how the fleet was brought to
+one version is in [the Postgres fleet upgrade](../explanation/postgres-fleet-upgrade.md).

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -38,4 +38,5 @@ Admission test:
   and two that look load-bearing but are not
 - [Charts and images](charts.md) — the two sibling repositories, what they hold,
   and where their generated reference lives
-- [UPS Modbus register map](../ups/modbus-register-map.md)
+- [UPS Modbus register map](ups-modbus-register-map.md) — every register confirmed
+  against the front panel, and how to switch Modbus on

--- a/docs/reference/ingress.md
+++ b/docs/reference/ingress.md
@@ -1,32 +1,46 @@
 # Ingress classes and certificates { .quad-reference }
 
-Three ingress classes, two certificate issuers. To put an app on one, use
-[expose an app](../how-to/expose-an-app.md).
+To put an app on an ingress, use [expose an app](../how-to/expose-an-app.md).
+The tables below are generated from the Traefik, cloudflared, cert-manager and
+external-dns manifests; the prose between them is not.
 
 ## Classes
 
-| Class | Controller | Reaches | Address |
-| --- | --- | --- | --- |
-| `public` | Traefik | LAN, and off-LAN only via a paired `cloudflare` Ingress | `192.168.50.129` |
-| `private` | Traefik | LAN only | `192.168.50.130` |
-| `cloudflare` | `strrl.dev/cloudflare-tunnel-ingress-controller` | the internet, through the `ankhmorpork-tunnel` | tunnel CNAME |
+<!-- generated:ingress-classes -->
+<!-- This block is written by hack/generate-docs-reference.py; edit the
+     manifests it reads, not the table. -->
+| Class | Controller chart | Address | Default class | Source |
+| --- | --- | --- | --- | --- |
+| `cloudflare` | `cloudflare-tunnel-ingress-controller` | Cloudflare tunnel `ankhmorpork-tunnel` | no | [`k8s/platform/network/cloudflared/values.yaml`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/platform/network/cloudflared/values.yaml) |
+| `private` | `traefik` | `192.168.50.130` | no | [`k8s/platform/network/traefik/private/values.yaml`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/platform/network/traefik/private/values.yaml) |
+| `public` | `traefik` | `192.168.50.129` | **yes** | [`k8s/platform/network/traefik/public/values.yaml`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/platform/network/traefik/public/values.yaml) |
+<!-- /generated:ingress-classes -->
 
-`public` is the cluster's **default** IngressClass (`isDefaultClass: true`), so an
-Ingress that omits `ingressClassName` gets it. Do not rely on that — the admission
-policy requires the field to be set explicitly.
+`private` is reachable from the LAN only. `public` is reachable from the LAN and,
+paired with a `cloudflare` Ingress for the same host, from outside — the how-to
+has the pairing and the reason. The two Traefik instances are separate
+HelmReleases with their own LoadBalancer IP, not one controller with two
+entrypoints.
 
-Both Traefik instances are separate HelmReleases with their own LoadBalancer IP,
-not one controller with two entrypoints.
+An Ingress that omits `ingressClassName` lands on the default class. Do not rely
+on that — the admission policy requires the field to be set explicitly.
 
 ## Certificate issuers
 
-| Issuer | Use |
-| --- | --- |
-| `letsencrypt-prod` | the default; HTTP-01 |
-| `letsencrypt-dns01` | when HTTP-01 cannot work — wildcards, or a name not yet reachable |
+<!-- generated:cluster-issuers -->
+<!-- This block is written by hack/generate-docs-reference.py; edit the
+     manifests it reads, not the table. -->
+| Issuer | Challenge | ACME server | Source |
+| --- | --- | --- | --- |
+| `letsencrypt-dns01` | DNS-01 (cloudflare) | Let's Encrypt, production | [`k8s/platform/security/cert-manager/additional/issuer-acme-dns01-cloudflare.yaml`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/platform/security/cert-manager/additional/issuer-acme-dns01-cloudflare.yaml) |
+| `letsencrypt-prod` | DNS-01 (cloudflare) | Let's Encrypt, production | [`k8s/platform/security/cert-manager/additional/issuer-acme-http.yaml`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/platform/security/cert-manager/additional/issuer-acme-http.yaml) |
+<!-- /generated:cluster-issuers -->
 
-Both are accepted by the admission policy; anything else is rejected. Set one with
-the `cert-manager.io/cluster-issuer` annotation.
+Both issuers solve the same challenge through Cloudflare, so a hostname does not
+have to be reachable before its certificate is issued and wildcards work on
+either. They differ only in the ACME account key behind them; `letsencrypt-prod`
+is the convention. Both are accepted by the admission policy; anything else is
+rejected. Set one with the `cert-manager.io/cluster-issuer` annotation.
 
 `cloudflare` Ingresses need no issuer and no TLS block: the tunnel terminates TLS
 at Cloudflare's edge.
@@ -47,12 +61,18 @@ rule text in [admission policies](admission-policies.md).
 `external-dns` writes records into **UniFi's resolver** — the house's internal
 DNS, not a public zone.
 
+<!-- generated:external-dns -->
+<!-- This block is written by hack/generate-docs-reference.py; edit the
+     manifests it reads, not the table. -->
 | Setting | Value |
 | --- | --- |
+| Provider | `webhook` |
 | Domains it will touch | `thaum.xyz`, `krupa.net.pl` |
-| Policy | `sync` — it deletes records it owns when the Ingress goes |
-| Ownership | TXT registry, `txtOwnerId: thaum.xyz`, `txtPrefix: k8s.` |
-| Fallback name | `{{.Name}}.{{.Namespace}}.ankhmorpork.thaum.xyz` |
+| Policy | `sync` |
+| Ownership | `txt` registry, `txtOwnerId: thaum.xyz`, `txtPrefix: k8s.` |
+| Fallback name for a Service with no host | `{{.Name}}.{{.Namespace}}.ankhmorpork.thaum.xyz` |
+| Source | [`k8s/platform/network/external-dns/values.yaml`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/platform/network/external-dns/values.yaml) |
+<!-- /generated:external-dns -->
 
 From a `cloudflare` Ingress, external-dns publishes the **tunnel CNAME**
 (`*.cfargotunnel.com`), which resolves nowhere on the LAN. This is why a
@@ -71,5 +91,5 @@ it.
 | `<name>.ankhmorpork.thaum.xyz` | internal, `private` class |
 | `<name>.krupa.net.pl` | external, `public` + `cloudflare` pair |
 
-Every hostname currently served is listed in [applications](apps.md), generated
-from the manifests.
+Every hostname served is listed in [applications](apps.md), generated from the
+Ingress manifests and the chart values.

--- a/docs/reference/storage-classes.md
+++ b/docs/reference/storage-classes.md
@@ -114,5 +114,6 @@ option trades away durability.
 - `unifi-nas` was measured on one node, buffered only.
 - fsync on the bare-device baselines is the noisiest measurement, CV 24–61%.
 
-Method and raw results are not in the repository; they live in the operator's
-local `bench/storage-2026-09/`.
+Method: [`hack/bench/storage/`](https://github.com/thaum-xyz/ankhmorpork/tree/master/hack/bench/storage).
+Raw results are not in the repository. The numbers describe the nodes named above
+on the date given — re-measure after a node, disk, network or DRBD option change.

--- a/docs/reference/ups-modbus-register-map.md
+++ b/docs/reference/ups-modbus-register-map.md
@@ -15,9 +15,9 @@ displayed value rather than inferred.
 | 0–4   | `PHOENIXTEC` (Eaton subsidiary; OEM behind PowerWalker) |
 | 16–24 | `VFI 1500 LICR IoT` |
 | 48–53 | `00.03.1760` — UPS firmware |
-| 56–63 | `CPANR1398610001` — serial |
+| 56–63 | serial number — not reproduced here; read it from the unit |
 | 286–290 | `01.08.000` — network stack version |
-| 296–299 | `4aebc90e` — device id |
+| 296–299 | device id — not reproduced here |
 
 ## Telemetry
 

--- a/hack/bench/storage/README.md
+++ b/hack/bench/storage/README.md
@@ -1,0 +1,155 @@
+# StorageClass benchmark — ankhmorpork
+
+Compares `longhorn`, `lvm-thin`, `piraeus-r2` and `unifi-nas`, one target at a
+time, across `beelink01`, `beelink02` and `master02`.
+
+**Looking for which class to use?** Read
+[choose a storage class](https://docs.thaum.xyz/how-to/choose-a-storage-class/);
+the measured ceilings are in [storage classes](https://docs.thaum.xyz/reference/storage-classes/)
+and the reasoning in [why storage is split the way it is](https://docs.thaum.xyz/explanation/storage-durability/).
+This README covers how the suite works.
+
+Longhorn was retired on the strength of the 2026-09 run. Its targets stay in
+`targets.env` commented out, so the comparison can be reproduced but a default
+run does not try to provision a class that no longer exists. Raw results are
+not committed; a run writes them to `results/`, which is ignored.
+
+```bash
+./full05.sh 4                              # both passes, 4 cycles each (~10h)
+
+./run.sh --dry-run                         # see the plan, touch nothing
+./run.sh --cycles 4 --buffered             # buffered pass, includes unifi-nas
+./run.sh --cycles 4 --skip unifi-nas       # O_DIRECT pass, local classes only
+./run.sh --resume dir05 --skip unifi-nas   # continue an interrupted run
+./run.sh --only lvm-thin                   # filter by class or node substring
+```
+
+Two passes because the modes answer different questions. **Buffered** is how
+applications actually behave and the only fair mode for `unifi-nas`; **O_DIRECT**
+puts the page cache out of the way so the local classes are strictly comparable.
+`unifi-nas` is skipped under O_DIRECT, where every write becomes its own
+synchronous round trip that no application performs.
+
+Cycles interleave across the whole matrix rather than running back to back, so
+load on this live cluster spreads over every target instead of poisoning one.
+Volumes are preconditioned once and reused across cycles — `--resume` keeps
+completed cycles and reuses any volume whose layout actually finished, so an
+interruption costs nothing already measured.
+
+Results land in `results/<run-id>-<profile>/` with a `summary.md`, a
+`results.csv`, the raw fio JSON per target, and the cluster state at run time.
+
+## Why this shape
+
+Every class is measured on **both** nodes, not just the one it is interesting
+on. Measuring `lvm-thin` on two nodes but `piraeus-r2` on one makes "piraeus is
+slower" unfalsifiable — it could just be a slower disk.
+
+That matters because the two nodes are not alike:
+
+| node | volume group | lvm-thin + piraeus pool | longhorn disk |
+| --- | --- | --- | --- |
+| `beelink01` | `ubuntu-vg` | `ubuntu-vg/thin-pool0` | `/dev/ubuntu-vg/longhorn` |
+| `master02` | `secondary-vg` | `secondary-vg/thin-pool0` | `/dev/secondary-vg/longhorn` |
+
+On each node all three local classes sit on the **same volume group**, so the
+same physical device. A class-to-class difference *within* one node is therefore
+stack overhead, not hardware. `piraeus-r2` is the sharpest case: its
+`temporary-topolvm` storage pool *is* `thin-pool0`, the pool `lvm-thin` uses, so
+`piraeus-r2` vs `lvm-thin` on one node isolates the cost of DRBD replication and
+nothing else.
+
+Runs are strictly serial for the same reason: two concurrent targets on a node
+would be measuring each other.
+
+## What it measures
+
+Nine fio jobs per target: a layout pass that fully allocates the file first, QD1
+latency with p99/p99.9, a `fsync=1` durable-commit test, QD64 IOPS ceilings, a
+70/30 mix, and sequential throughput.
+
+The `commit_fsync_4k_qd1` job is the one that decides whether a database can
+live on a class at all — it is what all eleven CNPG clusters pay per commit.
+
+Defaults: 8 GiB file in a 16 GiB volume, 45 s per job. The layout pass matters
+more than it looks — on a thin pool, reads of unallocated blocks are served from
+nowhere at fake speed, so nothing is measured until the file is fully written.
+
+## O_DIRECT, and why NFS needs a second run
+
+`direct=1` is the default: it is the only way to compare classes without the page
+cache answering on their behalf.
+
+It is also unrepresentative for `unifi-nas`. O_DIRECT on NFS turns every write
+into its own synchronous round trip with no client-side coalescing, which no real
+application does. A smoke run measured **26 write IOPS** at QD64 that way. Treat
+that as a property of the test, not a verdict on the NAS, and pair it with:
+
+```bash
+./run.sh --only unifi-nas --buffered
+```
+
+Buffered runs go to a separate `-buffered` results directory so they can never be
+accidentally compared against O_DIRECT ones.
+
+Note also that `unifi-nas` mounts `nfsvers=3` with `nolock`, so there is no NFS
+byte-range locking on that share regardless of performance.
+
+## Not equivalent durability
+
+The fast classes are partly fast because they promise less:
+
+| class | replicas | failure domain |
+| --- | --- | --- |
+| `lvm-thin` | 1 | node loss = data loss |
+| `piraeus-r2` | 2, DRBD sync | survives one node |
+| `longhorn` | 3 | survives two nodes |
+| `unifi-nas` | 1 share | survives any node, depends on the NAS |
+
+Ranking them on IOPS alone compares different products.
+
+## Operational notes
+
+- Not Flux-managed, on purpose. The `bench` namespace exists only while a run is
+  in flight and nothing here belongs in `k8s/apps` or `k8s/platform`.
+- Pods pin with `nodeAffinity`, never `nodeName`. `nodeName` bypasses the
+  scheduler, and `WaitForFirstConsumer` binding needs the scheduler to annotate
+  the PVC with `volume.kubernetes.io/selected-node` — with `nodeName` the
+  provisioner never fires and the PVC sits `Pending` forever. Both `lvm-thin` and
+  `piraeus-r2` use delayed binding.
+- Tolerations cover control-plane taints only, deliberately not
+  `node.kubernetes.io/unschedulable`, so a heavy IO job cannot land on a node
+  someone cordoned on purpose.
+- Resource requests are set because the `require-resource-requests`
+  ValidatingPolicy asks for them. The CPU limit is uniform and sized for
+  `master02` (3700m allocatable), so fio is never the bottleneck on one node and
+  throttled on another.
+- Longhorn targets wait for `robustness: healthy` before fio starts; a rebuilding
+  replica set would make the measurement worthless.
+- Each target's PVC is deleted and its PV confirmed gone before the next starts,
+  then a settle window passes, so no target competes with another's background
+  delete.
+- Thin pools do not return space to the VG until blocks are discarded. If `vgs`
+  looks fuller than expected after a run, use `hack/lvm-trim.sh` from the
+  ankhmorpork repo on the tested nodes.
+- This will move disk latency and Longhorn metrics enough to trip alerts. Silence
+  them first if you would rather not page yourself:
+  ```bash
+  amtool --alertmanager.url=<url> silence add \
+    --duration=2h --comment="storage benchmark" 'node=~"beelink01|master02"'
+  ```
+
+## Layout
+
+```
+run.sh                  orchestrator, serial, one target at a time
+report.py               fio JSON -> summary.md + results.csv
+targets.env             the matrix; beelink02 and master01 commented out
+                        (master01 is cordoned)
+fio/modern.fio          the job definitions
+manifests/              namespace, PVC/Job templates, pod entrypoint
+results/                run output
+```
+
+`fio` is installed at pod start from Alpine `3.24.1`, so the pods need egress.
+The entrypoint fails loudly if that install does not work.

--- a/hack/bench/storage/fio/modern.fio
+++ b/hack/bench/storage/fio/modern.fio
@@ -1,0 +1,109 @@
+# Primary profile. Answers "which class do I put this workload on".
+#
+# Differences from legacy.fio that matter:
+#   * layout job fully writes the file first, so no job measures thin-pool
+#     allocation or reads unallocated blocks (which a thin pool serves from
+#     nowhere, at fake speed)
+#   * qd1 jobs give real single-request latency, including p99/p99.9, which is
+#     where replication (DRBD, Longhorn) and network (NFS) actually show up
+#   * commit_fsync is the Postgres/etcd question: durable 4k commits. This is the
+#     number that decides whether a database can live on a class at all.
+
+[global]
+randrepeat=0
+verify=0
+ioengine=libaio
+direct=${FIO_DIRECT}
+filename=${MOUNT}/fiotest
+size=${FIO_SIZE}
+group_reporting=1
+percentile_list=50:95:99:99.9:99.99
+time_based=1
+runtime=${RUNTIME}
+ramp_time=5s
+
+[randread_4k_qd1]
+rw=randread
+bs=4k
+iodepth=1
+numjobs=1
+stonewall
+
+[randwrite_4k_qd1]
+rw=randwrite
+bs=4k
+iodepth=1
+numjobs=1
+stonewall
+
+# --- durability probes -------------------------------------------------------
+# Three different ways to demand durability. On a stack that genuinely pushes to
+# stable media, all three cost roughly one device flush, and none can be FASTER
+# than the bare device's flush. Comparing them across classes is what exposes a
+# stack that acknowledges a sync it has not actually performed:
+#   fsync     - flush data + metadata after each write
+#   fdatasync - flush data only, skipping the metadata update
+#   O_SYNC    - every write is itself synchronous, no separate flush call
+# fio reports sync-call latency separately from write latency; report.py surfaces
+# it as `sync p50/p99`, which is the number that matters here.
+[commit_fsync_4k_qd1]
+rw=randwrite
+bs=4k
+iodepth=1
+numjobs=1
+fsync=1
+stonewall
+
+[commit_fdatasync_4k_qd1]
+rw=randwrite
+bs=4k
+iodepth=1
+numjobs=1
+fdatasync=1
+stonewall
+
+[commit_osync_4k_qd1]
+rw=randwrite
+bs=4k
+iodepth=1
+numjobs=1
+sync=1
+stonewall
+
+[randread_4k_qd64]
+rw=randread
+bs=4k
+iodepth=16
+numjobs=4
+thread=1
+stonewall
+
+[randwrite_4k_qd64]
+rw=randwrite
+bs=4k
+iodepth=16
+numjobs=4
+thread=1
+stonewall
+
+[randrw_4k_qd16_70r]
+rw=randrw
+rwmixread=70
+bs=4k
+iodepth=16
+numjobs=1
+stonewall
+
+[seqread_1m_qd8]
+rw=read
+bs=1M
+iodepth=8
+numjobs=1
+stonewall
+
+[seqwrite_1m_qd8]
+rw=write
+bs=1M
+iodepth=8
+numjobs=1
+stonewall

--- a/hack/bench/storage/fio/precondition.fio
+++ b/hack/bench/storage/fio/precondition.fio
@@ -1,0 +1,24 @@
+# Preconditioning only, run once per volume before any measurement.
+#
+# Split out of modern.fio so a volume can be laid out once and then measured
+# many times. Without this every repeat would pay the 8GiB allocation again --
+# 150s on longhorn -- which is what made repeated sampling unaffordable.
+
+[global]
+ioengine=libaio
+direct=${FIO_DIRECT}
+filename=${MOUNT}/fiotest
+size=${FIO_SIZE}
+
+# Not a measurement. Allocates every block of the test file so the jobs below
+# hit real storage. Runs to completion rather than on a timer.
+[layout]
+rw=write
+bs=1M
+iodepth=8
+numjobs=1
+time_based=0
+ramp_time=0
+runtime=0
+stonewall
+

--- a/hack/bench/storage/full05.sh
+++ b/hack/bench/storage/full05.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Two passes, strictly sequential -- they must never overlap, because all three
+# local classes share a volume group per node and concurrent runs would measure
+# each other.
+#
+#   buffered : 15 targets incl. unifi-nas. The honest mode for NFS, and how
+#              applications actually use every one of these classes.
+#   O_DIRECT : 12 targets, unifi-nas skipped. Page cache out of the way, so the
+#              local classes are strictly comparable. NFS is excluded because
+#              O_DIRECT turns each write into its own synchronous round trip,
+#              which no application does and which measures the test, not the NAS.
+#
+# Each pass retries with --resume on an outright failure; --resume keeps
+# completed cycles and reuses volumes whose layout finished.
+cd "$(dirname "$0")"
+CYCLES="${1:-6}"
+
+run_pass() {
+  local id="$1"; shift
+  for attempt in 1 2 3 4 5 6; do
+    echo "=== $id attempt $attempt at $(date -u +%H:%M:%SZ) ==="
+    if [[ $attempt -eq 1 ]] && ! ls -d results/${id}-* >/dev/null 2>&1; then
+      ./run.sh --cycles "$CYCLES" --runtime 20 --settle 15 --run-id "$id" "$@" && return 0
+    else
+      ./run.sh --cycles "$CYCLES" --runtime 20 --settle 15 --resume "$id" "$@" && return 0
+    fi
+    echo "=== $id exited $?, retrying in 120s ==="
+    sleep 120
+  done
+  echo "=== $id gave up after 6 attempts ==="
+  return 1
+}
+
+echo "########## PASS 1/2: buffered, 15 targets ##########"
+run_pass buf05 --buffered
+echo "########## PASS 2/2: O_DIRECT, 12 targets ##########"
+run_pass dir05 --skip unifi-nas
+echo "########## both passes finished at $(date -u +%H:%M:%SZ) ##########"

--- a/hack/bench/storage/manifests/entrypoint.sh
+++ b/hack/bench/storage/manifests/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Runs inside the fio pod. Installs fio, renders the profile, emits JSON between
+# markers so run.sh can lift it straight out of `kubectl logs`.
+set -eu
+
+if ! command -v fio >/dev/null 2>&1; then
+  echo ">> installing fio"
+  apk add --no-cache fio >/dev/null 2>&1 || {
+    echo "FATAL: could not install fio (no egress from this pod?)" >&2
+    exit 1
+  }
+fi
+
+fio --version
+echo ">> mount: $(df -hT "$MOUNT" | tail -1)"
+echo ">> profile: $PROFILE  size=$FIO_SIZE direct=$FIO_DIRECT runtime=${RUNTIME}s"
+
+# fio expands ${VAR} in a job file from the environment.
+fio --output-format=json+ \
+    --output=/tmp/result.json \
+    --eta=never \
+    "/scripts/${PROFILE}.fio"
+
+echo "-----BEGIN FIO JSON-----"
+cat /tmp/result.json
+echo "-----END FIO JSON-----"
+
+rm -f "$MOUNT/fiotest"
+echo ">> done"

--- a/hack/bench/storage/manifests/job-hostpath.yaml.tpl
+++ b/hack/bench/storage/manifests/job-hostpath.yaml.tpl
@@ -1,0 +1,75 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  namespace: bench
+  labels:
+    storage-bench/target: ${TARGET_ID}
+    storage-bench/class: ${SC}
+    storage-bench/node: ${NODE}
+spec:
+  backoffLimit: 0
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        storage-bench/target: ${TARGET_ID}
+    spec:
+      restartPolicy: Never
+      # No PVC and no CSI driver: this target writes straight onto the
+      # filesystem Longhorn keeps its sparse replica files on, to establish what
+      # that device costs before any Longhorn code touches it.
+      #
+      # The scratch directory sits beside `replicas/`, not inside it, so nothing
+      # here looks like a replica to Longhorn. The file is removed by the
+      # entrypoint when fio finishes.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values: ["${NODE}"]
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: fio
+          image: ${FIO_IMAGE}
+          command: ["/bin/sh", "/scripts/entrypoint.sh"]
+          env:
+            - name: MOUNT
+              value: /data
+            - name: FIO_SIZE
+              value: "${FIO_SIZE}"
+            - name: FIO_DIRECT
+              value: "${FIO_DIRECT}"
+            - name: FIO_OFFSET_INCREMENT
+              value: "${FIO_OFFSET_INCREMENT}"
+            - name: RUNTIME
+              value: "${RUNTIME}"
+            - name: PROFILE
+              value: "${PROFILE}"
+          resources:
+            requests:
+              cpu: 500m
+              memory: 256Mi
+            limits:
+              cpu: "3"
+              memory: 1Gi
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: scripts
+              mountPath: /scripts
+      volumes:
+        - name: data
+          hostPath:
+            path: ${HOSTPATH}
+            type: DirectoryOrCreate
+        - name: scripts
+          configMap:
+            name: storage-bench-scripts

--- a/hack/bench/storage/manifests/job.yaml.tpl
+++ b/hack/bench/storage/manifests/job.yaml.tpl
@@ -1,0 +1,87 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  namespace: bench
+  labels:
+    storage-bench/target: ${TARGET_ID}
+    storage-bench/class: ${SC}
+    storage-bench/node: ${NODE}
+spec:
+  backoffLimit: 0
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        storage-bench/target: ${TARGET_ID}
+    spec:
+      restartPolicy: Never
+      # Pinning MUST be nodeAffinity, never nodeName. nodeName bypasses the
+      # scheduler, and WaitForFirstConsumer binding depends on the scheduler
+      # annotating the PVC with volume.kubernetes.io/selected-node -- with
+      # nodeName the annotation is never written, the provisioner never fires,
+      # and the PVC sits Pending while the pod sits ContainerCreating forever.
+      # Both delayed-binding classes here (lvm-thin, piraeus-r2) hit that.
+      #
+      # The pin is also what makes per-node numbers comparable: beelink01 runs
+      # ubuntu-vg, master02 runs secondary-vg, different physical devices.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values: ["${NODE}"]
+      # Control-plane taints only. Deliberately NOT `operator: Exists`, which
+      # would also tolerate node.kubernetes.io/unschedulable and let a heavy IO
+      # job land on a node someone cordoned on purpose. Benching master01 means
+      # uncordoning it first, as a visible decision.
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: fio
+          image: ${FIO_IMAGE}
+          command: ["/bin/sh", "/scripts/entrypoint.sh"]
+          env:
+            - name: MOUNT
+              value: /data
+            - name: FIO_SIZE
+              value: "${FIO_SIZE}"
+            - name: FIO_DIRECT
+              value: "${FIO_DIRECT}"
+            - name: FIO_OFFSET_INCREMENT
+              value: "${FIO_OFFSET_INCREMENT}"
+            - name: RUNTIME
+              value: "${RUNTIME}"
+            - name: PROFILE
+              value: "${PROFILE}"
+          resources:
+            # require-resource-requests ValidatingPolicy wants these set.
+            # The CPU limit is sized for master02, which only has 3700m
+            # allocatable -- fio must never be the bottleneck, but it also must
+            # not get throttled differently per node, so the limit is uniform.
+            requests:
+              cpu: 500m
+              memory: 256Mi
+            limits:
+              cpu: "3"
+              memory: 1Gi
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: scripts
+              mountPath: /scripts
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: ${PVC_NAME}
+        - name: scripts
+          configMap:
+            name: storage-bench-scripts

--- a/hack/bench/storage/manifests/namespace.yaml
+++ b/hack/bench/storage/manifests/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bench
+  labels:
+    # Not Flux-managed on purpose: this namespace exists only while a benchmark
+    # run is in flight. Nothing here belongs in k8s/apps or k8s/platform.
+    app.kubernetes.io/name: storage-bench

--- a/hack/bench/storage/manifests/pvc.yaml.tpl
+++ b/hack/bench/storage/manifests/pvc.yaml.tpl
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${PVC_NAME}
+  namespace: bench
+  labels:
+    storage-bench/target: ${TARGET_ID}
+    storage-bench/class: ${SC}
+    storage-bench/node: ${NODE}
+spec:
+  storageClassName: ${SC}
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: ${VOLUME_SIZE}

--- a/hack/bench/storage/report.py
+++ b/hack/bench/storage/report.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Turn a run directory of fio JSON into a readable comparison.
+
+Emits, into the run directory:
+  summary.md   -- comparison tables across every measured target
+  results.csv  -- every metric, one row per target/job
+
+Usage: report.py results/<run-id>
+"""
+import csv
+import glob
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def pct(io, key):
+    """Percentile in microseconds. Absent when the job ran with gtod_reduce.
+
+    Read/write stats carry percentiles under clat_ns; the sync block reports its
+    own under lat_ns instead, so fall through rather than returning nothing.
+    """
+    for block in ("clat_ns", "lat_ns"):
+        p = (io.get(block) or {}).get("percentile") or {}
+        v = p.get(key)
+        if v:
+            return v / 1000.0
+    return None
+
+
+def mean_us(io):
+    v = (io.get("clat_ns") or {}).get("mean") or (io.get("lat_ns") or {}).get("mean")
+    return v / 1000.0 if v else None
+
+
+def mibs(io):
+    # fio reports bw in KiB/s
+    return (io.get("bw") or 0) / 1024.0
+
+
+def _one(doc):
+    """Per-job metrics from a single fio run."""
+    jobs = {}
+    for job in doc.get("jobs", []):
+        r, w, sy = job.get("read", {}), job.get("write", {}), job.get("sync", {})
+        jobs[job.get("jobname", "?")] = {
+            "read_iops": r.get("iops", 0.0), "write_iops": w.get("iops", 0.0),
+            "read_mibs": mibs(r), "write_mibs": mibs(w),
+            "read_lat_us": mean_us(r), "write_lat_us": mean_us(w),
+            "read_p99_us": pct(r, "99.000000"), "write_p99_us": pct(w, "99.000000"),
+            "read_p999_us": pct(r, "99.900000"), "write_p999_us": pct(w, "99.900000"),
+            "sync_lat_us": mean_us(sy), "sync_p99_us": pct(sy, "99.000000"),
+            "sync_p999_us": pct(sy, "99.900000"),
+        }
+    return jobs
+
+
+def _agg(samples):
+    """Median plus spread across cycles.
+
+    Median rather than mean because a single cycle caught by a load spike on a
+    live cluster should not drag the number. `spread` is (max-min)/median, and
+    report it: a metric that swings 50%+ between identical cycles has not been
+    measured, it has been sampled once with extra steps.
+    """
+    out = {}
+    keys = set()
+    for s_ in samples:
+        keys |= set(s_.keys())
+    for k in keys:
+        vals = [s_[k] for s_ in samples if s_.get(k) is not None]
+        if not vals:
+            out[k] = None; out[k + "_spread"] = None; out[k + "_range"] = None; continue
+        vals.sort()
+        n = len(vals)
+        med = vals[n // 2] if n % 2 else (vals[n // 2 - 1] + vals[n // 2]) / 2
+        out[k] = med
+        # Coefficient of variation, not (max-min)/median. The range grows with
+        # sample count by construction -- more cycles catch more outliers -- so a
+        # range-based figure says variance got worse as evidence improved, which
+        # is backwards. CV is stable in n and comparable between runs.
+        if med and n > 1:
+            mean = sum(vals) / n
+            var = sum((v - mean) ** 2 for v in vals) / (n - 1)
+            out[k + "_spread"] = (var ** 0.5) / abs(med)
+        else:
+            out[k + "_spread"] = None
+        out[k + "_range"] = ((vals[-1] - vals[0]) / med) if med else None
+    out["_n"] = len(samples)
+    return out
+
+
+def load(run_dir):
+    """{target_id: {jobs, notes, n_cycles}} aggregated over measurement cycles."""
+    targets = {}
+    for name in sorted(os.listdir(run_dir)):
+        tdir = os.path.join(run_dir, name)
+        if not os.path.isdir(tdir):
+            continue
+        # cycle-N/fio.json is the current layout; a bare fio.json is a run from
+        # before interleaving existed and is treated as a single cycle.
+        paths = sorted(glob.glob(os.path.join(tdir, "cycle-*", "fio.json")))
+        if not paths and os.path.isfile(os.path.join(tdir, "fio.json")):
+            paths = [os.path.join(tdir, "fio.json")]
+        runs = []
+        for fp in paths:
+            try:
+                with open(fp) as fh:
+                    runs.append(_one(json.load(fh)))
+            except (json.JSONDecodeError, OSError) as exc:
+                print(f"  skipping {fp}: {exc}", file=sys.stderr)
+        if not runs:
+            continue
+        jobnames = set()
+        for r in runs:
+            jobnames |= set(r.keys())
+        targets[name] = {
+            "jobs": {jn: _agg([r[jn] for r in runs if jn in r]) for jn in jobnames},
+            "cycles": len(runs),
+            "notes": target_notes(tdir),
+        }
+    return targets
+
+
+def target_notes(tdir):
+    """Placement facts worth carrying into the report."""
+    notes = []
+    lh = os.path.join(tdir, "longhorn-volume.yaml")
+    if os.path.isfile(lh):
+        with open(lh) as fh:
+            for line in fh:
+                s = line.strip()
+                if s.startswith("robustness:"):
+                    notes.append(f"longhorn {s}")
+                elif s.startswith("numberOfReplicas:"):
+                    notes.append(f"longhorn {s}")
+    return notes
+
+
+def f(v, dp=1):
+    return "-" if v is None else f"{v:,.{dp}f}"
+
+
+def k(v):
+    if v is None:
+        return "-"
+    return f"{v/1000:.1f}k" if v >= 10000 else f"{v:,.0f}"
+
+
+def table(rows, headers):
+    out = ["| " + " | ".join(headers) + " |",
+           "| " + " | ".join("---" for _ in headers) + " |"]
+    out += ["| " + " | ".join(r) + " |" for r in rows]
+    return "\n".join(out)
+
+
+def confidence(targets):
+    """Flag metrics that did not reproduce across cycles.
+
+    Exists because read IOPS once measured 157.9k and 363.6k on two identical
+    nodes, and a single-sample harness reports that as a finding rather than as
+    noise. A metric whose cycles disagree by more than 25% has not been measured.
+    """
+    ncyc = max((d["cycles"] for d in targets.values()), default=1)
+    if ncyc < 2:
+        return ("\n### Measurement confidence\n\nSingle cycle, so nothing here has "
+                "been reproduced. Re-run with `--cycles 3` before trusting any "
+                "difference smaller than the gaps between classes.\n")
+    watch = [("randread_4k_qd64", "read_iops"), ("randwrite_4k_qd64", "write_iops"),
+             ("commit_fsync_4k_qd1", "sync_lat_us"), ("randread_4k_qd1", "read_lat_us"),
+             ("seqwrite_1m_qd8", "write_mibs")]
+    rows = []
+    for t in sorted(targets):
+        for job, metric in watch:
+            sp = targets[t]["jobs"].get(job, {}).get(metric + "_spread")
+            rg = targets[t]["jobs"].get(job, {}).get(metric + "_range")
+            if sp is not None and sp > 0.20:
+                rows.append([f"`{t}`", f"`{job}`", metric.replace("_", " "),
+                             f"{sp*100:.0f}%", f"{rg*100:.0f}%" if rg else "-"])
+    s2 = [f"\n### Measurement confidence\n",
+          f"Each target measured {ncyc}×, interleaved across the whole matrix rather "
+          "than back to back, so a load spike on this live cluster hits every target "
+          "rather than poisoning one. Tables above report the median.\n"]
+    if rows:
+        s2.append("Coefficient of variation above 20% across cycles. These are not "
+                  "settled measurements and should not carry an argument; the range "
+                  "column is max-min for context.\n")
+        s2.append(table(rows, ["target", "job", "metric", "CV", "range"]))
+    else:
+        s2.append("No metric exceeded 20% coefficient of variation across cycles.\n")
+    return "\n".join(s2)
+
+
+def durability_audit(targets):
+    """Compare each class's flush against the flush cost of its own device.
+
+    A stack cannot persist to media faster than the device beneath it can flush.
+    Where it appears to, it is acknowledging rather than persisting -- which is
+    exactly what Longhorn was found doing on 2026-09-04, and what a single
+    commits/s leaderboard silently rewards.
+
+    The reference is the hostpath-* target on the same node, which measures the
+    bare filesystem on that device with no CSI driver in the path.
+    """
+    refs = {}
+    for t, d in targets.items():
+        if t.startswith("hostpath-"):
+            node = t.rsplit("-", 1)[-1]
+            v = d["jobs"].get("commit_fsync_4k_qd1", {}).get("sync_lat_us")
+            if v:
+                refs[node] = v
+    if not refs:
+        return ("\n### Durability tier\n\nNo `hostpath-*` baseline in this run, so "
+                "flush behaviour could not be audited. Add one per node: without it "
+                "there is no way to tell a fast class from a class that skips the "
+                "work.\n")
+
+    rows, suspect = [], []
+    for t in sorted(targets):
+        if t.startswith("hostpath-"):
+            continue
+        node = t.rsplit("-", 1)[-1]
+        ref = refs.get(node)
+        got = targets[t]["jobs"].get("commit_fsync_4k_qd1", {}).get("sync_lat_us")
+        if not ref or not got:
+            continue
+        ratio = got / ref
+        # Below ~0.5x the device's own flush, the flush is not reaching media.
+        # Above that, the class is at least paying something the device charges.
+        if ratio < 0.5:
+            tier, note = "**not durable**", f"{1/ratio:.0f}× faster than its device"
+            suspect.append(t)
+        elif ratio < 0.9:
+            tier, note = "suspect", f"{1/ratio:.1f}× faster than its device"
+        else:
+            tier, note = "durable", f"{ratio:.1f}× the device's flush"
+        rows.append([f"`{t}`", f(got), f(ref), tier, note])
+
+    s2 = ["\n### Durability tier — is the flush real?\n",
+          "Every class is compared against the `hostpath-*` baseline on its own "
+          "node: the same filesystem and device with no CSI driver in the path. "
+          "Nothing can persist to media faster than that.\n",
+          table(rows, ["target", "fsync µs", "device µs", "tier", "note"])]
+    if suspect:
+        s2.append("\n> **Do not compare commit rates across tiers.** " +
+                  ", ".join(f"`{x}`" for x in suspect) +
+                  " acknowledge flushes without persisting them, so their commit "
+                  "rates measure a weaker promise and rank above classes that do "
+                  "the work. Compare within a tier, or not at all.\n")
+    return "\n".join(s2)
+
+
+def modern_report(targets):
+    s = []
+    order = sorted(targets)
+
+    s.append("### QD1 latency — one request at a time\n")
+    s.append("The number an interactive workload feels. Replication and network "
+             "overhead cannot hide behind queue depth here.\n")
+    rows = []
+    for t in order:
+        rd = targets[t]["jobs"].get("randread_4k_qd1", {})
+        wr = targets[t]["jobs"].get("randwrite_4k_qd1", {})
+        rows.append([f"`{t}`",
+                     f(rd.get("read_lat_us")), f(rd.get("read_p99_us")), f(rd.get("read_p999_us")),
+                     f(wr.get("write_lat_us")), f(wr.get("write_p99_us")), f(wr.get("write_p999_us"))])
+    s.append(table(rows, ["target", "read avg µs", "read p99", "read p99.9",
+                          "write avg µs", "write p99", "write p99.9"]))
+
+    s.append(durability_audit(targets))
+
+    s.append("\n### Durable commit — 4k write + fsync\n")
+    s.append("The database question. Postgres, etcd and SQLite all pay this on "
+             "every commit; this cluster runs eleven CNPG databases. `sync` "
+             "columns time the flush call itself.\n")
+    rows = []
+    for t in order:
+        j = targets[t]["jobs"].get("commit_fsync_4k_qd1", {})
+        rows.append([f"`{t}`", k(j.get("write_iops")),
+                     f(j.get("write_lat_us")), f(j.get("write_p99_us")),
+                     f(j.get("sync_lat_us")), f(j.get("sync_p99_us"))])
+    s.append(table(rows, ["target", "commits/s", "write avg µs", "write p99",
+                          "sync avg µs", "sync p99"]))
+
+    s.append("\n### Flush semantics — three ways to ask for durability\n")
+    s.append("A stack that pushes to stable media cannot beat the bare device's "
+             "flush, and the three primitives should land close together. Wide "
+             "gaps, or a class faster than the raw volume beneath it, mean an "
+             "acknowledgement rather than a flush.\n")
+    rows = []
+    for t in order:
+        jf = targets[t]["jobs"].get("commit_fsync_4k_qd1", {})
+        jd = targets[t]["jobs"].get("commit_fdatasync_4k_qd1", {})
+        jo = targets[t]["jobs"].get("commit_osync_4k_qd1", {})
+        rows.append([f"`{t}`",
+                     f(jf.get("sync_lat_us")), k(jf.get("write_iops")),
+                     f(jd.get("sync_lat_us")), k(jd.get("write_iops")),
+                     f(jo.get("write_lat_us")), k(jo.get("write_iops"))])
+    s.append(table(rows, ["target", "fsync µs", "fsync/s", "fdatasync µs",
+                          "fdatasync/s", "O_SYNC write µs", "O_SYNC/s"]))
+
+    s.append("\n### IOPS ceiling — 4k random, QD64\n")
+    rows = []
+    for t in order:
+        rd = targets[t]["jobs"].get("randread_4k_qd64", {})
+        wr = targets[t]["jobs"].get("randwrite_4k_qd64", {})
+        mx = targets[t]["jobs"].get("randrw_4k_qd16_70r", {})
+        rows.append([f"`{t}`",
+                     k(rd.get("read_iops")), f(rd.get("read_mibs"), 0),
+                     k(wr.get("write_iops")), f(wr.get("write_mibs"), 0),
+                     k(mx.get("read_iops")), k(mx.get("write_iops"))])
+    s.append(table(rows, ["target", "read IOPS", "read MiB/s", "write IOPS",
+                          "write MiB/s", "mixed read", "mixed write"]))
+
+    s.append("\n### Sequential throughput — 1 MiB, QD8\n")
+    rows = []
+    for t in order:
+        rd = targets[t]["jobs"].get("seqread_1m_qd8", {})
+        wr = targets[t]["jobs"].get("seqwrite_1m_qd8", {})
+        rows.append([f"`{t}`", f(rd.get("read_mibs"), 0), f(wr.get("write_mibs"), 0)])
+    s.append(table(rows, ["target", "read MiB/s", "write MiB/s"]))
+    return "\n".join(s)
+
+
+def write_csv(run_dir, targets):
+    fp = os.path.join(run_dir, "results.csv")
+    cols = ["target", "storageclass", "node", "job", "read_iops", "write_iops",
+            "read_mibs", "write_mibs", "read_lat_us", "write_lat_us",
+            "read_p99_us", "write_p99_us", "read_p999_us", "write_p999_us",
+            "sync_lat_us", "sync_p99_us", "sync_p999_us"]
+    with open(fp, "w", newline="") as fh:
+        w = csv.writer(fh)
+        w.writerow(cols)
+        for t in sorted(targets):
+            # target ids are "<class>-<node>"; node is the last dash-segment
+            sc, _, node = t.rpartition("-")
+            for job, m in targets[t]["jobs"].items():
+                w.writerow([t, sc, node, job] + [m.get(c) for c in cols[4:]])
+    return fp
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(__doc__)
+        return 2
+    run_dir = sys.argv[1]
+    if not os.path.isdir(run_dir):
+        print(f"not a directory: {run_dir}", file=sys.stderr)
+        return 1
+
+    meta_path = os.path.join(run_dir, "run-metadata.yaml")
+    targets = load(run_dir)
+    if not targets:
+        print(f"no fio results found under {run_dir}", file=sys.stderr)
+        return 1
+
+    meta = ""
+    if os.path.isfile(meta_path):
+        with open(meta_path) as fh:
+            meta = fh.read().strip()
+
+    doc = [f"# StorageClass performance — {os.path.basename(run_dir.rstrip('/'))}\n",
+           "Cluster: ankhmorpork. One target measured at a time; `lvm-thin`, "
+           "`piraeus-r2` and `longhorn` share a volume group on each node, so "
+           "concurrent runs would measure each other.\n",
+           "```yaml", meta, f"targets_measured: {len(targets)}", "```\n",
+           "## Results\n",
+           modern_report(targets),
+           confidence(targets),
+           "\n## Caveats\n",
+           "- On `beelink01` all three local classes live on `ubuntu-vg`; on "
+           "`master02` on `secondary-vg`. Same physical device per node, so "
+           "class-to-class differences on one node are stack overhead, not disk.\n"
+           "- `piraeus-r2` provisions from the `temporary-topolvm` pool, which "
+           "*is* `thin-pool0` — the same pool `lvm-thin` uses. `piraeus-r2` vs "
+           "`lvm-thin` on the same node therefore isolates DRBD replication cost.\n"
+           "- `longhorn` here is 3 replicas, `piraeus-r2` is 2, `lvm-thin` is 1 "
+           "and unreplicated. These are not equivalent durability, and the "
+           "faster classes are faster partly because they promise less.\n"
+           "- `unifi-nas` is NFSv3 with `nolock` over the node network to "
+           "192.168.40.10. Expect a hard throughput ceiling from the link, and "
+           "note that `nolock` means no NFS byte-range locking.\n"
+           "- `master01` is cordoned and so is not in the matrix.\n"]
+
+    out = os.path.join(run_dir, "summary.md")
+    with open(out, "w") as fh:
+        fh.write("\n".join(doc) + "\n")
+    csv_fp = write_csv(run_dir, targets)
+    print(f"  wrote {out}")
+    print(f"  wrote {csv_fp}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hack/bench/storage/run.sh
+++ b/hack/bench/storage/run.sh
@@ -1,0 +1,399 @@
+#!/usr/bin/env bash
+# Serial StorageClass benchmark for the ankhmorpork cluster.
+#
+# Runs exactly one target at a time. That is not politeness: lvm-thin,
+# piraeus-r2 and longhorn on a given node all sit on the same volume group, so
+# two concurrent targets would be measuring each other.
+#
+# Usage:
+#   ./run.sh                          # all targets in targets.env
+#   ./run.sh --only lvm-thin          # filter by class or node substring
+#   ./run.sh --resume <run-id>        # continue a run, skipping finished targets
+#   ./run.sh --only unifi-nas --buffered   # NFS as an app actually uses it
+#   ./run.sh --dry-run                # print the plan, touch nothing
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+: "${KUBECONFIG:=$HOME/.kube/clusters/ankhmorpork}"
+export KUBECONFIG
+
+PROFILE=modern
+FIO_IMAGE="docker.io/library/alpine:3.24.1"
+VOLUME_SIZE=16Gi
+FIO_SIZE=8G
+FIO_DIRECT=1
+FIO_OFFSET_INCREMENT=500M
+RUNTIME=45
+SETTLE=45
+JOB_TIMEOUT=1800
+ONLY=""
+SKIP=""
+DRY_RUN=false
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+RESUME=false
+# Repeat passes over the whole target list. On a live cluster a single pass
+# measures each target under whatever load happened to exist in its slot; three
+# interleaved passes spread that noise across all targets instead of pinning it
+# to one. report.py takes the median and reports the spread.
+CYCLES=3
+# Where the hostpath baseline writes. Beside Longhorn's replicas/ directory,
+# never inside it.
+HOSTPATH_DIR="/var/lib/rancher/longhorn/storage-bench-scratch"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --only) ONLY="$2"; shift 2 ;;
+    --skip) SKIP="$2"; shift 2 ;;
+    --runtime) RUNTIME="$2"; shift 2 ;;
+    --fio-size) FIO_SIZE="$2"; shift 2 ;;
+    --volume-size) VOLUME_SIZE="$2"; shift 2 ;;
+    --settle) SETTLE="$2"; shift 2 ;;
+    # O_DIRECT is the default because it is the only way to compare classes
+    # without the page cache answering for them. It is also unrepresentative for
+    # unifi-nas: direct=1 on NFS turns every write into its own synchronous
+    # round trip with no client-side coalescing, which no real application does.
+    # Use --buffered for a second NFS run that reflects actual app behaviour.
+    --buffered) FIO_DIRECT=0; shift ;;
+    --run-id) RUN_ID="$2"; shift 2 ;;
+    --resume) RUN_ID="$2"; RESUME=true; shift 2 ;;
+    --cycles) CYCLES="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    -h|--help) sed -n '2,20p' "$0"; exit 0 ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+SUFFIX=""
+[[ "$FIO_DIRECT" == "0" ]] && SUFFIX="-buffered"
+OUT="results/${RUN_ID}-${PROFILE}${SUFFIX}"
+log()  { printf '%s  %s\n' "$(date -u +%H:%M:%S)" "$*"; }
+fail() { printf '%s  ERROR: %s\n' "$(date -u +%H:%M:%S)" "$*" >&2; }
+
+render() {
+  # Deliberately not envsubst: it is not installed everywhere, and the template
+  # set is small and fully known.
+  sed -e "s|\${PVC_NAME}|${PVC_NAME}|g" \
+      -e "s|\${JOB_NAME}|${JOB_NAME}|g" \
+      -e "s|\${TARGET_ID}|${TARGET_ID}|g" \
+      -e "s|\${SC}|${SC}|g" \
+      -e "s|\${NODE}|${NODE}|g" \
+      -e "s|\${VOLUME_SIZE}|${VOLUME_SIZE}|g" \
+      -e "s|\${FIO_IMAGE}|${FIO_IMAGE}|g" \
+      -e "s|\${FIO_SIZE}|${FIO_SIZE}|g" \
+      -e "s|\${FIO_DIRECT}|${FIO_DIRECT}|g" \
+      -e "s|\${FIO_OFFSET_INCREMENT}|${FIO_OFFSET_INCREMENT}|g" \
+      -e "s|\${RUNTIME}|${RUNTIME}|g" \
+      -e "s|\${PROFILE}|${PROFILE}|g" \
+      -e "s|\${HOSTPATH}|${HOSTPATH_DIR}|g" \
+      "$1"
+}
+
+# --- target list -------------------------------------------------------------
+# Built with a read loop rather than mapfile: macOS ships bash 3.2, where
+# mapfile does not exist, and this script is run from a laptop.
+TARGETS=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && TARGETS+=("$line")
+done < <(grep -vE '^[[:space:]]*(#|$)' targets.env \
+         | awk '{print $1" "$2}' \
+         | { if [[ -n "$ONLY" ]]; then grep -- "$ONLY" || true; else cat; fi; } \
+         | { if [[ -n "$SKIP" ]]; then grep -v -- "$SKIP" || true; else cat; fi; })
+
+[[ ${#TARGETS[@]} -gt 0 ]] || { fail "no targets selected"; exit 1; }
+
+echo
+echo "run id     : $RUN_ID"
+echo "profile    : $PROFILE  (runtime ${RUNTIME}s/job, file $FIO_SIZE, volume $VOLUME_SIZE)"
+echo "io mode    : $([[ "$FIO_DIRECT" == "1" ]] && echo 'O_DIRECT' || echo 'buffered (page cache in play)')"
+echo "targets    : ${#TARGETS[@]}  x ${CYCLES} interleaved cycle(s)"
+printf '             %s\n' "${TARGETS[@]}"
+echo "output     : $OUT"
+echo "kubeconfig : $KUBECONFIG"
+echo
+
+if $DRY_RUN; then echo "dry run, stopping here"; exit 0; fi
+
+kubectl version --request-timeout=10s -o json >/dev/null || { fail "cluster unreachable"; exit 1; }
+mkdir -p "$OUT"
+
+# --- one-time setup ---------------------------------------------------------
+kubectl apply -f manifests/namespace.yaml >/dev/null
+kubectl -n bench create configmap storage-bench-scripts \
+  --from-file=entrypoint.sh=manifests/entrypoint.sh \
+  --from-file=modern.fio=fio/modern.fio \
+  --from-file=precondition.fio=fio/precondition.fio \
+  --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+log "namespace + scripts configmap ready"
+
+# Record the environment the numbers were produced in. Without this a results
+# directory is uninterpretable six months later.
+{
+  echo "run_id: $RUN_ID"
+  echo "profile: $PROFILE"
+  echo "fio_size: $FIO_SIZE"
+  echo "volume_size: $VOLUME_SIZE"
+  echo "runtime_per_job: ${RUNTIME}s"
+  echo "fio_direct: $FIO_DIRECT"
+  echo "io_mode: $([[ "$FIO_DIRECT" == "1" ]] && echo o_direct || echo buffered)"
+  echo "image: $FIO_IMAGE"
+} > "$OUT/run-metadata.yaml"
+kubectl get nodes -o wide            > "$OUT/env-nodes.txt" 2>&1 || true
+kubectl get sc -o yaml               > "$OUT/env-storageclasses.yaml" 2>&1 || true
+kubectl get nodes.longhorn.io -n longhorn-system -o wide \
+                                     > "$OUT/env-longhorn-nodes.txt" 2>&1 || true
+
+
+# --- connectivity resilience -------------------------------------------------
+# A 10-cycle run takes many hours over a laptop-to-cluster link, so a dropped
+# connection is expected rather than exceptional. Nothing below treats a failed
+# kubectl as a failed target: the fio work runs as Kubernetes Jobs and keeps
+# going regardless of whether this laptop can see it.
+
+# Retry a kubectl invocation through transient API/network errors.
+k() {
+  local tries=0 out rc
+  while :; do
+    out="$(kubectl "$@" 2>&1)"; rc=$?
+    [[ $rc -eq 0 ]] && { printf '%s' "$out"; return 0; }
+    # A genuine "not found" is an answer, not a network problem.
+    if [[ "$out" == *"NotFound"* || "$out" == *"not found"* ]]; then
+      printf '%s' "$out"; return $rc
+    fi
+    tries=$((tries+1))
+    if [[ $tries -ge 5 ]]; then printf '%s' "$out"; return $rc; fi
+    sleep $((tries*5))
+  done
+}
+
+# Block until the API answers again. Returns 1 only after ~30 minutes.
+wait_cluster() {
+  local waited=0
+  while ! kubectl version --request-timeout=10s -o json >/dev/null 2>&1; do
+    if [[ $waited -eq 0 ]]; then fail "  cluster unreachable, waiting for it to come back"; fi
+    sleep 20; waited=$((waited+20))
+    if [[ $waited -ge 5400 ]]; then fail "  cluster still unreachable after 90m"; return 1; fi
+  done
+  if [[ $waited -gt 0 ]]; then log "  cluster reachable again after ${waited}s"; fi
+  return 0
+}
+
+# Poll a Job to completion. Unlike `kubectl wait`, a failed poll is retried
+# rather than being mistaken for the Job failing -- which would delete a Job
+# that is still doing useful work.
+#   0 = succeeded, 1 = failed, 2 = timed out
+wait_job() {
+  local job="$1" timeout="$2" start=$SECONDS s f
+  while (( SECONDS - start < timeout )); do
+    if ! wait_cluster; then return 2; fi
+    s="$(kubectl -n bench get job "$job" -o jsonpath='{.status.succeeded}' 2>/dev/null)" || { sleep 15; continue; }
+    [[ "$s" == "1" ]] && return 0
+    f="$(kubectl -n bench get job "$job" -o jsonpath='{.status.failed}' 2>/dev/null)" || true
+    [[ -n "$f" && "$f" != "0" ]] && return 1
+    sleep 15
+  done
+  return 2
+}
+
+# Wait for a PVC to bind, tolerating connectivity loss the same way.
+wait_bound() {
+  local pvc="$1" timeout="$2" start=$SECONDS ph
+  while (( SECONDS - start < timeout )); do
+    if ! wait_cluster; then return 1; fi
+    ph="$(kubectl -n bench get pvc "$pvc" -o jsonpath='{.status.phase}' 2>/dev/null)" || { sleep 10; continue; }
+    [[ "$ph" == "Bound" ]] && return 0
+    sleep 10
+  done
+  return 1
+}
+
+cleanup_job() {
+  kubectl -n bench delete job "$1" --ignore-not-found --wait=true --timeout=120s >/dev/null 2>&1 || true
+}
+
+cleanup_target() {
+  local pvc="$1" job="$2"
+  kubectl -n bench delete job "$job" --ignore-not-found --wait=true --timeout=120s >/dev/null 2>&1 || true
+  local pv
+  pv="$(kubectl -n bench get pvc "$pvc" -o jsonpath='{.spec.volumeName}' 2>/dev/null || true)"
+  kubectl -n bench delete pvc "$pvc" --ignore-not-found --wait=true --timeout=300s >/dev/null 2>&1 || true
+  if [[ -n "$pv" ]]; then
+    # Reclaim must finish before the next target starts, or the next run competes
+    # with a background delete on the same thin pool.
+    for _ in $(seq 1 60); do
+      kubectl get pv "$pv" >/dev/null 2>&1 || break
+      sleep 5
+    done
+  fi
+}
+
+# --- phase 1: provision and precondition ------------------------------------
+# Volumes are laid out once and kept for every cycle. Preconditioning an 8GiB
+# file costs ~150s on longhorn, so paying it per cycle is what previously made
+# repeated sampling unaffordable.
+FAILED=()
+set +u  # bash 3.2 treats an empty array as unbound under set -u
+LIVE=()
+
+i=0
+for target in "${TARGETS[@]}"; do
+  i=$((i+1))
+  SC="${target%% *}"; NODE="${target##* }"
+  IS_HOSTPATH=false; [[ "$SC" == hostpath-* ]] && IS_HOSTPATH=true
+  TARGET_ID="${SC}-${NODE}"
+  PVC_NAME="bench-${TARGET_ID}"; JOB_NAME="prep-${TARGET_ID}"
+  TDIR="$OUT/$TARGET_ID"; mkdir -p "$TDIR"
+
+  echo
+  log "[prep $i/${#TARGETS[@]}] $SC on $NODE"
+  cleanup_job "$JOB_NAME"
+
+  # On resume, a Bound PVC from the interrupted attempt is already
+  # preconditioned; recreating it would throw away ~25 minutes of layout work
+  # across the matrix for nothing.
+  # Bound is NOT the same as preconditioned: a volume whose layout job was
+  # interrupted binds fine but is only partly allocated, and reads of
+  # unallocated blocks come back at fake speed. Reuse only volumes whose layout
+  # actually finished, recorded by the marker written below.
+  if $RESUME && ! $IS_HOSTPATH && [[ -f "$TDIR/.preconditioned" ]] \
+     && [[ "$(kubectl -n bench get pvc "$PVC_NAME" -o jsonpath='{.status.phase}' 2>/dev/null)" == "Bound" ]]; then
+    log "  volume already provisioned and preconditioned, reusing"
+    LIVE+=("$target")
+    continue
+  fi
+
+  if $IS_HOSTPATH; then
+    PROFILE=precondition render manifests/job-hostpath.yaml.tpl > "$TDIR/prep.yaml"
+  else
+    kubectl -n bench delete pvc "$PVC_NAME" --ignore-not-found --wait=true --timeout=300s >/dev/null 2>&1
+    render manifests/pvc.yaml.tpl > "$TDIR/pvc.yaml"
+    kubectl apply -f "$TDIR/pvc.yaml" >/dev/null
+    PROFILE=precondition render manifests/job.yaml.tpl > "$TDIR/prep.yaml"
+  fi
+  kubectl apply -f "$TDIR/prep.yaml" >/dev/null
+
+  if ! $IS_HOSTPATH && ! wait_bound "$PVC_NAME" 600; then
+    fail "  pvc never bound"
+    kubectl -n bench describe pvc "$PVC_NAME" > "$TDIR/pvc-describe.txt" 2>&1 || true
+    FAILED+=("$TARGET_ID (pvc unbound)"); cleanup_job "$JOB_NAME"; continue
+  fi
+
+  if ! $IS_HOSTPATH; then
+    PV="$(kubectl -n bench get pvc "$PVC_NAME" -o jsonpath='{.spec.volumeName}')"
+    kubectl get pv "$PV" -o yaml > "$TDIR/pv-live.yaml" 2>&1 || true
+    case "$SC" in
+      longhorn|longhorn-*)
+        for _ in $(seq 1 60); do
+          r="$(kubectl -n longhorn-system get volumes.longhorn.io "$PV" \
+                -o jsonpath='{.status.robustness}' 2>/dev/null || true)"
+          [[ "$r" == "healthy" ]] && break; sleep 5
+        done
+        log "  longhorn robustness=${r:-unknown}"
+        kubectl -n longhorn-system get replicas.longhorn.io -l "longhornvolume=$PV" \
+          -o wide > "$TDIR/longhorn-replicas.txt" 2>&1 || true ;;
+      piraeus-*)
+        kubectl get volumeattachments -o wide 2>/dev/null | grep -- "$PV" \
+          > "$TDIR/volumeattachment.txt" 2>&1 || true
+        # Which state was measured matters most for the roaming class: a Pod can
+        # attach diskless and run fully remote until auto-diskful converts it.
+        # Without this the two states are indistinguishable in the results.
+        LC=$(kubectl -n platform-storage get pods -l app.kubernetes.io/component=linstor-controller \
+               -o name 2>/dev/null | head -1)
+        if [[ -n "$LC" ]]; then
+          kubectl -n platform-storage exec "$LC" -- linstor resource list-volumes 2>/dev/null \
+            | grep -- "$PV" > "$TDIR/linstor-placement.txt" 2>&1 || true
+          if grep -qi "diskless" "$TDIR/linstor-placement.txt" 2>/dev/null; then
+            log "  NOTE: $NODE holds a DISKLESS attachment -- measuring remote I/O"
+          fi
+        fi ;;
+    esac
+  fi
+
+  if wait_job "$JOB_NAME" "$JOB_TIMEOUT"; then
+    log "  preconditioned"
+    touch "$TDIR/.preconditioned"
+    LIVE+=("$target")
+  else
+    fail "  preconditioning did not complete"
+    rm -f "$TDIR/.preconditioned"
+    kubectl -n bench logs "job/$JOB_NAME" --tail=40 > "$TDIR/prep.log" 2>&1 || true
+    FAILED+=("$TARGET_ID (precondition)")
+  fi
+  cleanup_job "$JOB_NAME"
+done
+
+[[ ${#LIVE[@]} -gt 0 ]] || { fail "nothing preconditioned successfully"; exit 1; }
+
+# --- phase 2: interleaved measurement cycles --------------------------------
+for cyc in $(seq 1 "$CYCLES"); do
+  echo
+  log "########## cycle $cyc of $CYCLES ##########"
+  j=0
+  for target in "${LIVE[@]}"; do
+    j=$((j+1))
+    SC="${target%% *}"; NODE="${target##* }"
+    IS_HOSTPATH=false; [[ "$SC" == hostpath-* ]] && IS_HOSTPATH=true
+    TARGET_ID="${SC}-${NODE}"
+    PVC_NAME="bench-${TARGET_ID}"; JOB_NAME="run${cyc}-${TARGET_ID}"
+    CDIR="$OUT/$TARGET_ID/cycle-$cyc"; mkdir -p "$CDIR"
+
+    if $RESUME && [[ -s "$CDIR/fio.json" ]] \
+       && python3 -c "import json,sys;json.load(open(sys.argv[1]))" "$CDIR/fio.json" 2>/dev/null; then
+      log "  [$j/${#LIVE[@]}] $TARGET_ID already measured, skipping"; continue
+    fi
+
+    cleanup_job "$JOB_NAME"
+    if $IS_HOSTPATH; then render manifests/job-hostpath.yaml.tpl > "$CDIR/job.yaml"
+    else render manifests/job.yaml.tpl > "$CDIR/job.yaml"; fi
+    kubectl apply -f "$CDIR/job.yaml" >/dev/null
+
+    if wait_job "$JOB_NAME" "$JOB_TIMEOUT"; then
+      # Logs can fail on a blip even though the Job succeeded; retry before
+      # concluding the measurement was lost.
+      for _ in 1 2 3; do
+        kubectl -n bench logs "job/$JOB_NAME" --tail=-1 > "$CDIR/pod.log" 2>&1 && break
+        sleep 10
+      done
+      sed -n '/-----BEGIN FIO JSON-----/,/-----END FIO JSON-----/p' "$CDIR/pod.log" \
+        | sed '1d;$d' > "$CDIR/fio.json" || true
+      if [[ -s "$CDIR/fio.json" ]] && python3 -c "import json,sys;json.load(open(sys.argv[1]))" "$CDIR/fio.json" 2>/dev/null; then
+        log "  [$j/${#LIVE[@]}] $TARGET_ID ok"
+      else
+        fail "  [$j/${#LIVE[@]}] $TARGET_ID produced no valid json"
+        rm -f "$CDIR/fio.json"; FAILED+=("$TARGET_ID cycle$cyc (no json)")
+      fi
+    else
+      fail "  [$j/${#LIVE[@]}] $TARGET_ID job did not complete"
+      kubectl -n bench logs "job/$JOB_NAME" --tail=40 > "$CDIR/pod.log" 2>&1 || true
+      FAILED+=("$TARGET_ID cycle$cyc (job)")
+    fi
+    cleanup_job "$JOB_NAME"
+    sleep "$SETTLE"
+  done
+done
+
+# --- phase 3: teardown -------------------------------------------------------
+echo
+log "tearing down volumes"
+for target in "${TARGETS[@]}"; do
+  SC="${target%% *}"; NODE="${target##* }"
+  [[ "$SC" == hostpath-* ]] && continue
+  cleanup_target "bench-${SC}-${NODE}" "unused"
+done
+
+echo
+log "all targets done"
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+  fail "${#FAILED[@]} target(s) had problems:"
+  printf '         - %s\n' "${FAILED[@]}" >&2
+fi
+
+echo
+log "building report"
+python3 report.py "$OUT" || fail "report generation failed"
+echo
+echo "results: $OUT"
+echo "report : $OUT/summary.md"
+echo
+echo "Thin pools do not return space to the VG until the blocks are discarded."
+echo "Run hack/lvm-trim.sh on the tested nodes if 'vgs' looks fuller than expected."

--- a/hack/bench/storage/targets.env
+++ b/hack/bench/storage/targets.env
@@ -1,0 +1,61 @@
+# The test matrix, one target per line: <storageclass> <node>
+#
+# Every class runs on every node on purpose. Testing one class on two nodes and
+# another on one makes "X is slower" unfalsifiable -- it could just be a slower
+# disk. beelink01 and beelink02 are near-identical hardware on the same VG, so
+# they also act as a consistency check: if they disagree, something is off with
+# a node rather than with a storage class.
+#
+# On each node the three classes sit on the SAME volume group, so the same
+# physical device, and the difference measured is the CSI/replication stack:
+#   beelink01/02  lvm-thin + piraeus -> ubuntu-vg/thin-pool0    longhorn -> /dev/ubuntu-vg/longhorn
+#   master02      lvm-thin + piraeus -> secondary-vg/thin-pool0 longhorn -> /dev/secondary-vg/longhorn
+#
+# unifi-nas is deliberately absent: it is network-bound at one 1GbE link, that
+# question is settled, and it costs ~13 min a target to re-confirm.
+
+lvm-thin    beelink01
+lvm-thin    beelink02
+lvm-thin    master02
+# piraeus-r2 carries al-extents=6433 + max-buffers=8000 as of 2026-09-03.
+piraeus-r2  beelink01
+piraeus-r2  beelink02
+piraeus-r2  master02
+# Baseline for the device Longhorn actually writes to: a hostPath straight onto
+# /var/lib/rancher/longhorn, the thick (linear) LV holding its sparse replica
+# files. No PVC, no CSI driver, no Longhorn engine.
+#
+# This is the control the earlier runs lacked. Two comparisons fall out of it:
+#   lvm-thin vs hostpath-longhorn  -> cost of dm-thin versus a thick LV
+#   longhorn vs hostpath-longhorn  -> cost of the Longhorn engine itself
+# Together they say whether Longhorn's suspiciously cheap fsync is just the
+# thin/thick difference or something the engine is doing.
+# One node only. unifi-nas reaches the same NAS over the same network from every
+# node, and per-node numbers agreed within ~5% (106 vs 104 MiB/s sequential read),
+# so the extra two nodes bought nothing. They cost a great deal: buffered NFS
+# write jobs overrun their 20s runtime by ~15x because dirty pages accumulate in
+# the page cache and NFS close-to-open consistency flushes the backlog over a
+# 1GbE link when fio closes the file. ~27 min per target against ~6 for the rest.
+unifi-nas   beelink01
+
+# piraeus-r2-roaming is deliberately not measured. It carries the same DRBD
+# tuning as piraeus-r2, applied 2026-09-03 on the strength of piraeus-r2's
+# numbers alone, so it remains tuned-but-unbenchmarked by choice rather than
+# oversight. Its diskless/auto-diskful behaviour means it has two distinct
+# performance states and would need its own methodology.
+
+# Longhorn retired 2026-09-06 (docs: explanation/storage-durability). Uncomment to
+# reproduce the comparison; the class no longer exists in the cluster.
+#hostpath-longhorn  beelink01
+#hostpath-longhorn  beelink02
+#hostpath-longhorn  master02
+
+#longhorn    beelink01
+#longhorn    beelink02
+#longhorn    master02
+
+# master01 is cordoned (SchedulingDisabled since 2026-08-30) and Longhorn reports
+# it unschedulable, so a run needs `kubectl uncordon master01` first.
+#lvm-thin    master01
+#longhorn    master01
+

--- a/hack/generate-docs-reference.py
+++ b/hack/generate-docs-reference.py
@@ -6,7 +6,7 @@ from prose, so the parts that are mechanically derivable are generated here and
 checked in CI rather than typed. Everything this writes is overwritten on every
 run -- edit this script, not the output.
 
-Pages written:
+Whole pages written:
 
   docs/reference/apps.md                 every app, namespace, Kustomization, hosts
   docs/reference/admission-policies.md   every Kyverno policy anywhere under k8s/
@@ -14,6 +14,11 @@ Pages written:
                                          interval, prune, wait, dependsOn
   docs/reference/helm-releases.md        every HelmRelease: chart, source, interval,
                                          where its values come from
+
+Blocks written into otherwise hand-written pages, between
+`<!-- generated:NAME -->` and `<!-- /generated:NAME -->` markers:
+
+  docs/reference/ingress.md   ingress-classes, cluster-issuers, external-dns
 
 Chart *versions* are deliberately not written anywhere here. Renovate bumps them
 in the manifests several times a week, and a generated page that carried them
@@ -25,6 +30,7 @@ new file is invisible until staged.
 """
 
 import pathlib
+import re
 import subprocess
 import sys
 
@@ -61,6 +67,10 @@ def load_all(path):
         return []
 
 
+def is_k8s_object(doc):
+    return "apiVersion" in doc and "kind" in doc
+
+
 def rel(path):
     return str(path.relative_to(ROOT))
 
@@ -79,6 +89,21 @@ def tree(repo_path):
 
 def code_list(items, empty="—"):
     return ", ".join(f"`{x}`" for x in items) if items else empty
+
+
+def write_block(path, name, body):
+    """Replace the content between the generated:NAME markers in a hand-written page."""
+    text = path.read_text()
+    start, end = f"<!-- generated:{name} -->", f"<!-- /generated:{name} -->"
+    if start not in text or end not in text:
+        sys.exit(f"{rel(path)}: missing markers for generated block {name!r}")
+    head, rest = text.split(start, 1)
+    _, tail = rest.split(end, 1)
+    note = (
+        "<!-- This block is written by hack/generate-docs-reference.py; edit the\n"
+        "     manifests it reads, not the table. -->\n"
+    )
+    path.write_text(f"{head}{start}\n{note}{body.rstrip()}\n{end}{tail}")
 
 
 # --- Flux Kustomizations -----------------------------------------------------
@@ -183,6 +208,54 @@ def write_flux_kustomizations(rows):
 # --- Applications ------------------------------------------------------------
 
 
+def hosts_from_values(doc):
+    """Hostnames a Helm chart would render an Ingress for, read from values.
+
+    Charts disagree on shape, so this walks every subtree under a key named
+    `ingress` and accepts the three forms in use: `host: x`, `hosts: [x]`, and
+    `hosts: [{host: x}]` or `[{name: x}]`. The class is `className` or
+    `ingressClassName` on the same mapping, else the cluster default. Anything
+    with `enabled: false` is skipped. Returned as (host, class, "values").
+    """
+    found = []
+
+    def hosts_in(node):
+        if not isinstance(node, dict) or node.get("enabled") is False:
+            return
+        cls = node.get("className") or node.get("ingressClassName") or "default class"
+        names = []
+        if isinstance(node.get("host"), str):
+            names.append(node["host"])
+        for h in node.get("hosts", []) or []:
+            if isinstance(h, str):
+                names.append(h)
+            elif isinstance(h, dict):
+                n = h.get("host") or h.get("name")
+                if isinstance(n, str):
+                    names.append(n)
+        for n in names:
+            found.append((n, cls, "values"))
+        for k, v in node.items():
+            if k in ("hosts", "tls", "annotations", "labels"):
+                continue
+            if isinstance(v, dict):
+                hosts_in(v)
+
+    def walk(node):
+        if isinstance(node, dict):
+            for k, v in node.items():
+                if k == "ingress":
+                    hosts_in(v)
+                else:
+                    walk(v)
+        elif isinstance(node, list):
+            for v in node:
+                walk(v)
+
+    walk(doc)
+    return found
+
+
 def apps(kustomizations):
     """One row per directory under k8s/apps.
 
@@ -210,7 +283,9 @@ def apps(kustomizations):
                     cls = d.get("spec", {}).get("ingressClassName", "?")
                     for rule in d.get("spec", {}).get("rules", []) or []:
                         if rule.get("host"):
-                            ingresses.append((rule["host"], cls))
+                            ingresses.append((rule["host"], cls, "manifest"))
+                elif not is_k8s_object(d):
+                    ingresses.extend(hosts_from_values(d))
         owners = sorted(
             {
                 k["name"]
@@ -232,14 +307,19 @@ def write_apps(rows):
     )
     out.append(
         "\n!!! note\n\n"
-        "    Hostnames are read from Ingress **manifests**. An Ingress rendered by a\n"
-        "    Helm chart from `values.yaml` does not appear here, so an app with no\n"
-        "    hostname listed is not necessarily unreachable.\n"
+        "    Hostnames come from Ingress manifests and from the `ingress` section of\n"
+        "    chart values; the latter are marked *values*. A host whose class reads\n"
+        "    *default class* is rendered by a chart that sets no class and lands on\n"
+        "    the cluster default — see [ingress classes](ingress.md).\n"
     )
     out.append("\n| App | Namespace | Flux Kustomization | Hostnames |")
     out.append("\n| --- | --- | --- | --- |\n")
     for app, ns, flux, ing, readme in rows:
-        hosts = "<br>".join(f"`{h}` ({c})" for h, c in ing) if ing else "—"
+        cells = []
+        for h, c, src in ing:
+            tag = f" ({c})" if src == "manifest" else f" ({c}, *values*)"
+            cells.append(f"`{h}`{tag}")
+        hosts = "<br>".join(cells) if cells else "—"
         name = f"[`{app}`]({REPO}/blob/master/{rel(readme)})" if readme else f"`{app}`"
         out.append(
             f"| {name} | `{ns or '—'}` | "
@@ -388,13 +468,17 @@ def component_namespace(path, cache):
     return None
 
 
-def helm_releases(kustomizations):
+def helm_repositories():
     repos = {}
     for f in yaml_files("k8s"):
         for d in load_all(f):
             if d.get("kind") == "HelmRepository":
                 repos[d["metadata"]["name"]] = d.get("spec", {}).get("url", "")
+    return repos
 
+
+def helm_releases(kustomizations):
+    repos = helm_repositories()
     rows, cache = [], {}
     for f in sorted(yaml_files("k8s")):
         for d in load_all(f):
@@ -466,6 +550,152 @@ def write_helm_releases(rows):
     (DOCS / "helm-releases.md").write_text("".join(out))
 
 
+# --- Ingress: classes, issuers, external-dns (blocks in ingress.md) ----------
+
+
+def sibling_chart(values_file):
+    """Chart name of the HelmRelease that sits next to a values file."""
+    for f in sorted(values_file.parent.glob("*.yaml")):
+        for d in load_all(f):
+            if d.get("kind") == "HelmRelease":
+                spec = d.get("spec", {})
+                return (
+                    spec.get("chart", {}).get("spec", {}).get("chart")
+                    or spec.get("chartRef", {}).get("name")
+                    or "?"
+                ), f
+    return "?", None
+
+
+def ingress_classes():
+    """One row per IngressClass a network component's chart creates.
+
+    Read from values rather than from IngressClass manifests because the classes
+    here are chart-created: `ingressClass.name` in the Traefik and cloudflared
+    values. The address is the Traefik LoadBalancer IP or the Cloudflare tunnel.
+    """
+    rows = []
+    for f in sorted(yaml_files("k8s/platform/network")):
+        for d in load_all(f):
+            if is_k8s_object(d):
+                continue
+            ic = d.get("ingressClass")
+            if not isinstance(ic, dict) or not ic.get("name") or ic.get("enabled") is False:
+                continue
+            chart, release = sibling_chart(f)
+            lb = d.get("service", {}).get("spec", {}).get("loadBalancerIP")
+            tunnel = d.get("cloudflare", {}).get("tunnelName")
+            if lb:
+                address = f"`{lb}`"
+            elif tunnel:
+                address = f"Cloudflare tunnel `{tunnel}`"
+            else:
+                address = "—"
+            rows.append(
+                {
+                    "name": ic["name"],
+                    "chart": chart,
+                    "address": address,
+                    "default": bool(ic.get("isDefaultClass", False)),
+                    "file": f,
+                }
+            )
+    rows.sort(key=lambda r: r["name"])
+    return rows
+
+
+def cluster_issuers():
+    rows = []
+    for f in sorted(yaml_files("k8s")):
+        for d in load_all(f):
+            if d.get("kind") != "ClusterIssuer":
+                continue
+            acme = d.get("spec", {}).get("acme", {})
+            challenges = []
+            for s in acme.get("solvers", []) or []:
+                for kind in ("dns01", "http01"):
+                    if kind in s:
+                        provider = next(iter((s[kind] or {}).keys()), "")
+                        label = "DNS-01" if kind == "dns01" else "HTTP-01"
+                        challenges.append(f"{label} ({provider})" if provider else label)
+            server = acme.get("server", "")
+            if "acme-v02.api.letsencrypt.org" in server:
+                server = "Let's Encrypt, production"
+            elif "acme-staging" in server:
+                server = "Let's Encrypt, **staging**"
+            rows.append(
+                {
+                    "name": d["metadata"]["name"],
+                    "challenges": challenges or ["—"],
+                    "server": server or "—",
+                    "file": f,
+                }
+            )
+    rows.sort(key=lambda r: r["name"])
+    return rows
+
+
+def external_dns_settings():
+    """The external-dns values that decide what gets published where."""
+    files = [f for f in yaml_files("k8s/platform/network/external-dns") if f.name.startswith("values")]
+    for f in files:
+        for d in load_all(f):
+            if is_k8s_object(d):
+                continue
+            provider = d.get("provider")
+            if isinstance(provider, dict):
+                provider = provider.get("name", "?")
+            template = None
+            for arg in d.get("extraArgs", []) or []:
+                if isinstance(arg, str) and arg.startswith("--fqdn-template="):
+                    # Helm-escaped in the values file: {{`{{`}}.Name{{`}}`}} -> {{.Name}}
+                    template = arg.split("=", 1)[1].replace("{{`{{`}}", "{{").replace("{{`}}`}}", "}}")
+            return {
+                "provider": provider or "—",
+                "domains": d.get("domainFilters", []) or [],
+                "policy": d.get("policy", "—"),
+                "registry": d.get("registry", "—"),
+                "owner": d.get("txtOwnerId", "—"),
+                "prefix": d.get("txtPrefix", "—"),
+                "template": template,
+                "file": f,
+            }
+    return None
+
+
+def write_ingress_blocks():
+    page = DOCS / "ingress.md"
+
+    ic = ingress_classes()
+    body = ["| Class | Controller chart | Address | Default class | Source |", "| --- | --- | --- | --- | --- |"]
+    for r in ic:
+        body.append(
+            f"| `{r['name']}` | `{r['chart']}` | {r['address']} | "
+            f"{'**yes**' if r['default'] else 'no'} | {blob(r['file'])} |"
+        )
+    write_block(page, "ingress-classes", "\n".join(body))
+
+    ci = cluster_issuers()
+    body = ["| Issuer | Challenge | ACME server | Source |", "| --- | --- | --- | --- |"]
+    for r in ci:
+        body.append(f"| `{r['name']}` | {', '.join(r['challenges'])} | {r['server']} | {blob(r['file'])} |")
+    write_block(page, "cluster-issuers", "\n".join(body))
+
+    ed = external_dns_settings()
+    if ed is None:
+        sys.exit("external-dns values not found")
+    body = ["| Setting | Value |", "| --- | --- |"]
+    body.append(f"| Provider | `{ed['provider']}` |")
+    body.append(f"| Domains it will touch | {code_list(ed['domains'])} |")
+    body.append(f"| Policy | `{ed['policy']}` |")
+    body.append(f"| Ownership | `{ed['registry']}` registry, `txtOwnerId: {ed['owner']}`, `txtPrefix: {ed['prefix']}` |")
+    if ed["template"]:
+        body.append(f"| Fallback name for a Service with no host | `{ed['template']}` |")
+    body.append(f"| Source | {blob(ed['file'])} |")
+    write_block(page, "external-dns", "\n".join(body))
+    return len(ic), len(ci)
+
+
 # --- main --------------------------------------------------------------------
 
 
@@ -480,9 +710,11 @@ def main():
     write_policies(pol)
     hr = helm_releases(ks)
     write_helm_releases(hr)
+    n_classes, n_issuers = write_ingress_blocks()
     print(
         f"wrote flux-kustomizations.md ({len(ks)}), apps.md ({len(app_rows)}), "
-        f"admission-policies.md ({len(pol)}), helm-releases.md ({len(hr)})"
+        f"admission-policies.md ({len(pol)}), helm-releases.md ({len(hr)}), "
+        f"ingress.md blocks ({n_classes} classes, {n_issuers} issuers)"
     )
 
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -57,7 +57,7 @@ nav = [
     { "Charts and images" = "reference/charts.md" },
     { "Ingress and certificates" = "reference/ingress.md" },
     { "Storage classes" = "reference/storage-classes.md" },
-    { "UPS Modbus register map" = "ups/modbus-register-map.md" },
+    { "UPS Modbus register map" = "reference/ups-modbus-register-map.md" },
   ] },
   { "Explanation" = [
     "explanation/index.md",
@@ -67,7 +67,7 @@ nav = [
     { "ConfigMap autoreload" = "explanation/configmap-autoreload.md" },
     { "Why storage is split the way it is" = "explanation/storage-durability.md" },
     { "Rule linting with pint" = "explanation/pint-rule-linting.md" },
-    { "Postgres fleet upgrade plan" = "postgres/fleet-upgrade-plan.md" },
+    { "The Postgres fleet upgrade" = "explanation/postgres-fleet-upgrade.md" },
   ] },
 ]
 


### PR DESCRIPTION
Follow-ups from the docs review, everything except the Kustomization rename (separate PR, it needs live steps).

## What changes

- **Two strays moved into their sections.** `docs/postgres/` → `explanation/postgres-fleet-upgrade.md`, retitled as a record of a finished upgrade; `docs/ups/` → `reference/ups-modbus-register-map.md`, with the unit's serial and device id no longer reproduced. Reversible if you want them back.
- **Planned lists → issues.** #1360–#1364 filed (Postgres recovery was already #1333); both index pages point at the `documentation` label. Closed #109 (the 2022 "host the docs" issue) as done.
- **Generated blocks.** `ingress.md` now carries three tables written by the generator between `<!-- generated:NAME -->` markers: classes with LB IPs and default flag, ClusterIssuers with challenge type, external-dns settings. Generating the issuer table corrected the page — `letsencrypt-prod` is DNS-01, not HTTP-01 (the http01 solver is commented out).
- **Chart-rendered hosts in `apps.md`.** The `ingress` section of chart values is read in the three shapes in use and marked *values*. Five apps were half-listed; pyrra's host was missing.
- **One home per fact.** Four restated facts trimmed to a sentence and a link (autoreload timing log, the Pod-template warning, piraeus-r2 vs roaming, the stable-ConfigMap mechanism).
- **Benchmark method committed** to `hack/bench/storage/` (scripts, fio jobs, manifest templates, README; results ignored). Longhorn targets commented out with a note.

## Surfaced, not changed

`pocket-id` renders its Traefik Ingress on `private` for `login.krupa.net.pl`, while the host-naming table says `krupa.net.pl` hosts are `public` + `cloudflare`. Functionally identical when a cloudflare pair exists; noted in case it was not deliberate.

## Check

```
make docs-reference-check PYTHON=python3
make docs-lint PYTHON=python3
make docs-build
```

Lint: 0 errors, 10 warnings (down from 16), all left as judgment calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
