### PR TITLE
slo: one week is the window for all of them

### DIFF
--- a/k8s/apps/atuin/app/slo-availability.yaml
+++ b/k8s/apps/atuin/app/slo-availability.yaml
@@ -15,10 +15,15 @@ spec:
   # everything would report on kubelet reachability, which KubePodNotReady
   # already covers, and would drown the sync API at a ratio of 577:1.
   #
-  # What is left is thin and honestly so: ~30 requests a day, ~840 per window.
-  # A 4w availability figure over that is meaningful; a 5m burn rate over it is
-  # mostly noise. Whether that matters is exactly what the unrouted burn-in is
-  # for -- read it back with everything else around 2026-10-06.
+  # What is left is thin and honestly so: 242 requests over the last 5 days,
+  # so ~339 per 7d window. That is the thinnest denominator of any SLO here and
+  # the window change made it thinner -- at a 99% target the budget is 3.4
+  # requests, so a single 5xx spends 29% of a week's budget and four breach it.
+  # The window is still right: the alternative is a 4w figure that takes four
+  # times as long to say anything and still cannot survive four errors. What
+  # carries alerting for a service this quiet is atuin-probe-success, which is
+  # exercised every 30s regardless of whether anyone syncs. Read this one back
+  # as a trend, not as a gate.
   #
   # target is a PLACEHOLDER.
   description: >-
@@ -50,4 +55,4 @@ spec:
       total:
         metric: http_requests_total{job="atuin",path=~"/api/v0/.*"}
   target: "99"
-  window: 4w
+  window: 7d

--- a/k8s/apps/atuin/app/slo-latency.yaml
+++ b/k8s/apps/atuin/app/slo-latency.yaml
@@ -44,4 +44,4 @@ spec:
       total:
         metric: http_requests_duration_seconds_count{job="atuin",path=~"/api/v0/.*"}
   target: "99"
-  window: 4w
+  window: 7d

--- a/k8s/apps/atuin/app/slo-probe-success.yaml
+++ b/k8s/apps/atuin/app/slo-probe-success.yaml
@@ -33,4 +33,4 @@ spec:
     bool_gauge:
       metric: probe_success{instance=~"https://atuin\\.thaum\\.xyz(/.*)?"}
   target: "95.0"
-  window: 4w
+  window: 7d

--- a/k8s/apps/changedetection/proxy/slo-probe-success.yaml
+++ b/k8s/apps/changedetection/proxy/slo-probe-success.yaml
@@ -36,4 +36,4 @@ spec:
     bool_gauge:
       metric: probe_success{instance=~"https://change\\.krupa\\.net\\.pl(/.*)?"}
   target: "95.0"
-  window: 4w
+  window: 7d

--- a/k8s/apps/datalake-metrics/prometheus/slo-prometheus-notification-errors.yaml
+++ b/k8s/apps/datalake-metrics/prometheus/slo-prometheus-notification-errors.yaml
@@ -23,4 +23,4 @@ spec:
       total:
         metric: prometheus_notifications_sent_total{job="prometheus-k8s"}
   target: "99"
-  window: 2w
+  window: 7d

--- a/k8s/apps/datalake-metrics/prometheus/slo-prometheus-query-errors.yaml
+++ b/k8s/apps/datalake-metrics/prometheus/slo-prometheus-query-errors.yaml
@@ -25,4 +25,4 @@ spec:
       total:
         metric: prometheus_http_requests_total{job="prometheus-k8s",handler=~"/api/v1/query.*"}
   target: "95.0"
-  window: 4w
+  window: 7d

--- a/k8s/apps/datalake-metrics/prometheus/slo-prometheus-rule-evaluation-failures.yaml
+++ b/k8s/apps/datalake-metrics/prometheus/slo-prometheus-rule-evaluation-failures.yaml
@@ -23,4 +23,4 @@ spec:
       total:
         metric: prometheus_rule_evaluations_total{job="prometheus-k8s"}
   target: "99.99"
-  window: 2w
+  window: 7d

--- a/k8s/apps/datalake-metrics/prometheus/slo-prometheus-sd-kubernetes-errors.yaml
+++ b/k8s/apps/datalake-metrics/prometheus/slo-prometheus-sd-kubernetes-errors.yaml
@@ -23,4 +23,4 @@ spec:
       total:
         metric: prometheus_sd_kubernetes_http_request_total{job="prometheus-k8s"}
   target: "99"
-  window: 2w
+  window: 7d

--- a/k8s/apps/grafana/grafana/slo-probe-success.yaml
+++ b/k8s/apps/grafana/grafana/slo-probe-success.yaml
@@ -33,4 +33,4 @@ spec:
     bool_gauge:
       metric: probe_success{instance=~"https://grafana\\.krupa\\.net\\.pl(/.*)?"}
   target: "95.0"
-  window: 4w
+  window: 7d

--- a/k8s/apps/homer/app/slo-probe-success.yaml
+++ b/k8s/apps/homer/app/slo-probe-success.yaml
@@ -32,4 +32,4 @@ spec:
     bool_gauge:
       metric: probe_success{instance=~"https://ankhmorpork\\.thaum\\.xyz(/.*)?"}
   target: "95.0"
-  window: 4w
+  window: 7d

--- a/k8s/apps/karakeep/web/slo-probe-success.yaml
+++ b/k8s/apps/karakeep/web/slo-probe-success.yaml
@@ -31,4 +31,4 @@ spec:
     bool_gauge:
       metric: probe_success{instance=~"https://keep\\.krupa\\.net\\.pl(/.*)?"}
   target: "95.0"
-  window: 4w
+  window: 7d

--- a/k8s/apps/mealie/app/slo-probe-success.yaml
+++ b/k8s/apps/mealie/app/slo-probe-success.yaml
@@ -31,4 +31,4 @@ spec:
     bool_gauge:
       metric: probe_success{instance=~"https://recipes\\.krupa\\.net\\.pl(/.*)?"}
   target: "95.0"
-  window: 4w
+  window: 7d

--- a/k8s/apps/mended-drum/open-webui/slo-probe-success.yaml
+++ b/k8s/apps/mended-drum/open-webui/slo-probe-success.yaml
@@ -31,4 +31,4 @@ spec:
     bool_gauge:
       metric: probe_success{instance=~"https://drum\\.krupa\\.net\\.pl(/.*)?"}
   target: "95.0"
-  window: 4w
+  window: 7d

--- a/k8s/apps/mended-drum/tools/slo-probe-success.yaml
+++ b/k8s/apps/mended-drum/tools/slo-probe-success.yaml
@@ -31,4 +31,4 @@ spec:
     bool_gauge:
       metric: probe_success{instance=~"https://drum\\-tools\\.krupa\\.net\\.pl(/.*)?"}
   target: "95.0"
-  window: 4w
+  window: 7d

--- a/k8s/apps/paperless/manifests/app/slo-probe-success.yaml
+++ b/k8s/apps/paperless/manifests/app/slo-probe-success.yaml
@@ -34,4 +34,4 @@ spec:
     bool_gauge:
       metric: probe_success{instance=~"https://papers\\.krupa\\.net\\.pl(/.*)?"}
   target: "95.0"
-  window: 4w
+  window: 7d

--- a/k8s/apps/photos/app/slo-probe-success.yaml
+++ b/k8s/apps/photos/app/slo-probe-success.yaml
@@ -33,4 +33,4 @@ spec:
     bool_gauge:
       metric: probe_success{instance=~"https://photos\\.krupa\\.net\\.pl(/.*)?"}
   target: "95.0"
-  window: 4w
+  window: 7d

--- a/k8s/apps/plex/app/slo-probe-success.yaml
+++ b/k8s/apps/plex/app/slo-probe-success.yaml
@@ -31,4 +31,4 @@ spec:
     bool_gauge:
       metric: probe_success{instance=~"https://vod\\.krupa\\.net\\.pl(/.*)?"}
   target: "95.0"
-  window: 4w
+  window: 7d

--- a/k8s/apps/pocket-id/app/slo-availability.yaml
+++ b/k8s/apps/pocket-id/app/slo-availability.yaml
@@ -11,8 +11,12 @@ spec:
   #
   # target is a PLACEHOLDER. Prometheus holds days, not weeks, so no number here
   # is grounded yet. The burn alerts fire anyway, at info/none, so they land in
-  # ALERTS without routing anywhere -- that is how we find out whether these
-  # windows are noisy at 4 requests a minute before anyone lets them page.
+  # ALERTS without routing anywhere -- that is how we find out whether the
+  # windows are noisy before anyone lets them page. On a 7d window the fastest
+  # tier is 1m/15m, and this SLI serves ~4.2 requests a minute, so the short
+  # window holds about four samples: at 99% one 5xx does not fire (the 15m
+  # window sees 1.7% against a 14% threshold) and at 99.9% it does. That
+  # threshold, not the window, is the thing to pick carefully.
   # Revisit the target, and the severities, from 2026-10-06.
   #
   # Read the denominator before trusting a ratio over it: essentially all of
@@ -51,4 +55,4 @@ spec:
       total:
         metric: http_server_request_duration_seconds_count{job="pocket-id/pocket-id"}
   target: "99"
-  window: 4w
+  window: 7d

--- a/k8s/apps/pocket-id/app/slo-latency.yaml
+++ b/k8s/apps/pocket-id/app/slo-latency.yaml
@@ -35,4 +35,4 @@ spec:
       total:
         metric: http_server_request_duration_seconds_count{job="pocket-id/pocket-id"}
   target: "99"
-  window: 4w
+  window: 7d

--- a/k8s/apps/pocket-id/app/slo-probe-success.yaml
+++ b/k8s/apps/pocket-id/app/slo-probe-success.yaml
@@ -33,4 +33,4 @@ spec:
     bool_gauge:
       metric: probe_success{instance=~"https://login\\.krupa\\.net\\.pl(/.*)?"}
   target: "95.0"
-  window: 4w
+  window: 7d

--- a/k8s/apps/stirling-pdf/slo-probe-success.yaml
+++ b/k8s/apps/stirling-pdf/slo-probe-success.yaml
@@ -31,4 +31,4 @@ spec:
     bool_gauge:
       metric: probe_success{instance=~"https://pdf\\.krupa\\.net\\.pl(/.*)?"}
   target: "95.0"
-  window: 4w
+  window: 7d

--- a/k8s/apps/vod-arr/seerr/slo-probe-success.yaml
+++ b/k8s/apps/vod-arr/seerr/slo-probe-success.yaml
@@ -31,4 +31,4 @@ spec:
     bool_gauge:
       metric: probe_success{instance=~"https://seek\\.krupa\\.net\\.pl(/.*)?"}
   target: "95.0"
-  window: 4w
+  window: 7d

--- a/k8s/platform/observability/kube-prometheus-stack/slo-apiserver-read-cluster-latency.yaml
+++ b/k8s/platform/observability/kube-prometheus-stack/slo-apiserver-read-cluster-latency.yaml
@@ -34,4 +34,4 @@ spec:
       total:
         metric: apiserver_request_sli_duration_seconds_count{component="apiserver",scope=~"cluster|",verb=~"LIST|GET"}
   target: "99"
-  window: 2w
+  window: 7d

--- a/k8s/platform/observability/kube-prometheus-stack/slo-apiserver-read-namespace-latency.yaml
+++ b/k8s/platform/observability/kube-prometheus-stack/slo-apiserver-read-namespace-latency.yaml
@@ -34,4 +34,4 @@ spec:
       total:
         metric: apiserver_request_sli_duration_seconds_count{component="apiserver",scope=~"namespace|",verb=~"LIST|GET"}
   target: "99"
-  window: 2w
+  window: 7d

--- a/k8s/platform/observability/kube-prometheus-stack/slo-apiserver-read-resource-latency.yaml
+++ b/k8s/platform/observability/kube-prometheus-stack/slo-apiserver-read-resource-latency.yaml
@@ -34,4 +34,4 @@ spec:
       total:
         metric: apiserver_request_sli_duration_seconds_count{component="apiserver",scope=~"resource|",verb=~"LIST|GET"}
   target: "99"
-  window: 2w
+  window: 7d

--- a/k8s/platform/observability/kube-prometheus-stack/slo-apiserver-read-response-errors.yaml
+++ b/k8s/platform/observability/kube-prometheus-stack/slo-apiserver-read-response-errors.yaml
@@ -23,4 +23,4 @@ spec:
       total:
         metric: apiserver_request_total{component="apiserver",verb=~"LIST|GET"}
   target: "99"
-  window: 2w
+  window: 7d

--- a/k8s/platform/observability/kube-prometheus-stack/slo-apiserver-write-response-errors.yaml
+++ b/k8s/platform/observability/kube-prometheus-stack/slo-apiserver-write-response-errors.yaml
@@ -23,4 +23,4 @@ spec:
       total:
         metric: apiserver_request_total{component="apiserver",verb=~"POST|PUT|PATCH|DELETE"}
   target: "99"
-  window: 2w
+  window: 7d

--- a/k8s/platform/observability/kube-prometheus-stack/slo-coredns-response-errors.yaml
+++ b/k8s/platform/observability/kube-prometheus-stack/slo-coredns-response-errors.yaml
@@ -23,4 +23,4 @@ spec:
       total:
         metric: coredns_dns_responses_total{job="coredns"}
   target: "99.9"
-  window: 2w
+  window: 7d

--- a/k8s/platform/observability/kube-prometheus-stack/slo-kubelet-request-errors.yaml
+++ b/k8s/platform/observability/kube-prometheus-stack/slo-kubelet-request-errors.yaml
@@ -23,4 +23,4 @@ spec:
       total:
         metric: rest_client_requests_total{job="kubelet"}
   target: "99"
-  window: 2w
+  window: 7d

--- a/k8s/platform/observability/kube-prometheus-stack/slo-kubelet-runtime-errors.yaml
+++ b/k8s/platform/observability/kube-prometheus-stack/slo-kubelet-runtime-errors.yaml
@@ -23,4 +23,4 @@ spec:
       total:
         metric: kubelet_runtime_operations_total{job="kubelet"}
   target: "99"
-  window: 2w
+  window: 7d

--- a/k8s/platform/observability/kube-prometheus-stack/slo-prometheus-operator-http-errors.yaml
+++ b/k8s/platform/observability/kube-prometheus-stack/slo-prometheus-operator-http-errors.yaml
@@ -23,4 +23,4 @@ spec:
       total:
         metric: prometheus_operator_kubernetes_client_http_requests_total{job="kube-prometheus-stack-operator"}
   target: "99.5"
-  window: 2w
+  window: 7d

--- a/k8s/platform/observability/kube-prometheus-stack/slo-prometheus-operator-reconcile-errors.yaml
+++ b/k8s/platform/observability/kube-prometheus-stack/slo-prometheus-operator-reconcile-errors.yaml
@@ -25,4 +25,4 @@ spec:
       total:
         metric: prometheus_operator_reconcile_operations_total{job="kube-prometheus-stack-operator"}
   target: "95"
-  window: 2w
+  window: 7d


### PR DESCRIPTION
All 33 objectives move to `window: 7d`. 32 files change; `external-probe-success` was already 7d.

Every window was inherited rather than chosen — 4w from the shared blackbox SLO that #1336 decomposed, 2w from the kubernetes-mixin definitions 6a took over.

### Why

A 4w window cannot say anything for four weeks, and six probes only started measuring the right thing on 09-06, so they hold under a day each. 7d gives every objective a complete window about a week from now, and four a month instead of one. It is also a target a single week can falsify: the 6.5-minute migration outage on 09-06 is **16%** of a 99.9%/4w budget and **65%** of a 99.9%/7d one.

### This changes the alert tiers, not just the denominator

Pyrra derives the burn-rate windows from the SLO window:

| window | fast | | | slow |
|---|---|---|---|---|
| 4w | `5m/1h` | `30m/6h` | `2h/1d` | `6h/4d` |
| 2w | `3m/30m` | `15m/3h` | `1h/12h` | `3h/2d` |
| **7d** | **`1m/15m`** | `8m/1h30m` | `30m/6h` | `1h30m/1d` |

The interaction worth knowing is at the fast end. Both windows must exceed `14 * (1 - target)`, and the short one is now 1m — two samples at a 30s probe interval:

| target | 1m window | 15m window | fires? |
|---|---|---|---|
| 95% | 0.50 vs 0.70 | — | no |
| 99% | 0.50 vs 0.14 ✓ | 0.033 vs 0.14 | **no** |
| 99.9% | 0.50 vs 0.014 ✓ | 0.033 vs 0.014 ✓ | **yes** |

So 99.9%/7d alerts on a single failed probe. That is internally consistent — it is a ten-minute weekly budget — but it means choosing 99.9% is choosing to alert on 30-second blips, of which there were four in the last 5.4 days. Relevant when 6c.3 picks the real targets.

### Denominators checked against live 7d data, not assumed

| SLI | requests / 7d |
|---|---|
| apiserver | 31.7M |
| kubelet runtime ops | 20M |
| prometheus rule evals | 25M |
| coredns | 12.7M |
| prometheus notifications | 1.4M |
| prom-operator k8s client | 53.3k |
| prometheus k8s SD events | 39.2k |
| pocket-id | 42k (~4.2/min) |
| **atuin** | **~339** |

Only atuin is thin — one 5xx spends 29% of a 99% budget. Its comment now says so, and says that `atuin-probe-success` is what carries alerting for a service that quiet. pocket-id's comment gained the concrete 1m/15m arithmetic above.

**All 33 currently pass their placeholder targets against 7d of data**, including the three tighter ones: coredns 99.9991% against 99.9%, rule evaluations 99.9997% against 99.99%, operator client 100% against 99.5%.

### No history lost

Recording rules rename from `:count4w`/`:count2w` to `:count1w`, but they compute over raw data, so the achieved ratio is available immediately over as much of the 7d as exists. The burn-in is read back through the `slo` label on `ALERTS`, which does not change.

### Verified

- `make validate` — 123 targets render and validate cleanly
- `make prometheusrules` — pint lint clean over 72 rule entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)