### PR TITLE
piraeus: exclude master01 by name from every Piraeus workload

### DIFF
--- a/k8s/platform/storage/piraeus-datastore/cluster/values.yaml
+++ b/k8s/platform/storage/piraeus-datastore/cluster/values.yaml
@@ -1,19 +1,32 @@
 # Config reference: https://github.com/piraeusdatastore/helm-charts/blob/main/charts/linstor-cluster/values.yaml
 
 linstorCluster:
+  # A node has to match both nodeSelector and nodeAffinity to run any Piraeus
+  # component. The operator applies them to the satellite, CSI node plugin and
+  # HA controller DaemonSets and to the controller Deployments alike, and a node
+  # they exclude also cannot run a Pod that mounts a Piraeus volume.
   nodeSelector:
     linstor: "true"
-  # Only nodes with one of the existing TopoLVM thin pools can host a local
-  # replica. This also prevents Piraeus volumes from scheduling onto a node
-  # where the CSI node and LINSTOR satellite are absent.
   nodeAffinity:
     nodeSelectorTerms:
+      # Expressions inside one term are ANDed; a second term would be an OR.
       - matchExpressions:
+          # Only nodes with one of the existing TopoLVM thin pools can host a
+          # local replica. This also prevents Piraeus volumes from scheduling
+          # onto a node where the CSI node and LINSTOR satellite are absent.
           - key: devices.topolvm.io/vg
             operator: In
             values:
               - secondary-vg
               - ubuntu-vg
+          # master01 has Secure Boot issues that stop the DRBD kernel module
+          # from loading, so a satellite there cannot work. It has a
+          # secondary-vg and would otherwise qualify, so it is excluded by
+          # name instead of relying on the absence of the linstor label.
+          - key: kubernetes.io/hostname
+            operator: NotIn
+            values:
+              - master01
   tolerations:
     - key: node-role.kubernetes.io/control-plane
       operator: Exists

--- a/k8s/platform/storage/piraeus-datastore/operator/values.yaml
+++ b/k8s/platform/storage/piraeus-datastore/operator/values.yaml
@@ -13,6 +13,18 @@ priorityClassName: system-cluster-critical
 nodeSelector:
   linstor: "true"
 
+# Same exclusion as linstorCluster.nodeAffinity in ../cluster/values.yaml: the
+# operator itself needs no DRBD, but nothing of Piraeus should land on master01.
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: NotIn
+              values:
+                - master01
+
 # A single operator replica does not benefit from a PDB and minAvailable: 1
 # would prevent voluntary eviction during a node drain.
 podDisruptionBudget:


### PR DESCRIPTION
## Why

\`master01\` cannot run a LINSTOR satellite (Secure Boot stops the DRBD module from loading, see b27f651d). Today the only thing keeping Piraeus off it is that the node has **no** \`linstor: "true"\` label. That is an absence, recorded nowhere in Git, and the node does carry \`devices.topolvm.io/vg: secondary-vg\`, so it passes the existing nodeAffinity. One stray label would land a satellite, the CSI node plugin and the HA controller on it.

## What

- \`cluster/values.yaml\`: add \`kubernetes.io/hostname NotIn [master01]\` to the **same** nodeAffinity term as the VG check (ANDed). Per the upstream LinstorCluster reference, nodeSelector and nodeAffinity both have to match for a node to run Piraeus, and a node they exclude also cannot run a Pod that mounts a Piraeus volume.
- \`operator/values.yaml\`: the same rule through the chart's \`affinity\` value, so the operator follows the same policy.
- The \`linstor\` label selector stays as a second guard.
- The GUI Deployment carries no placement rules and is left alone; it handles no data.

## Verification

- \`make validate\` clean.
- \`flux-build\` render: the LinstorCluster carries both expressions in one term; the operator Deployment carries the affinity.
- Evaluated against live node labels: beelink01, beelink02, master02 still match; master01 does not, and would not even with \`linstor=true\` added.

## Rollout

No placement change on the live cluster. Pod templates of \`linstor-csi-node\`, \`ha-controller\` and the three controller Deployments gain the expression and roll once; satellite DaemonSets pin by node name and are untouched, so DRBD is not disturbed.

\`\`\`bash
flux reconcile source git ankhmorpork
flux -n flux-system reconcile kustomization piraeus-datastore
flux -n platform-storage reconcile helmrelease piraeus-operator
flux -n platform-storage reconcile helmrelease linstor-cluster
\`\`\`

Hold the rollout until \`master02\` has dropped its \`drbd.linbit.com/lost-quorum\` taint (present since the 2026-09-07 09:07Z reboot).

## Follow-up

#1372 adds \`docs/reference/hardware.md\`, whose nodes section explains master01 by the missing label. Once both are in, that sentence should say the node is excluded by name in the LinstorCluster nodeAffinity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)