### PR TITLE
Gate kured reboots on cluster health, and drain softly

### DIFF
--- a/k8s/platform/cluster/descheduler/values.yaml
+++ b/k8s/platform/cluster/descheduler/values.yaml
@@ -20,20 +20,55 @@ serviceMonitor:
 # including LowNodeUtilization and RemoveDuplicates, which rebalance by evicting
 # and would churn pods across the four nodes.
 #
-# No node carries a taint today, so this evicts nothing. It is here for
-# NoSchedule taints: those stop new pods but leave running ones, and this is
-# what migrates them off.
+# This is the soft-drain half of the kured reboot pipeline. kured taints a node
+# `thaum.xyz/kured-node-reboot:PreferNoSchedule` as soon as it wants a reboot
+# but finds the lock held; this plugin then walks the movable pods off it while
+# it waits, so the real drain has less to do and less to time out on. It also
+# still serves its original purpose: NoSchedule taints such as
+# `drbd.linbit.com/lost-quorum` stop new pods but leave running ones, and this
+# is what migrates them off.
 deschedulerPolicyAPIVersion: descheduler/v1alpha2
 deschedulerPolicy:
+  # Bound the churn. Without these, tainting three nodes at once (all four
+  # wanting a reboot in the same window) lets one pass evict most of the
+  # cluster. Two pods per node per run at a 5m interval is a trickle that
+  # still empties a node well inside kured's 1h lockReleaseDelay.
+  maxNoOfPodsToEvictPerNode: 2
+  maxNoOfPodsToEvictTotal: 6
   profiles:
     - name: default
       pluginConfig:
         - name: DefaultEvictor
           args:
+            # Only evict a pod that can actually be scheduled somewhere else.
+            # Mandatory once PreferNoSchedule is in scope: a soft taint does
+            # not stop placement, so without nodeFit the descheduler would
+            # happily evict a pod and let the scheduler put it straight back
+            # on the same node, or leave it Pending when every node is
+            # tainted.
+            nodeFit: true
             podProtections:
               extraEnabled:
                 - PodsWithPVC
+              config:
+                # Narrowed from "every pod with a PVC". Protecting all of them
+                # made the soft drain a no-op for the 27 pods on roaming
+                # Piraeus or NFS volumes, which follow their pod to any node.
+                # What genuinely cannot move is node-local storage:
+                #   lvm-thin   topolvm, pinned to one node's VG -- this is
+                #              where all 11 CNPG clusters live
+                #   piraeus-r2 two DRBD replicas, no diskless attach
+                # Those stay protected; the databases are moved by CNPG's own
+                # switchover during the drain, not by eviction.
+                PodsWithPVC:
+                  protectedStorageClasses:
+                    - name: lvm-thin
+                    - name: piraeus-r2
         - name: RemovePodsViolatingNodeTaints
+          args:
+            # Act on kured's PreferNoSchedule reboot taint, not just on
+            # NoSchedule. This is what makes the soft drain happen.
+            includePreferNoSchedule: true
       plugins:
         deschedule:
           enabled:

--- a/k8s/platform/cluster/system-kured/prometheus-rules.yaml
+++ b/k8s/platform/cluster/system-kured/prometheus-rules.yaml
@@ -10,48 +10,6 @@ spec:
           expr: |
             sum_over_time(kured_reboot_required[1d])
 
-        # --- Drain gates ---------------------------------------------------
-        # The two `info` alerts below exist to be read by kured, not by a
-        # human: they are named in `alertFilterRegexp` in values.yaml, and
-        # while either is firing kured refuses to cordon anything. `info`
-        # routes to the null receiver, so neither opens a GitHub issue.
-        # Editing one changes reboot behaviour -- keep it in step with the
-        # regexp.
-
-        # A node that has been unschedulable for 45m is not one kured is
-        # mid-cycle on: a healthy cordon+drain+reboot+uncordon takes ~25m at
-        # the current drainTimeout. So this means a manual cordon or a drain
-        # that gave up, and in either case the cluster is already a node down
-        # -- which is how the 2026-09-07 cascade started.
-        - alert: NodeUnschedulable
-          annotations:
-            description: Node {{ $labels.node }} has been unschedulable for over 45m, so the cluster is effectively a node short. kured will not begin draining any other node until this clears.
-            summary: Node has been cordoned for longer than a reboot cycle.
-          expr: |
-            kube_node_spec_unschedulable == 1
-          for: 45m
-          labels:
-            severity: info
-
-        # Every CNPG cluster carries a `<name>-primary` PDB with
-        # disruptionsAllowed permanently 0; draining the primary's node only
-        # works because the operator switches over first, and it can only do
-        # that to a ready, streaming replica. With no streaming replica the
-        # PDB blocks the eviction for as long as the drain is allowed to run.
-        # The CNPG* alerts shipped by the chart cover backups and replication
-        # lag, not this, and the chart is vendored -- hence the rule lives
-        # here, next to the gate that consumes it.
-        - alert: CNPGClusterNoStreamingReplica
-          annotations:
-            description: The postgres primary of {{ $labels.namespace }}/{{ $labels.job }} has no streaming replica, so it cannot be switched over and its PDB will block a drain of whichever node it runs on.
-            summary: CNPG cluster has no replica to switch over to.
-          expr: |
-            max by (namespace, job) (cnpg_pg_replication_streaming_replicas) == 0
-          for: 5m
-          labels:
-            severity: info
-
-        # --- Backstops -----------------------------------------------------
         - alert: KuredDrainFailure
           annotations:
             description: Kured on cluster {{ $labels.cluster }} left node {{ $labels.node }} in unschedulable state for more than 24h. This most likely indicates failed node drain and requires manual intervention.
@@ -63,9 +21,11 @@ spec:
           for: 24h
           labels:
             severity: warning
-        # Also the backstop for the drain gates above: a gate that stays shut
-        # -- a chronic drbd alert, an unreachable Prometheus -- shows up as a
-        # node whose reboot never happens, and nothing else will say so.
+
+        # Also the backstop for the reboot gate in values.yaml: a gate that
+        # stays shut -- a chronic drbd alert, an unreachable Prometheus -- shows
+        # up as a node whose reboot never happens. kured 1.23.0 exposes no
+        # metric for a blocked reboot, so nothing else will say so.
         - alert: KuredRebootRequired
           annotations:
             description: Node {{ $labels.node }} has been waiting for a kured reboot for over a week, which spans several reboot windows.

--- a/k8s/platform/cluster/system-kured/prometheus-rules.yaml
+++ b/k8s/platform/cluster/system-kured/prometheus-rules.yaml
@@ -9,6 +9,49 @@ spec:
         - record: :kured_reboot_required:sum_over_time1d
           expr: |
             sum_over_time(kured_reboot_required[1d])
+
+        # --- Drain gates ---------------------------------------------------
+        # The two `info` alerts below exist to be read by kured, not by a
+        # human: they are named in `alertFilterRegexp` in values.yaml, and
+        # while either is firing kured refuses to cordon anything. `info`
+        # routes to the null receiver, so neither opens a GitHub issue.
+        # Editing one changes reboot behaviour -- keep it in step with the
+        # regexp.
+
+        # A node that has been unschedulable for 45m is not one kured is
+        # mid-cycle on: a healthy cordon+drain+reboot+uncordon takes ~25m at
+        # the current drainTimeout. So this means a manual cordon or a drain
+        # that gave up, and in either case the cluster is already a node down
+        # -- which is how the 2026-09-07 cascade started.
+        - alert: NodeUnschedulable
+          annotations:
+            description: Node {{ $labels.node }} has been unschedulable for over 45m, so the cluster is effectively a node short. kured will not begin draining any other node until this clears.
+            summary: Node has been cordoned for longer than a reboot cycle.
+          expr: |
+            kube_node_spec_unschedulable == 1
+          for: 45m
+          labels:
+            severity: info
+
+        # Every CNPG cluster carries a `<name>-primary` PDB with
+        # disruptionsAllowed permanently 0; draining the primary's node only
+        # works because the operator switches over first, and it can only do
+        # that to a ready, streaming replica. With no streaming replica the
+        # PDB blocks the eviction for as long as the drain is allowed to run.
+        # The CNPG* alerts shipped by the chart cover backups and replication
+        # lag, not this, and the chart is vendored -- hence the rule lives
+        # here, next to the gate that consumes it.
+        - alert: CNPGClusterNoStreamingReplica
+          annotations:
+            description: The postgres primary of {{ $labels.namespace }}/{{ $labels.job }} has no streaming replica, so it cannot be switched over and its PDB will block a drain of whichever node it runs on.
+            summary: CNPG cluster has no replica to switch over to.
+          expr: |
+            max by (namespace, job) (cnpg_pg_replication_streaming_replicas) == 0
+          for: 5m
+          labels:
+            severity: info
+
+        # --- Backstops -----------------------------------------------------
         - alert: KuredDrainFailure
           annotations:
             description: Kured on cluster {{ $labels.cluster }} left node {{ $labels.node }} in unschedulable state for more than 24h. This most likely indicates failed node drain and requires manual intervention.
@@ -20,6 +63,9 @@ spec:
           for: 24h
           labels:
             severity: warning
+        # Also the backstop for the drain gates above: a gate that stays shut
+        # -- a chronic drbd alert, an unreachable Prometheus -- shows up as a
+        # node whose reboot never happens, and nothing else will say so.
         - alert: KuredRebootRequired
           annotations:
             description: Node {{ $labels.node }} has been waiting for a kured reboot for over a week, which spans several reboot windows.

--- a/k8s/platform/cluster/system-kured/values.yaml
+++ b/k8s/platform/cluster/system-kured/values.yaml
@@ -3,15 +3,75 @@
 configuration:
   annotateNodes: true
   concurrency: 1
-  # Abort drain after this time
-  drainTimeout: "2h"
-  period: "2h"
+
+  # --- Reboot window ---------------------------------------------------------
   rebootDays:
   - mo
   - we
   - th
   startTime: "07:00:00"
   endTime: "12:00:00"
+  # Poll every 20m, not 2h. `period` is not just the sentinel check -- it is
+  # also the retry interval for a node that found the lock held or found the
+  # cluster unhealthy. At 2h a node that lost one race sat out the rest of the
+  # window, so a 5h window fitted two nodes instead of four. 20m also caps
+  # failed-drain churn at one attempt per 40m (drainTimeout + period).
+  period: "20m"
+
+  # --- Drain -----------------------------------------------------------------
+  # 20m, not 2h. A drain that has not finished in 20m is PDB-blocked and is not
+  # going to finish: every CNPG cluster carries a `<name>-primary` PDB whose
+  # disruptionsAllowed is permanently 0, and it only clears when the operator
+  # switches the primary away -- which it cannot do when the only replica sits
+  # on a node that is itself cordoned. Timing out is cheap: forceReboot is
+  # false, so kured releases the lock and best-effort uncordons, then retries
+  # next period. Two hours of that is what turned one bad drain into a
+  # cluster-wide outage.
+  drainTimeout: "20m"
+  # Stop waiting on pods that have been Terminating for over a minute. A DRBD
+  # volume that will not detach otherwise holds the whole drain open.
+  skipWaitForDeleteTimeout: "60"
+
+  # --- Soft drain ------------------------------------------------------------
+  # Applied to a node the moment it wants a reboot but finds the lock held, and
+  # removed once its reboot is done or the window closes. Two effects: the node
+  # stops attracting pods evicted from the node currently rebooting, and the
+  # descheduler moves what it can off the node ahead of time (see
+  # RemovePodsViolatingNodeTaints / includePreferNoSchedule in
+  # k8s/platform/cluster/descheduler/values.yaml). By the time the lock comes
+  # free, the real drain has much less left to do.
+  preferNoScheduleTaint: "thaum.xyz/kured-node-reboot"
+
+  # --- Safety gate -----------------------------------------------------------
+  # Do not start a reboot while the cluster is already short a node. kured
+  # queries `ALERTS` here and refuses to cordon while any active alert matches.
+  #
+  # alertFilterMatchOnly inverts the regexp from a mute-list into an allow-list
+  # of blockers: ONLY these alerts block, everything else is ignored. Without
+  # it the regexp means the opposite and every unrelated alert would stop
+  # reboots. alertFiringOnly ignores `pending`.
+  #
+  # The list is exactly "reasons a drain cannot succeed":
+  #   KubeNode{NotReady,Unreachable,ReadinessFlapping} -- a node is down
+  #   NodeUnschedulable                -- a node is cordoned (manually, or by a
+  #                                       drain that got stuck); this is the
+  #                                       one that would have stopped the
+  #                                       2026-09-07 cascade
+  #   CNPGClusterNoStreamingReplica    -- a postgres primary has nowhere to
+  #                                       switch over to, so its PDB will
+  #                                       block the drain forever
+  #   drbd*                            -- Piraeus replicas are resyncing or
+  #                                       short of quorum
+  #
+  # Fail-safe by design: if this Prometheus is unreachable, kured treats that
+  # as blocked and reboots nothing. KuredRebootRequired is the backstop that
+  # tells you the gate has been closed too long.
+  prometheusUrl: "http://prometheus-k8s.datalake-metrics.svc.cluster.local:9090"
+  alertFilterRegexp: "^(KubeNodeNotReady|KubeNodeUnreachable|KubeNodeReadinessFlapping|NodeUnschedulable|CNPGClusterNoStreamingReplica|drbd.+)$"
+  alertFilterMatchOnly: true
+  alertFiringOnly: true
+
+  # --- Pacing ----------------------------------------------------------------
   lockReleaseDelay: "1h"
   # Without a TTL an interrupted holder strands the lock forever -- restarting
   # the daemonset mid-reboot does exactly that, since the release delay is

--- a/k8s/platform/cluster/system-kured/values.yaml
+++ b/k8s/platform/cluster/system-kured/values.yaml
@@ -51,17 +51,23 @@ configuration:
   # it the regexp means the opposite and every unrelated alert would stop
   # reboots. alertFiringOnly ignores `pending`.
   #
-  # The list is exactly "reasons a drain cannot succeed":
-  #   KubeNode{NotReady,Unreachable,ReadinessFlapping} -- a node is down
-  #   NodeUnschedulable                -- a node is cordoned (manually, or by a
-  #                                       drain that got stuck); this is the
-  #                                       one that would have stopped the
-  #                                       2026-09-07 cascade
-  #   CNPGClusterNoStreamingReplica    -- a postgres primary has nowhere to
-  #                                       switch over to, so its PDB will
-  #                                       block the drain forever
-  #   drbd*                            -- Piraeus replicas are resyncing or
-  #                                       short of quorum
+  # The list is exactly "reasons a drain cannot succeed". It matches on alert
+  # NAMES as plain strings, so renaming one of these rules silently opens the
+  # gate -- nothing fails, kured just stops checking. Each name and where it
+  # is defined:
+  #   KubeNode{NotReady,Unreachable,ReadinessFlapping}
+  #                    kubernetes-mixin; a node is down or flapping
+  #   NodeUnschedulable
+  #                    k8s/platform/observability/kube-prometheus-stack/
+  #                    prometheusrule-workloads.yaml -- a node is cordoned
+  #                    (manually, or by a drain that got stuck); this is the
+  #                    one that would have stopped the 2026-09-07 cascade
+  #   CNPGClusterNoStreamingReplica
+  #                    k8s/platform/storage/cnpg-system/operator/
+  #                    prometheusrule.yaml -- a postgres primary has nowhere
+  #                    to switch over to, so its PDB blocks the drain forever
+  #   drbd*            piraeus-datastore chart; replicas resyncing or short
+  #                    of quorum
   #
   # Fail-safe by design: if this Prometheus is unreachable, kured treats that
   # as blocked and reboots nothing. KuredRebootRequired is the backstop that

--- a/k8s/platform/observability/kube-prometheus-stack/prometheusrule-workloads.yaml
+++ b/k8s/platform/observability/kube-prometheus-stack/prometheusrule-workloads.yaml
@@ -35,3 +35,28 @@ spec:
           for: 15m
           labels:
             severity: info
+    - name: kube-node-custom.rules
+      rules:
+        # A node cordoned for 45m is not one kured is mid-cycle on: a healthy
+        # cordon -> drain -> reboot -> uncordon measured 25 min at the current
+        # drainTimeout. So this means a manual cordon, or a drain that gave up,
+        # and either way the cluster is already a node short.
+        #
+        # Not covered upstream -- the kubernetes-mixin ships KubeNodeNotReady,
+        # KubeNodeUnreachable and KubeNodeReadinessFlapping, all of which key on
+        # node *readiness*; a cordoned node stays Ready, so none of them fires.
+        #
+        # `severity: info` routes to the null receiver and opens no issue. That
+        # is deliberate: this alert's consumer is kured, which refuses to cordon
+        # while it is firing -- see `alertFilterRegexp` in
+        # k8s/platform/cluster/system-kured/values.yaml. Renaming it there and
+        # here has to happen together.
+        - alert: NodeUnschedulable
+          annotations:
+            description: Node {{ $labels.node }} has been unschedulable for over 45m, so the cluster is effectively a node short. kured will not begin draining any other node until this clears.
+            summary: Node has been cordoned for longer than a reboot cycle.
+          expr: |
+            kube_node_spec_unschedulable == 1
+          for: 45m
+          labels:
+            severity: info

--- a/k8s/platform/storage/cnpg-system/operator/kustomization.yaml
+++ b/k8s/platform/storage/cnpg-system/operator/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - repository.yaml
   - release.yaml
   - podmonitor.yaml
+  - prometheusrule.yaml
   - configmap-dashboard.yaml
 configMapGenerator:
   - name: values-cnpg

--- a/k8s/platform/storage/cnpg-system/operator/prometheusrule.yaml
+++ b/k8s/platform/storage/cnpg-system/operator/prometheusrule.yaml
@@ -1,0 +1,36 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/name: cloudnative-pg
+  name: cloudnative-pg
+spec:
+  groups:
+    - name: cnpg-custom.rules
+      rules:
+        # Cross-cluster, so it belongs to the operator rather than to any one
+        # database. The per-cluster CNPG* alerts come from the `cnpg-database`
+        # chart and cover backups and replication lag; none of them covers
+        # having no replica at all.
+        #
+        # Every CNPG cluster carries a `<name>-primary` PDB with
+        # disruptionsAllowed permanently 0. Draining the primary's node only
+        # works because the operator switches over first, and it can only
+        # switch to a ready, streaming replica on a schedulable node. With no
+        # streaming replica the PDB blocks the eviction for as long as the
+        # drain is allowed to run.
+        #
+        # `severity: info` routes to the null receiver and opens no issue. That
+        # is deliberate: this alert's consumer is kured, which refuses to cordon
+        # while it is firing -- see `alertFilterRegexp` in
+        # k8s/platform/cluster/system-kured/values.yaml. Renaming it there and
+        # here has to happen together.
+        - alert: CNPGClusterNoStreamingReplica
+          annotations:
+            description: The postgres primary of {{ $labels.namespace }}/{{ $labels.job }} has no streaming replica, so it cannot be switched over and its PDB will block a drain of whichever node it runs on.
+            summary: CNPG cluster has no replica to switch over to.
+          expr: |
+            max by (namespace, job) (cnpg_pg_replication_streaming_replicas) == 0
+          for: 5m
+          labels:
+            severity: info


### PR DESCRIPTION
Closes the gap behind #1353, #1354, #1355, #1356, #1357, #1371, #1373, #1374, #1376 and #1377.

## What happened

kured rebooted a node into a cluster that was already a node short, then spent two hours failing to drain it.

The postgres PDBs did their job. Every CNPG cluster carries a `<name>-primary` PDB whose `disruptionsAllowed` is **permanently 0** — a drain of the primary's node only ever succeeds because the operator switches the primary away first, and the PDB follows it. CNPG will only switch over to a ready, streaming replica *on a schedulable node* ([`replicas.go:301`](https://github.com/cloudnative-pg/cloudnative-pg/blob/v1.30.0/internal/controller/replicas.go#L301) skips candidates on cordoned ones). With `master01` cordoned, several clusters had no candidate, so the PDBs held and the drain had nothing to do but wait out `drainTimeout: 2h`.

The same failure was still running while this was written: `master02` held the lock, and both beelinks asked at 07:58 and 08:03, were refused, and — because `period: 2h` is *also* the retry interval — their next questions landed at 09:58 and 10:03, both before the lock freed at 10:07. Losing one race to the lock cost them the whole window.

## Three knobs that already existed, and were off

| Gripe | Mechanism |
| --- | --- |
| Drained while a node was already unavailable | `prometheusUrl` + `alertFilterMatchOnly: true` |
| Drained for far too long | `drainTimeout: 20m`, `period: 20m`, `skipWaitForDeleteTimeout: 60` |
| No soft drain before the real one | `preferNoScheduleTaint` + descheduler `includePreferNoSchedule` |

**Ask before cordoning.** `alertFilterMatchOnly` inverts the regexp from a mute-list into an *allow-list of blockers*: only six named alerts stop a reboot, everything else is ignored. Two of them did not exist and are added here — `NodeUnschedulable` and `CNPGClusterNoStreamingReplica`. Both are `severity: info`, which routes to the null receiver, so they open no issues; their only reader is kured. Rules live with what remediates their signal, per CLAUDE.md, which is why the CNPG one sits next to the gate that consumes it rather than with the vendored chart.

**Fail fast.** A drain that has not finished in 20m is PDB-blocked and will not finish. Timing out is cheap — `forceReboot` is false, so kured releases the lock and best-effort uncordons ([`main.go:691`](https://github.com/kubereboot/kured/blob/1.23.0/cmd/kured/main.go#L691)), then retries. The post-reboot uncordon runs *before* any blocker check, so the new gate cannot deadlock a lock-holder.

**Clear the way first.** Narrowing `protectedStorageClasses` to the two node-local classes is what gives the soft drain anything to do: protecting every PVC made it a no-op for the 27 pods on roaming or NFS volumes that can perfectly well move. All 11 CNPG clusters are on `lvm-thin` and stay protected — they are moved by switchover during the drain, not by eviction. `nodeFit: true` is mandatory once a soft taint is in scope, or a pod gets evicted straight back onto the same node.

## Thresholds are backtested, not guessed

`NodeUnschedulable` has to separate a node kured is legitimately mid-cycle on from one that is stuck. Over 7d of `kube_node_spec_unschedulable`:

| Node | Cordoned | What it was | vs. 45m gate |
| --- | --- | --- | --- |
| `master02` | 25 min | one healthy kured cycle | passes — never fires |
| `master01` | 4365 min | the deliberate cordon behind the cascade | blocks, 97× over |

The CNPG gate backtests as cleanly: `atuin/postgres` sat ~100 min with zero streaming replicas and `grafana/postgres` ~25, while `mealie`'s single 30-second blip stays correctly under the 5m `for`.

## Verification

- `make validate` — all 124 targets render and validate cleanly
- `make prometheusrules` — `pint lint` adds no findings
- descheduler policy parsed by the real `v0.36.0` binary in `--dry-run` against the live cluster: 0 evictions, correctly, since `master02` holds only DaemonSets and protected `lvm-thin` CNPG pods
- `helm template` confirms every new flag reaches the DaemonSet

## Deliberately not in this PR

- **CNPG `DRAIN_TAINTS`.** Adding kured's taint key would make the operator switch primaries off a *queued* node minutes early — a real win, at the cost of primaries converging onto whichever node is not yet tainted. Worth doing separately once this settles.
- **`lockReleaseDelay`.** Left at 1h, which paces a window to two or three nodes rather than four. With three windows a week that is fine; 30m would buy the fourth.
- **The litellm rollout deadlock** (#1374) is untouched. `PreferNoSchedule` does not block scheduling, so it is neither helped nor harmed.

One caveat worth knowing: kured 1.23.0 exposes no metric for a blocked reboot, so a gate that stays shut is visible only in its logs and, eventually, `KuredRebootRequired` at 7d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
