### PR TITLE
vod-arr: pin the seerr migration Job to a linstor node

### DIFF
--- a/hack/seerr-sqlite-to-postgres/README.md
+++ b/hack/seerr-sqlite-to-postgres/README.md
@@ -5,7 +5,12 @@ A Job runs pgloader against the SQLite file on `seerr-config` and copies the
 rows into the `postgres-seerr` cluster. It lives here and not under `k8s/`
 because Flux must never apply it: it truncates seerr's tables first.
 
-Rehearsed on 2026-09-07 against `postgres:17` and `seerr:v3.4.1` with a copy of
+Ran on 2026-09-07: 793 rows in, 793 imported, 0 errors, and seerr read all 28
+requests and both users back through its API. pgloader checkpointed the WAL on
+close, so the `-wal` and `-shm` files are gone and `db.sqlite3` is left as the
+fallback.
+
+Rehearsed first, on the same day, against `postgres:17` and `seerr:v3.4.1` with a copy of
 the live file: 793 rows over 14 tables, foreign keys dropped and recreated by
 pgloader, sequences reset, schema byte-identical to one seerr created itself,
 seerr serving every request and user through its API afterwards, and a second

--- a/hack/seerr-sqlite-to-postgres/job.yaml
+++ b/hack/seerr-sqlite-to-postgres/job.yaml
@@ -63,6 +63,11 @@ spec:
             - mountPath: /load
               name: load
               readOnly: true
+      # Same constraint as the seerr Deployment, and for the same reason: this
+      # Pod mounts seerr-config, a piraeus-r2-roaming volume, and master01 runs
+      # no linstor CSI node plugin.
+      nodeSelector:
+        linstor: "true"
       restartPolicy: Never
       # Same identity as the seerr pod: the SQLite files are 0644 node:node.
       securityContext:


### PR DESCRIPTION
Follow-up to #1383 and the #1381 cutover, which is now done.

The migration Job mounts `seerr-config`, a `piraeus-r2-roaming` volume, so it
needs the same `nodeSelector: linstor=true` the Deployment got — otherwise the
Job Pod can land on master01 and sit in Pending on a failed attach, exactly as
the app Pod did. It happened to schedule onto master02 on the day, so this is a
latent trap rather than something that bit; the next person to re-run the load
would have hit it at a bad moment.

Also records what the run produced, since the README claimed only a rehearsal:

```
Total import time  ✓  793  793  92.8 kB  0.618s
```

793 rows read, 793 imported, 0 errors across 14 tables, matching the counts
taken off the live SQLite file beforehand. Verified back through seerr's own
API — 28 requests, 2 users — not just by counting rows in Postgres.

One detail worth having written down: pgloader checkpoints the WAL when it
closes the database, so `db.sqlite3-wal` and `-shm` are gone afterwards and
`db.sqlite3` stands alone as the fallback until a scheduled backup of
`postgres-seerr` has completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
