### PR TITLE
slo: two consistency fixes before the targets are set

### DIFF
--- a/k8s/apps/ai-gateway/app/slo-probe-success.yaml
+++ b/k8s/apps/ai-gateway/app/slo-probe-success.yaml
@@ -15,8 +15,8 @@ spec:
   #
   # target is a PLACEHOLDER. Unlike the other probe SLOs it is not even carried
   # over from the shared objective -- ai-gateway was never in it, so there is no
-  # history behind this number at all. Set it from data once the probe has run
-  # a few weeks.
+  # history behind this number at all. Set it with the other 33 once this probe
+  # has a full 7d window behind it.
   description: >-
     Fraction of successful blackbox probes against ai-gateway.krupa.net.pl.
   alerting:
@@ -32,4 +32,4 @@ spec:
     bool_gauge:
       metric: probe_success{instance=~"https://ai-gateway\\.krupa\\.net\\.pl(/.*)?"}
   target: "95.0"
-  window: 4w
+  window: 7d

--- a/k8s/platform/observability/blackbox-exporter/exporter/slo-external-probe-success.yaml
+++ b/k8s/platform/observability/blackbox-exporter/exporter/slo-external-probe-success.yaml
@@ -9,9 +9,18 @@ spec:
   # operator here can commit to, which is the whole reason they are not in the
   # objective next door.
   #
-  # Selecting on environment!="ankhmorpork" rather than naming the two hosts, so
-  # a new external probe joins this SLO by default rather than silently
-  # inflating the one for services we actually serve.
+  # Selecting on environment rather than naming the two hosts, so a new external
+  # probe joins this SLO by default rather than silently inflating the one for
+  # services we actually serve.
+  #
+  # environment!="" is load-bearing, not belt-and-braces. A negative matcher
+  # alone fails open: it matches series that carry no environment label at all,
+  # and every probe series written before #1326 added that label is one of
+  # those. They stop being written but stay inside the 7d lookback, so this SLO
+  # was computing over 20 series -- the 2 real ones and 18 stale internal ones,
+  # dragging keep's achieved figure to 97.5% under an objective that should
+  # never have seen it. Requiring the label present keeps the "joins by default"
+  # property and excludes anything unlabelled.
   #
   # target is a PLACEHOLDER carried over unchanged. When the numbers are set
   # around 2026-10-06 this one should end up looser than its neighbour, not
@@ -33,6 +42,6 @@ spec:
     bool_gauge:
       grouping:
         - instance
-      metric: probe_success{environment!="ankhmorpork"}
+      metric: probe_success{environment!="ankhmorpork", environment!=""}
   target: "95.0"
   window: 7d


### PR DESCRIPTION
Two one-line fixes, both things that would have been read as real signal in October.

### 1. ai-gateway was the only objective left on a 4w window

#1369 moved all 33 objectives to `window: 7d`. ai-gateway's landed in parallel from #1337 carrying the template's 4w default, so the live rules show exactly one straggler:

```
recording-rule window suffixes: {'4w': 2, '1w': 30}
4w tier: AiGatewayProbeBudgetBurn  5m/1h, 2h/1d, 6h/4d
```

Left alone it reads as a deliberate exception rather than a merge-ordering artifact, and its slowest tier would need four days of sustained failure where every other service needs one.

### 2. `external-probe-success` was matching 18 series it should never see

Its selector is `environment!="ankhmorpork"`, intended so a new external probe joins by default. **A negative matcher alone fails open** — it also matches series with no `environment` label at all, and every probe series written before #1326 added that label is one of those. They stop being written but stay inside the 7d lookback.

Counted live:

| selector | avs | lancre | unlabelled |
|---|---|---|---|
| `environment!="ankhmorpork"` | 1 | 1 | **18** |
| `environment!="ankhmorpork", environment!=""` | 1 | 1 | 0 |

It was reporting `keep.krupa.net.pl/api/health` at **97.5% achieved** under an objective for endpoints this cluster does not run. Requiring the label to be present keeps the "joins by default" property and excludes anything unlabelled.

This would have self-healed on **2026-09-13**, when #1326 falls out of the 7d window — which is exactly when the targets are due to be set from these numbers. At the old 4w window it would have persisted into October.

Same class as the burn-rate warm-up artifact found while answering whether 7d makes alerts noisier: a label change does not only create new series, it leaves the old ones lying inside every lookback window that selects them by negation.

`make validate` — 124 targets render and validate cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)