### PR TITLE
flux: name the device-plugins Kustomization after its component

### DIFF
--- a/docs/reference/flux-kustomizations.md
+++ b/docs/reference/flux-kustomizations.md
@@ -34,12 +34,12 @@ see [how Flux is layered](../explanation/flux-layering.md).
 | `cnpg-system` | [`k8s/platform/storage/cnpg-system`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/storage/cnpg-system) | `15m0s` | yes | no | `kyverno` |
 | `csi-nfs` | [`k8s/platform/storage/csi-nfs`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/storage/csi-nfs) | `15m0s` | yes | no | `kyverno` |
 | `descheduler` | [`k8s/platform/cluster/descheduler`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/cluster/descheduler) | `15m0s` | yes | no | — |
+| `device-plugins` | [`k8s/platform/cluster/device-plugins`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/cluster/device-plugins) | `15m0s` | yes | no | — |
 | `external-dns` | [`k8s/platform/network/external-dns`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/network/external-dns) | `15m0s` | yes | no | — |
 | `external-secrets` | [`k8s/platform/security/external-secrets`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/security/external-secrets) | `15m0s` | yes | no | — |
 | `flux-system` | [`k8s/platform/cluster/flux-system`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/cluster/flux-system) | `15m0s` | **no** | no | — |
 | `k8up` | [`k8s/platform/storage/k8up`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/storage/k8up) | `15m0s` | yes | no | — |
 | `kube-prometheus-stack` | [`k8s/platform/observability/kube-prometheus-stack`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/observability/kube-prometheus-stack) | `15m0s` | yes | no | — |
-| `kube-system` | [`k8s/platform/cluster/device-plugins`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/cluster/device-plugins) | `15m0s` | yes | no | — |
 | `kyverno` | [`k8s/platform/security/kyverno`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/security/kyverno) | `15m0s` | yes | **yes** (15m) | — |
 | `kyverno-policies` | [`k8s/platform/security/kyverno/policies`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/security/kyverno/policies) | `15m0s` | yes | no | `kyverno` |
 | `node-feature-discovery` | [`k8s/platform/cluster/node-feature-discovery`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/cluster/node-feature-discovery) | `15m0s` | yes | no | — |

--- a/k8s/flux/platform/device-plugins.yaml
+++ b/k8s/flux/platform/device-plugins.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: kube-system
+  name: device-plugins
   namespace: flux-system
 spec:
   interval: 15m0s


### PR DESCRIPTION
Renames the one Flux Kustomization named after a namespace rather than its component: `kube-system` → `device-plugins`, path `k8s/platform/cluster/device-plugins`. Surfaced by the generated Flux Kustomizations page from #1359; that page is regenerated here.

## Why this is its own PR

The `platform` umbrella has `prune: false`, so removing the old file does **not** delete the live `kube-system` Kustomization. It would keep reconciling the same three objects (the `intel-gpu-plugin` DaemonSet and two NodeFeatureRules) alongside the new one, and the two would flap over the `kustomize.toolkit.fluxcd.io/name` label. And the old Kustomization has `prune: true` itself, so deleting it outright garbage-collects those objects before the new one adopts them.

## Cutover, in order

Before merging — stop the old one and make its deletion harmless:

```
export KUBECONFIG=~/.kube/clusters/ankhmorpork
flux -n flux-system suspend kustomization kube-system
kubectl -n flux-system patch kustomization kube-system --type merge -p '{"spec":{"prune":false}}'
```

Merge, then:

```
flux reconcile source git ankhmorpork
flux -n flux-system reconcile kustomization platform          # creates device-plugins
flux -n flux-system reconcile kustomization device-plugins    # adopts the three objects
kubectl -n kube-system get ds intel-gpu-plugin -o jsonpath='{.metadata.labels.kustomize\.toolkit\.fluxcd\.io/name}{"\n"}'
#   expect: device-plugins
flux -n flux-system delete kustomization kube-system --silent # prune is false now, nothing is collected
kubectl -n kube-system get ds intel-gpu-plugin                # still present
```

Live state when checked on 2026-09-07: `kube-system` Ready, `prune: true`, not suspended, inventory of exactly those three objects. Nothing else references the name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
