### PR TITLE
vod-arr: back up the three configs nothing else covers

### DIFF
--- a/k8s/apps/vod-arr/backup/kustomization.yaml
+++ b/k8s/apps/vod-arr/backup/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pvc.yaml
+  - schedule.yaml

--- a/k8s/apps/vod-arr/backup/pvc.yaml
+++ b/k8s/apps/vod-arr/backup/pvc.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: backup-repo
+  labels:
+    app.kubernetes.io/component: backup
+    app.kubernetes.io/name: vod-arr
+spec:
+  # This namespace's restic repository. Repositories stay per-namespace even
+  # though the password is shared: a corrupted one then costs a single
+  # namespace, restic check stays cheap, and concurrent backups never contend
+  # for the same repository lock over an NFSv3 mount with nolock.
+  #
+  # excluded_from_alerts is stamped by kyverno's mutate-nfs-pvc-alert-exclusion
+  # for every unifi-nas claim. Do not add it here.
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: unifi-nas

--- a/k8s/apps/vod-arr/backup/schedule.yaml
+++ b/k8s/apps/vod-arr/backup/schedule.yaml
@@ -1,0 +1,59 @@
+apiVersion: k8up.io/v1
+kind: Schedule
+metadata:
+  name: backup
+  labels:
+    app.kubernetes.io/component: backup
+    app.kubernetes.io/name: vod-arr
+spec:
+  backend:
+    # No repoPasswordSecretRef: the operator supplies RESTIC_PASSWORD from
+    # BACKUP_GLOBALREPOPASSWORD. Setting it here would override that for this
+    # namespace alone.
+    #
+    # The repository is plain restic files on the UNAS rather than S3 via a
+    # fourth versitygw. versitygw's posix backend would write those same files
+    # to that same export; going direct means a restore needs restic and an NFS
+    # mount, with no cluster running.
+    local:
+      mountPath: /repo
+    volumeMounts:
+      - name: backup-repo
+        mountPath: /repo
+  # Runs as root, deliberately. csi-nfs creates each subdir 0775 owned by
+  # 977:988 -- measured on a live claim, where the sonarr pod at uid 1000
+  # cannot write to its own backup directory -- and the UNAS refuses chown, so
+  # fsGroup cannot fix it either. paperless works around this with a root
+  # initContainer that chmods the export; K8up builds these Pods itself, so
+  # that is not available. A backup agent also has to read every file it is
+  # pointed at, regardless of ownership.
+  podSecurityContext:
+    runAsUser: 0
+    runAsGroup: 0
+  backup:
+    # Fixed rather than @daily-random: a restic repository is only consistent at
+    # rest, so an off-site copy of it needs a known quiet window. Staggered
+    # clear of paperless (22:36) and CNPG (23:17-03:47).
+    schedule: "15 22 * * *"
+    volumes:
+      - name: backup-repo
+        persistentVolumeClaim:
+          claimName: backup-repo
+  check:
+    schedule: "45 6 * * 0"
+    volumes:
+      - name: backup-repo
+        persistentVolumeClaim:
+          claimName: backup-repo
+  prune:
+    # After check, so a repository that already fails verification is not
+    # repacked before anyone has seen the failure.
+    schedule: "15 8 * * 0"
+    retention:
+      keepDaily: 14
+      keepWeekly: 8
+      keepMonthly: 6
+    volumes:
+      - name: backup-repo
+        persistentVolumeClaim:
+          claimName: backup-repo

--- a/k8s/apps/vod-arr/cleanuparr/deployment.yaml
+++ b/k8s/apps/vod-arr/cleanuparr/deployment.yaml
@@ -20,6 +20,12 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: cleanuparr
+        # cleanuparr.db, events.db and users.db are all live SQLite, so the
+        # file-level copies can tear. This streams consistent copies of all three
+        # into the repository as one tar; that is what to restore from, and the
+        # file-level copies stay as a fallback.
+        k8up.io/backupcommand: /opt/apprise-venv/bin/python3 /backup/dump.py
+        k8up.io/file-extension: .tar
       labels:
         app.kubernetes.io/component: cleaner
         app.kubernetes.io/name: cleanuparr
@@ -61,6 +67,9 @@ spec:
           volumeMounts:
             - mountPath: /config
               name: config
+            - mountPath: /backup
+              name: backup-script
+              readOnly: true
       restartPolicy: Always
       securityContext:
         fsGroup: 1000
@@ -69,3 +78,6 @@ spec:
         - name: config
           persistentVolumeClaim:
             claimName: cleanuparr-config
+        - name: backup-script
+          configMap:
+            name: backup-script-cleanuparr

--- a/k8s/apps/vod-arr/cleanuparr/kustomization.yaml
+++ b/k8s/apps/vod-arr/cleanuparr/kustomization.yaml
@@ -5,3 +5,18 @@ resources:
   - ingress.yaml
   - pvc-config.yaml
   - service.yaml
+configMapGenerator:
+  # Named per app: cleanuparr and seerr both live in vod-arr, so a bare
+  # `backup-script` collides -- validate-configmaps catches it, same lesson as
+  # values-<release>.
+  #
+  # The dump script is a real file so it stays readable and lintable. Inlining
+  # it in the k8up.io/backupcommand annotation is not an option: K8up tokenises
+  # that string with qsplit, whose quotes neither nest nor escape.
+  - name: backup-script-cleanuparr
+    files:
+      - scripts/dump.py
+generatorOptions:
+  # Stable name. The script is read at exec time from the mounted ConfigMap, so
+  # a change reaches the next backup without rolling the pod.
+  disableNameSuffixHash: true

--- a/k8s/apps/vod-arr/cleanuparr/pvc-config.yaml
+++ b/k8s/apps/vod-arr/cleanuparr/pvc-config.yaml
@@ -1,6 +1,16 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  annotations:
+    # Opt in to K8up. The operator runs with skipWithoutAnnotation, so a claim
+    # without this is not backed up -- which is what keeps the six CNPG claims
+    # in this namespace out, since they self-backup via barman.
+    #
+    # Three live SQLite databases here -- cleanuparr.db, users.db and events.db,
+    # the last being 36M of the 40M volume -- so the file-level copies can tear.
+    # scripts/dump.py streams consistent copies of all three; that tar is what
+    # to restore from.
+    k8up.io/backup: "true"
   name: cleanuparr-config
 spec:
   accessModes:

--- a/k8s/apps/vod-arr/cleanuparr/scripts/dump.py
+++ b/k8s/apps/vod-arr/cleanuparr/scripts/dump.py
@@ -1,0 +1,53 @@
+"""Stream a consistent tar of cleanuparr's SQLite databases to stdout.
+
+Invoked by K8up via the k8up.io/backupcommand annotation. All three are live,
+so copying the files off a running volume can tear them. sqlite3's online
+backup API takes the read lock and hands back a coherent copy instead.
+
+events.db is by far the largest -- 36M of the 40M volume -- and is an action
+log rather than configuration. It is included anyway because it is cheap and
+excluding it would need a second decision about what a partial restore means.
+
+The image ships no sqlite3 binary. It does carry a python for apprise, whose
+stdlib sqlite3 is all this needs; the interpreter path is absolute because that
+venv is not on PATH for a non-login shell.
+
+Exiting non-zero fails the K8up Job, which is what K8upJobFailed alerts on.
+That is the point of doing this here rather than trusting the file-level copy:
+a broken dump is loud, where a torn database is silent until a restore.
+"""
+
+import io
+import sqlite3
+import sys
+import tarfile
+
+DATABASES = ("cleanuparr.db", "events.db", "users.db")
+CONFIG_DIR = "/config"
+
+
+def snapshot(name):
+    """Return a consistent copy of the named database as bytes."""
+    source = sqlite3.connect(f"file:{CONFIG_DIR}/{name}?mode=ro", uri=True)
+    try:
+        memory = sqlite3.connect(":memory:")
+        try:
+            source.backup(memory)
+            return memory.serialize()
+        finally:
+            memory.close()
+    finally:
+        source.close()
+
+
+def main():
+    with tarfile.open(fileobj=sys.stdout.buffer, mode="w|") as tar:
+        for name in DATABASES:
+            data = snapshot(name)
+            entry = tarfile.TarInfo(name)
+            entry.size = len(data)
+            tar.addfile(entry, io.BytesIO(data))
+            print(f"{name}: {len(data)} bytes", file=sys.stderr)
+
+
+main()

--- a/k8s/apps/vod-arr/kustomization.yaml
+++ b/k8s/apps/vod-arr/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
   - flaresolverr/
   - cleanuparr/
   - recyclarr/
+  - backup/

--- a/k8s/apps/vod-arr/qbittorrent/pvc-config.yaml
+++ b/k8s/apps/vod-arr/qbittorrent/pvc-config.yaml
@@ -1,6 +1,14 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  annotations:
+    # Opt in to K8up. The operator runs with skipWithoutAnnotation, so a claim
+    # without this is not backed up -- which is what keeps the six CNPG claims
+    # in this namespace out, since they self-backup via barman.
+    #
+    # No hook needed: /config/qBittorrent is JSON, .conf and the BT_backup
+    # fastresume files, with no database in it.
+    k8up.io/backup: "true"
   name: qbittorrent-config
 spec:
   accessModes:

--- a/k8s/apps/vod-arr/seerr/deployment.yaml
+++ b/k8s/apps/vod-arr/seerr/deployment.yaml
@@ -20,6 +20,12 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: seerr
+        # db/db.sqlite3 is live SQLite in WAL mode, so the file-level copy can
+        # tear. This streams a VACUUM INTO copy into the repository as its own
+        # snapshot; that is what to restore from, and the file-level copy stays
+        # as a fallback.
+        k8up.io/backupcommand: node /backup/dump.js
+        k8up.io/file-extension: .sqlite
       labels:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: seerr
@@ -67,6 +73,9 @@ spec:
           volumeMounts:
             - mountPath: /app/config
               name: config
+            - mountPath: /backup
+              name: backup-script
+              readOnly: true
       initContainers:
         # First-run only. The normal settings load merges this over the
         # defaults, so everything omitted stays UI-owned.
@@ -128,3 +137,6 @@ spec:
         - name: config
           persistentVolumeClaim:
             claimName: seerr-config
+        - name: backup-script
+          configMap:
+            name: backup-script-seerr

--- a/k8s/apps/vod-arr/seerr/kustomization.yaml
+++ b/k8s/apps/vod-arr/seerr/kustomization.yaml
@@ -7,3 +7,18 @@ resources:
   - pvc-config.yaml
   - service.yaml
   - slo-probe-success.yaml
+configMapGenerator:
+  # Named per app: cleanuparr and seerr both live in vod-arr, so a bare
+  # `backup-script` collides -- validate-configmaps catches it, same lesson as
+  # values-<release>.
+  #
+  # The dump script is a real file so it stays readable and lintable. Inlining
+  # it in the k8up.io/backupcommand annotation is not an option: K8up tokenises
+  # that string with qsplit, whose quotes neither nest nor escape.
+  - name: backup-script-seerr
+    files:
+      - scripts/dump.js
+generatorOptions:
+  # Stable name. The script is read at exec time from the mounted ConfigMap, so
+  # a change reaches the next backup without rolling the pod.
+  disableNameSuffixHash: true

--- a/k8s/apps/vod-arr/seerr/pvc-config.yaml
+++ b/k8s/apps/vod-arr/seerr/pvc-config.yaml
@@ -1,6 +1,15 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  annotations:
+    # Opt in to K8up. The operator runs with skipWithoutAnnotation, so a claim
+    # without this is not backed up -- which is what keeps the six CNPG claims
+    # in this namespace out, since they self-backup via barman.
+    #
+    # db/db.sqlite3 is live SQLite in WAL mode -- the -wal and -shm files are
+    # both present -- so the file-level copy can tear. scripts/dump.js streams a
+    # consistent copy; that is what to restore from.
+    k8up.io/backup: "true"
   name: seerr-config
 spec:
   accessModes:

--- a/k8s/apps/vod-arr/seerr/scripts/dump.js
+++ b/k8s/apps/vod-arr/seerr/scripts/dump.js
@@ -1,0 +1,57 @@
+// Stream a consistent copy of seerr's SQLite database to stdout.
+//
+// Invoked by K8up via the k8up.io/backupcommand annotation. db.sqlite3 runs in
+// WAL mode -- the -wal and -shm files are both present -- so copying it off a
+// running volume can tear it.
+//
+// VACUUM INTO rather than a driver-specific backup call: it is one SQL
+// statement, produces a coherent standalone database, and works through
+// whatever driver happens to be bundled. The image ships no sqlite3 binary and
+// carries node-sqlite3 rather than better-sqlite3, which has no serialize().
+// The require path is absolute because this script lives outside /app and node
+// resolves modules relative to the file.
+//
+// VACUUM INTO refuses to overwrite, hence the unlink first. The copy is written
+// to /tmp rather than the config volume so a backup never adds to what is being
+// backed up.
+//
+// Exiting non-zero fails the K8up Job, which is what K8upJobFailed alerts on.
+// That is the point of doing this here rather than trusting the file-level
+// copy: a broken dump is loud, where a torn database is silent until a restore.
+
+const sqlite3 = require("/app/node_modules/sqlite3");
+const fs = require("fs");
+
+const SOURCE = "/app/config/db/db.sqlite3";
+const TARGET = "/tmp/seerr-backup.sqlite";
+
+const fail = (what, err) => {
+  process.stderr.write(`${what}: ${err.message}\n`);
+  process.exit(1);
+};
+
+try {
+  fs.unlinkSync(TARGET);
+} catch (e) {
+  // absent is the normal case
+}
+
+const db = new sqlite3.Database(SOURCE, sqlite3.OPEN_READONLY, (err) => {
+  if (err) fail("open", err);
+  db.run("VACUUM INTO ?", [TARGET], (err2) => {
+    if (err2) fail("vacuum", err2);
+    process.stderr.write(`${SOURCE}: ${fs.statSync(TARGET).size} bytes\n`);
+    const stream = fs.createReadStream(TARGET);
+    stream.on("error", (e) => fail("read", e));
+    // Let the process end when the pipe drains rather than calling exit, which
+    // would risk truncating stdout mid-flush.
+    stream.on("close", () => {
+      try {
+        fs.unlinkSync(TARGET);
+      } catch (e) {
+        // the dump already succeeded; a stale temp file is not worth failing on
+      }
+    });
+    stream.pipe(process.stdout);
+  });
+});


### PR DESCRIPTION
Closes the last real gap found when auditing what actually reaches the NAS.

Four of the seven vod-arr configs already back themselves up — bazarr, prowlarr, radarr and sonarr write to the `backups` PVC on the NAS, freshest **Sep 6 22:18**. The other three had **no route to the NAS at all**, which matters now the off-site design is "everything to the NAS, NAS ships off-site": they would never have gone off-site either.

| claim | size | hook | why |
| --- | --- | --- | --- |
| `qbittorrent-config` | 8M | none | JSON, `.conf` and BT_backup fastresume — no database |
| `cleanuparr-config` | 40M | `dump.py` | three live SQLite DBs |
| `seerr-config` | 4.7M | `dump.js` | `db.sqlite3` in WAL mode |

## Both hooks verified against the running containers

**cleanuparr** — 466944 + 36732928 + 73728 bytes across `cleanuparr.db`, `events.db` and `users.db`, all three passing `PRAGMA integrity_check` after extraction. No `sqlite3` binary in the image, so it uses the python that ships for apprise; the interpreter path is absolute because that venv is not on `PATH`. `events.db` is 36M of the 40M volume and is an action log rather than config — included anyway, since excluding it would need a second decision about what a partial restore means.

**seerr** — 368640 bytes out, `integrity_check ok`, 50 tables, 28 media requests. `VACUUM INTO` rather than a driver-specific backup call: the image bundles `node-sqlite3`, not `better-sqlite3`, so there is no `serialize()`. The copy goes to `/tmp` so a backup never adds to the volume being backed up, and the process ends when the pipe drains rather than calling `exit`, which would risk truncating stdout mid-flush.

## One thing kustomize caught for me

Both apps are in `vod-arr`, so naming both ConfigMaps `backup-script` made the build fail outright — `may not add resource with an already registered id`. They are named per app now. In karakeep and mended-drum the namespaces differed, which is why it did not come up before; same lesson as `values-<release>`.

The six CNPG claims need no annotation to stay out — `skipWithoutAnnotation` means opting in is explicit.

## seerr's hook is deliberately temporary

Moving seerr onto CNPG postgres is the better answer and is filed separately — it would delete this hook, make seerr consistent with the three arrs already on CNPG, and get barman backups with PITR rather than a nightly dump. Seerr documents the SQLite→PostgreSQL path via pgloader.

Shipping the hook anyway because it is written and verified, the migration is a real piece of work that will not land today, and deleting one file plus four lines afterwards is cheaper than leaving a live WAL-mode database with only a possibly-torn file copy in the meantime.

`seerr-config` keeps its file-level backup either way — `settings.json` lives on that volume regardless of the database backend.

Refs #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)
