### PR TITLE
vod-arr: keep seerr on nodes that can attach its piraeus volume

### DIFF
--- a/k8s/apps/vod-arr/seerr/deployment.yaml
+++ b/k8s/apps/vod-arr/seerr/deployment.yaml
@@ -138,6 +138,21 @@ spec:
           volumeMounts:
             - mountPath: /app/config
               name: config
+      # seerr-config is a piraeus-r2-roaming volume, and that class has no node
+      # affinity on the PV -- being able to attach from anywhere is the point of
+      # the roaming variant. What it still needs is the linstor CSI node plugin,
+      # which runs only where Piraeus does. master01 cannot load the DRBD module
+      # (Secure Boot), so it carries no satellite and no plugin; a Pod scheduled
+      # there fails to attach forever with "CSINode master01 does not contain
+      # driver linstor.csi.linbit.com". Nothing stopped that until master01 was
+      # uncordoned, at which point the scheduler picked it every time -- it holds
+      # the least of anything in the cluster.
+      #
+      # Selecting on the label rather than excluding a hostname: this is the same
+      # label the Piraeus component uses to place its own workloads, so it tracks
+      # which nodes can serve these volumes instead of restating today's answer.
+      nodeSelector:
+        linstor: "true"
       restartPolicy: Always
       # The image is already USER node:node, which is uid 1000.
       securityContext:


### PR DESCRIPTION
Unblocks the #1381 cutover. The seerr Pod rolled onto master01 and stayed
Pending:

```
AttachVolume.Attach failed for volume "pvc-2cb6e58c...":
CSINode master01 does not contain driver linstor.csi.linbit.com
```

master01 cannot load the DRBD kernel module (Secure Boot), so it runs no
LINSTOR satellite and no CSI node plugin. It was cordoned until earlier today;
this was the first piraeus-backed Pod to reschedule since, and scaling 0/1 six
times put it on master01 six times — it holds the least of anything in the
cluster, so it wins every scheduling decision.

## Why the Pod, and not the storage class

The class-level fix was tried first and does not work here:

| approach | why not |
| --- | --- |
| `allowedTopologies` on the class | consulted only at **bind** time, for unbound PVCs. All seven roaming volumes are already bound, and the scheduler then reads the PV's own `nodeAffinity`, which is empty. |
| `allowRemoteVolumeAccess: [- fromSame: [linstor]]` | `fromSame` skips topology keys the driver does not publish, and it publishes only `kubernetes.io/hostname` and `linbit.com/hostname`. It would silently no-op. |
| patch `nodeAffinity` onto the bound PV | does not persist. Both a merge patch and a JSON patch are accepted — the JSON patch even returns the new value — and a fresh read shows the field empty again. |

So for a volume that already exists, the Pod is the only place the constraint
can live. A follow-up will make *newly provisioned* roaming volumes carry
proper affinity, which is what stops this recurring.

`nodeSelector: linstor=true` rather than `hostname NotIn [master01]`: that is
the label the Piraeus component itself selects on, so it tracks which nodes can
serve these volumes instead of restating today's answer. It matches beelink01,
beelink02 and master02, and roaming is preserved across all three.

## Scope

This is why only some apps are exposed:

| class | `allowRemoteVolumeAccess` | PV `nodeAffinity` | exposed |
| --- | --- | --- | --- |
| `piraeus-r2` | `false` | pinned to its two replica nodes | no |
| `piraeus-r2-roaming` | `true` | empty | **yes** |

The other six roaming volumes in this namespace have the same exposure on
their next reschedule. This commit only unblocks seerr; the rest is a separate
change.

Note the claim in 4f6747e4 that a node excluded by `linstorCluster.nodeAffinity`
"also cannot run a Pod that mounts a Piraeus volume" does not hold — that
affinity places Piraeus' own workloads and says nothing about application Pods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
