### PR TITLE
ai-gateway: give litellm a probe and its own metrics

### DIFF
--- a/k8s/apps/ai-gateway/app/kustomization.yaml
+++ b/k8s/apps/ai-gateway/app/kustomization.yaml
@@ -4,7 +4,10 @@ resources:
   - repository.yaml
   - release.yaml
   - credentials.yaml
+  - metrics-credentials.yaml
+  - servicemonitor.yaml
   - ingress-cloudflare.yaml
+  - slo-probe-success.yaml
 configMapGenerator:
   - name: values-litellm
     files:

--- a/k8s/apps/ai-gateway/app/metrics-credentials.yaml
+++ b/k8s/apps/ai-gateway/app/metrics-credentials.yaml
@@ -1,0 +1,50 @@
+# The credential Prometheus uses to scrape litellm's /metrics, kept out of
+# litellm-secrets on purpose: that Secret is listed in environmentSecrets and is
+# pulled in wholesale with envFrom, so every key in it becomes an environment
+# variable inside the litellm process. A scrape credential has no business
+# there, and the master key has no business being the scrape credential.
+#
+# The value is a litellm *virtual key*, not the master key. Virtual keys live in
+# litellm's database rather than its config, so this one cannot be declared here
+# -- it is minted once against POST /key/generate and put in Doppler under
+# AI_GATEWAY_PROMETHEUS_KEY. Until that exists this ExternalSecret stays
+# NotReady and the scrape returns 401, which is the visible failure rather than
+# a silent one.
+#
+# It has to be minted with allowed_routes, and that is not a detail:
+#
+#   {"key_alias":"prometheus-scrape","allowed_routes":["/metrics","/metrics/"]}
+#
+# /metrics is guarded as an admin route, so a plain virtual key is refused with
+# "Only proxy admin can be used to ... Route=/metrics/. Your role=unknown" no
+# matter which key type it carries. Tested against 1.97.0 with a database: of
+# the four key types the UI offers, only `default` ("Full Access") reaches
+# /metrics, and only when the key belongs to a user whose role is proxy_admin --
+# llm_api, management and read_only are all 401 even then, and so is
+# proxy_admin_viewer.
+#
+# allowed_routes takes a different path through the auth check: it satisfies the
+# route check without the admin role, and simultaneously confines the key. The
+# scoped key above answers 200 on /metrics/ and 403 on /models, /model/info,
+# /key/info, /user/info, /spend/logs, /global/spend/report, /chat/completions
+# and /key/generate. A Full Access admin key would have reached all of them,
+# which would have made Prometheus's scrape credential a way to mint keys and
+# spend money -- the opposite of why this Secret is separate from the master
+# key in the first place.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: litellm-metrics-credentials
+  labels:
+    app.kubernetes.io/name: litellm
+spec:
+  data:
+    - remoteRef:
+        key: AI_GATEWAY_PROMETHEUS_KEY
+      secretKey: PROMETHEUS_AUTH_TOKEN
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-auth-api
+  target:
+    name: litellm-metrics-credentials

--- a/k8s/apps/ai-gateway/app/release.yaml
+++ b/k8s/apps/ai-gateway/app/release.yaml
@@ -22,8 +22,15 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: values-litellm
-  # The litellm chart has no ingress.labels, and homer-operator selects
-  # Ingresses by label.
+  # The litellm chart has no ingress.labels, and both homer-operator and
+  # blackbox's ingress Probe select Ingresses by label. The probe-uri annotation
+  # in values.yaml is inert on its own -- the Probe finds the Ingress by
+  # ingress.thaum.xyz/probe and only then reads the URI off it.
+  #
+  # The label goes on this Ingress and not the cloudflare twin in
+  # ingress-cloudflare.yaml: blackbox derives the scheme from whether the
+  # Ingress declares TLS, and the tunnel one declares none, so probing it builds
+  # an http:// target nothing answers.
   postRenderers:
     - kustomize:
         patches:
@@ -34,3 +41,6 @@ spec:
               - op: add
                 path: /metadata/labels/homer.rajsingh.info~1enabled
                 value: "true"
+              - op: add
+                path: /metadata/labels/ingress.thaum.xyz~1probe
+                value: enabled

--- a/k8s/apps/ai-gateway/app/servicemonitor.yaml
+++ b/k8s/apps/ai-gateway/app/servicemonitor.yaml
@@ -1,0 +1,49 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: litellm
+    app.kubernetes.io/instance: litellm
+  name: litellm
+spec:
+  endpoints:
+    # The chart's Service exposes one port, named `http`, and litellm serves
+    # /metrics on it alongside the API -- there is no separate metrics listener
+    # to point at.
+    - port: http
+      # With the trailing slash on purpose. /metrics answers 307 to /metrics/;
+      # Prometheus does follow that, but the hop is free to avoid and a
+      # redirect is one more thing to be wrong about later.
+      path: /metrics/
+      interval: 60s
+      # /metrics requires a litellm API key (default since 1.85.0). The token is
+      # a dedicated virtual key, not the master key; see
+      # metrics-credentials.yaml. prometheus-operator resolves this Secret from
+      # this ServiceMonitor's namespace, the same way karakeep's PodMonitor
+      # already does.
+      bearerTokenSecret:
+        name: litellm-metrics-credentials
+        key: PROMETHEUS_AUTH_TOKEN
+      # litellm counts the scrape as a request it served, so every scrape
+      # increments litellm_proxy_total_requests_metric{route="/metrics"} -- one
+      # per minute per replica, for ever. Verified against 1.97.0 locally: a
+      # proxy with no traffic at all still reported that series.
+      #
+      # Left in, a RED signal built on these counters would be mostly this
+      # monitoring reading itself, and an error ratio would be diluted by a
+      # denominator that grows on a timer. Dropped, the counters describe actual
+      # use of the gateway and go quiet when nobody is using it, which is the
+      # honest reading.
+      #
+      # The regex is anchored by the operator and written out in full rather
+      # than relying on a default -- an omitted or empty regex defaults to (.*),
+      # which here would drop every series and leave a target that scrapes
+      # cleanly and yields nothing.
+      metricRelabelings:
+        - action: drop
+          sourceLabels: [route]
+          regex: /metrics/?
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: litellm
+      app.kubernetes.io/instance: litellm

--- a/k8s/apps/ai-gateway/app/slo-probe-success.yaml
+++ b/k8s/apps/ai-gateway/app/slo-probe-success.yaml
@@ -1,0 +1,35 @@
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: ai-gateway-probe-success
+spec:
+  # Availability as a person experiences it: the blackbox probe, end to end
+  # through DNS, TLS and the ingress. The first availability signal this service
+  # has ever had -- before #1337 all 308 metric families in the namespace came
+  # from cadvisor, kube-state-metrics or the CNPG database, and described the
+  # container and its Postgres rather than whether the gateway answers.
+  #
+  # Matches on the host rather than the full probe URL, so changing
+  # ingress.thaum.xyz/probe-uri retunes the check without silently emptying the
+  # SLO behind it.
+  #
+  # target is a PLACEHOLDER. Unlike the other probe SLOs it is not even carried
+  # over from the shared objective -- ai-gateway was never in it, so there is no
+  # history behind this number at all. Set it from data once the probe has run
+  # a few weeks.
+  description: >-
+    Fraction of successful blackbox probes against ai-gateway.krupa.net.pl.
+  alerting:
+    name: AiGatewayProbeBudgetBurn
+    absentName: AiGatewayProbeMetricAbsent
+    severities:
+      fastBurn: info
+      mediumBurn: info
+      slowBurn: none
+      longTermBurn: none
+      absent: warning
+  indicator:
+    bool_gauge:
+      metric: probe_success{instance=~"https://ai-gateway\\.krupa\\.net\\.pl(/.*)?"}
+  target: "95.0"
+  window: 4w

--- a/k8s/apps/ai-gateway/app/values.yaml
+++ b/k8s/apps/ai-gateway/app/values.yaml
@@ -39,6 +39,34 @@ proxy_config:
     request_timeout: 120
     fallbacks:
       - claude-sonnet: [claude-haiku]
+    # Registers litellm's own /metrics collectors. Without this the route still
+    # exists -- it is mounted unconditionally and answers 401 -- so a 401 from
+    # /metrics says nothing about whether the callback is loaded.
+    callbacks: ["prometheus"]
+    # /metrics keeps its API key requirement (the default since litellm 1.85.0,
+    # and this runs 1.97.0). That is not optional here: ingress path is `/`
+    # Prefix, so anything litellm serves is internet-facing, and these metrics
+    # carry per-key spend, team aliases and user emails. Prometheus scrapes it
+    # with a dedicated virtual key -- see servicemonitor.yaml.
+    #
+    # The default label set on the request counters includes client_ip and
+    # user_agent, which on a public endpoint is the atuin problem with the
+    # internet supplying the values: one permanent series per scanner. end_user,
+    # user and user_email are unbounded for the same reason. Dropping them at
+    # the source rather than in metricRelabelings keeps the series out of the
+    # scrape entirely.
+    #
+    # Kept deliberately: `route` (bounded by litellm's own router, unlike an
+    # arbitrary URL path), api_key_alias (readable, and bounded by the number of
+    # keys issued), team/team_alias, and the model and provider labels the RED
+    # signal splits on.
+    prometheus_exclude_labels:
+      - "client_ip"
+      - "user_agent"
+      - "end_user"
+      - "user"
+      - "user_email"
+      - "hashed_api_key"
   general_settings:
     master_key: os.environ/PROXY_MASTER_KEY
 ingress:
@@ -46,8 +74,17 @@ ingress:
   className: public
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    #cert-manager.io/cluster-issuer: letsencrypt-prod
-    #ingress.thaum.xyz/probe-uri: /-/healthy
+    # Not /-/healthy, which is Prometheus's convention and 404s here in 22
+    # bytes; not /health, which needs a key and answers 401. /health/readiness
+    # is what the chart points its own readiness and startup probes at, so it is
+    # litellm's answer to "can this pod serve", database included -- and it
+    # returns {"status":"healthy","db":"connected"} in 37 bytes rather than a UI
+    # shell that would come back 200 with the backend dead.
+    #
+    # The matching ingress.thaum.xyz/probe *label* is added by the postRenderer
+    # in release.yaml. This annotation alone does nothing: blackbox's Probe
+    # selects Ingresses on that label and only then reads the URI from here.
+    ingress.thaum.xyz/probe-uri: /health/readiness
     item.homer.rajsingh.info/name: "Litellm"
     item.homer.rajsingh.info/logo: "https://cdn.jsdelivr.net/npm/@loganmarchione/homelab-svg-assets@latest/assets/openai-white.svg"
     item.homer.rajsingh.info/order: "40"


### PR DESCRIPTION
Closes #1337.

ai-gateway was the one service in the cluster with no availability signal of any kind. Both routes the issue offered are taken here, because they answer different questions: the probe covers DNS, TLS and the ingress end to end, the metrics cover what litellm itself is doing.

## The health path, checked rather than assumed

The issue was right not to trust `/-/healthy`. Measured against the live public ingress:

| path | code | size |
| --- | --- | --- |
| `/-/healthy` | **404** | 22 B |
| `/health` | 401 | 115 B |
| `/health/liveliness` | 200 | 12 B |
| `/health/readiness` | 200 | 37 B — `{"status":"healthy","db":"connected"}` |

`/health/readiness` is the pick: it is what the chart points its own readiness *and startup* probes at, so it is litellm's own answer to whether a pod can serve, database included.

The annotation was already in `values.yaml`, commented out. Uncommenting it alone would still have done nothing — blackbox's `Probe` finds Ingresses by the `ingress.thaum.xyz/probe` **label** and only then reads the URI off them. The chart has no `ingress.labels`, so that label joins the homer one in the existing postRenderer. It goes on the traefik Ingress rather than the cloudflare twin, because blackbox derives the scheme from whether the Ingress declares TLS and the tunnel one declares none.

## /metrics keeps its API key requirement

The ingress serves `/` Prefix, so everything litellm exposes is internet-facing — `/metrics` is reachable from the internet today, returning 401. These metrics carry per-key spend, team aliases and user emails, so disabling that auth would publish them.

Prometheus scrapes it with a dedicated virtual key, in its own Secret rather than `litellm-secrets` — that one is listed in `environmentSecrets` and pulled in wholesale with `envFrom`, so every key in it becomes an environment variable inside the litellm process.

**The key must be minted with `allowed_routes`**, which took some finding. `/metrics` is guarded as an admin route, so the check is on the key's owner *role*, not the key type the UI offers. Tested against 1.97.0 with a real database:

| key owner role | `key_type` | `/metrics/` |
| --- | --- | --- |
| *(none)* | any of the four | 401 |
| `proxy_admin_viewer` | `read_only` | 401 |
| `proxy_admin` | `llm_api` ("AI APIs") | 401 |
| `proxy_admin` | `management` ("Management") | 401 |
| `proxy_admin` | `read_only` | 401 |
| `proxy_admin` | `default` ("Full Access") | 200 |

Only Full Access owned by a `proxy_admin` gets through — which would have made the scrape credential able to mint keys and spend money, the opposite of why the Secret is separate. `allowed_routes` takes a different path through the auth check: it satisfies the route check without the admin role, and confines the key at the same time.

| route | scoped key | Full Access + `proxy_admin` |
| --- | --- | --- |
| `/metrics/` | 200 | 200 |
| `/models`, `/model/info` | **403** | 200 |
| `/key/info`, `/user/info` | **403** | 200 |
| `/spend/logs`, `/global/spend/report` | **403** | 200 |
| `POST /chat/completions` | **403** | 200 |
| `POST /key/generate` | **403** | 200 |

## Two things verified locally because both fail silently

Run in a container on 1.97.0, not taken from the docs:

- **`prometheus_exclude_labels` is honoured.** `client_ip` and `user_agent` are on the request counters by default, and on a public endpoint that is the atuin problem with the internet supplying the values — one permanent series per scanner. The emitted series now carry only `api_key_alias, api_provider, exception_class, exception_status, model_id, org_alias, org_id, requested_model, route, team, team_alias`.
- **litellm counts the scrape as a request it served.** A proxy with no traffic at all still reported `litellm_proxy_total_requests_metric{route="/metrics"}`. At 60s across two replicas a RED signal would have been mostly this monitoring reading itself, with an error ratio diluted by a denominator that grows on a timer. Dropped at scrape time.

Also found: `/metrics` answers 307 to `/metrics/`. Prometheus follows it, but the ServiceMonitor uses the trailing slash so there is one less thing to be wrong about later.

## Before this works

The virtual key has to exist in Doppler as `AI_GATEWAY_PROMETHEUS_KEY`; virtual keys live in litellm's database, not its config, so it cannot be declared in git.

```
curl -sX POST https://ai-gateway.krupa.net.pl/key/generate \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -H 'Content-Type: application/json' \
  -d '{"key_alias":"prometheus-scrape","allowed_routes":["/metrics","/metrics/"]}'
```

Until then the ExternalSecret stays NotReady and the target 401s — a visible failure rather than a silent one. **The probe half is unaffected and starts working on merge.**

## Deliberately not here

- **A RED SLO on the new counters.** No data behind a target yet; worth a follow-up once metrics have flowed.
- **A real number for the probe SLO.** The target is a placeholder, and unlike the other probe SLOs it is not even inherited from the shared objective — ai-gateway was never in it.

## Validation

`make validate` clean across all 123 targets. The postRenderer's `add` on `/metadata/labels` is safe: the live Ingress already carries labels, and the homer patch beside it has been working through the same path for 76 days.
