### PR TITLE
Discover Secure Boot module signing instead of hardcoding master01

### DIFF
--- a/docs/reference/annotations.md
+++ b/docs/reference/annotations.md
@@ -145,6 +145,47 @@ than what happens to be in git.
 | **Read by** | Grafana's dashboard sidecar |
 | **Effect** | Files the dashboard under that folder |
 
+### `feature.node.kubernetes.io/module-signing-enforced`
+
+| | |
+| --- | --- |
+| **Type** | Label |
+| **Set on** | `Node` |
+| **Value** | `true`, `false`, `unknown` |
+| **Written by** | the `module-signing-labeler` DaemonSet, via a `NodeFeature` object |
+| **Effect** | None by itself — available to `nodeSelector`, `nodeAffinity` and `NodeFeatureRule` |
+
+`true` means the kernel rejects unsigned out-of-tree modules, which is what
+decides whether a node can run Piraeus: its DRBD module is built in a container
+and signed by nobody. Node Feature Discovery has no source for this, so it is
+fed to it — the DaemonSet reads sysfs and hands nfd-master a `NodeFeature`
+object, the CRD NFD offers 3rd-party extensions. Manifest and reasoning:
+[`k8s/platform/cluster/node-feature-discovery/module-signing/daemonset.yaml`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/platform/cluster/node-feature-discovery/module-signing/daemonset.yaml).
+
+Two companion labels carry the inputs the verdict was derived from, for when a
+node classifies surprisingly:
+
+| Label | Values |
+| --- | --- |
+| `feature.node.kubernetes.io/secureboot` | `enabled`, `disabled`, `legacy-bios`, `unknown` |
+| `feature.node.kubernetes.io/kernel-lockdown` | `none`, `integrity`, `confidentiality`, `unavailable`, `unknown` |
+
+!!! warning "Gate on the verdict, not on either input"
+
+    Secure Boot is only the usual *cause* here. Lockdown can be raised from the
+    kernel command line without it, and a kernel built without
+    `CONFIG_LOCK_DOWN_IN_EFI_SECURE_BOOT` enforces nothing with Secure Boot on.
+    The kernel rejects an unsigned module if the `sig_enforce` parameter is set
+    **or** lockdown is above `none`, so the verdict ORs both paths.
+
+    `feature.node.kubernetes.io/kernel-config.*` is not a substitute either. It
+    describes what the running kernel was *built* to support and reads identically
+    on every node here whatever the firmware is doing.
+
+Exclude with `NotIn [true]` rather than selecting on `false`: a node whose label
+is missing — labeler not run, discovery broken — then still matches, so a failure
+of discovery cannot deschedule a storage workload that was running.
+
 ## Look load-bearing, are not
 
 ### `role: alert-rules` and `prometheus: k8s` on PrometheusRules

--- a/k8s/platform/cluster/node-feature-discovery/kustomization.yaml
+++ b/k8s/platform/cluster/node-feature-discovery/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - repository.yaml
   - namespace.yaml
   - release.yaml
+  - module-signing/
 configMapGenerator:
   - name: values-nfd
     files:

--- a/k8s/platform/cluster/node-feature-discovery/module-signing/daemonset.yaml
+++ b/k8s/platform/cluster/node-feature-discovery/module-signing/daemonset.yaml
@@ -1,0 +1,205 @@
+# Discovers whether a node's kernel will load an unsigned out-of-tree module --
+# the condition that decides where Piraeus can run, since its DRBD module is
+# built in a container and signed by nobody.
+#
+# Publishes three labels. The verdict is module-signing-enforced; secureboot and
+# kernel-lockdown are the inputs it was derived from, kept because a "true" with
+# no visible cause is not debuggable:
+#
+#   feature.node.kubernetes.io/module-signing-enforced  true | false | unknown
+#   feature.node.kubernetes.io/secureboot               enabled | disabled | legacy-bios | unknown
+#   feature.node.kubernetes.io/kernel-lockdown          none | integrity | confidentiality | unavailable | unknown
+#
+# The verdict ORs the two enforcement paths because the kernel does: an unsigned
+# module is rejected if the sig_enforce parameter is set *or* if lockdown is
+# above none (module_sig_check falls through to security_locked_down). Reading
+# either one alone misclassifies a kernel that uses the other.
+#
+# Secure Boot is deliberately not the verdict. It is only the usual cause on
+# these Ubuntu nodes -- lockdown can be raised from the kernel command line
+# without it, and a kernel built without CONFIG_LOCK_DOWN_IN_EFI_SECURE_BOOT
+# enforces nothing with Secure Boot on.
+#
+# NFD has no firmware or lockdown source of its own, and nothing it already
+# collects stands in: kernel-config flags describe what the kernel was *built*
+# to support and read identically on every node here. So these are read from
+# sysfs and handed to nfd-master through a NodeFeature object, the CRD NFD
+# offers 3rd-party extensions.
+#
+# One apply per Pod lifetime, deliberately. None of the three can change without
+# a reboot, and a reboot restarts this Pod; the Pod then idles on pause instead
+# of looping, so restart counts stay at zero and this never reads as a crashloop.
+#
+# The objects are named module-signing-<node> and carry
+# nfd.node.kubernetes.io/node-name, which is both how nfd-master attaches them to
+# a Node and how nfd-gc drops them when a node leaves the cluster. Deleting this
+# DaemonSet does *not* remove the labels -- delete the NodeFeature objects for that.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: module-signing-labeler
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: module-signing-labeler
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: module-signing-labeler
+    spec:
+      serviceAccountName: module-signing-labeler
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: read-sysfs
+          image: docker.io/library/busybox:1.38.0
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              efi=/host-sys/firmware/efi
+              sbvar=$efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c
+              lockdownfile=/host-sys/kernel/security/lockdown
+              sigfile=/host-sys/module/module/parameters/sig_enforce
+
+              # efivarfs prefixes every variable with four attribute bytes, so
+              # the payload is the last byte: 1 enabled, 0 disabled.
+              if [ ! -d "$efi" ]; then
+                secureboot=legacy-bios
+              elif [ ! -r "$sbvar" ]; then
+                secureboot=unknown
+              elif [ "$(tail -c1 "$sbvar" | od -An -tu1 | tr -dc 0-9)" = "1" ]; then
+                secureboot=enabled
+              else
+                secureboot=disabled
+              fi
+
+              # The file lists every mode with the active one in brackets. It is
+              # absent unless the lockdown LSM is both built in and in CONFIG_LSM.
+              lockdown=unavailable
+              if [ -r "$lockdownfile" ]; then
+                lockdown=$(tr ' ' '\n' <"$lockdownfile" | sed -n 's/^\[\(.*\)\]$/\1/p')
+                if [ -z "$lockdown" ]; then
+                  lockdown=unknown
+                fi
+              fi
+
+              sig=absent
+              if [ -r "$sigfile" ]; then
+                sig=$(cat "$sigfile")
+              fi
+
+              enforced=unknown
+              if [ "$lockdown" = integrity ] || [ "$lockdown" = confidentiality ]; then
+                enforced=true
+              elif [ "$sig" = Y ]; then
+                enforced=true
+              elif [ "$sig" = N ]; then
+                enforced=false
+              elif [ "$lockdown" = none ]; then
+                # No sig_enforce parameter means module signing was not compiled
+                # in, and lockdown says it is not enforcing either.
+                enforced=false
+              fi
+
+              echo "$NODE_NAME: module-signing-enforced=$enforced (secureboot=$secureboot lockdown=$lockdown sig_enforce=$sig)"
+              cat >/work/nodefeature.yaml <<EOF
+              apiVersion: nfd.k8s-sigs.io/v1alpha1
+              kind: NodeFeature
+              metadata:
+                name: module-signing-$NODE_NAME
+                labels:
+                  nfd.node.kubernetes.io/node-name: $NODE_NAME
+              spec:
+                labels:
+                  feature.node.kubernetes.io/module-signing-enforced: "$enforced"
+                  feature.node.kubernetes.io/secureboot: "$secureboot"
+                  feature.node.kubernetes.io/kernel-lockdown: "$lockdown"
+                features:
+                  attributes:
+                    hostsecurity.state:
+                      elements:
+                        module-signing-enforced: "$enforced"
+                        secureboot: "$secureboot"
+                        lockdown: "$lockdown"
+                        sig-enforce: "$sig"
+              EOF
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: host-sys
+              mountPath: /host-sys
+              readOnly: true
+            - name: work
+              mountPath: /work
+          securityContext:
+            # Root, because these sysfs modes are set by the kernel and vary --
+            # efivars is world-readable on these nodes, 0600 on some firmware.
+            # Read-only mount, no caps, no escalation.
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+        - name: apply
+          # Upstream Kubernetes build, pinned to the cluster's minor, as in
+          # k8s/apps/valheim/restarter/cronjob.yaml. Distroless, hence the split
+          # from the shell above.
+          image: registry.k8s.io/kubectl:v1.34.10
+          command:
+            - kubectl
+            - apply
+            - --server-side
+            - --force-conflicts
+            - --field-manager=module-signing-labeler
+            - --filename
+            - /work/nodefeature.yaml
+          volumeMounts:
+            - name: work
+              mountPath: /work
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+      containers:
+        # A DaemonSet needs a long-lived container; the work is done by the time
+        # this starts. pause costs nothing and never restarts.
+        - name: idle
+          image: registry.k8s.io/pause:3.10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 1m
+              memory: 8Mi
+      volumes:
+        - name: host-sys
+          hostPath:
+            path: /sys
+            type: Directory
+        - name: work
+          emptyDir: {}

--- a/k8s/platform/cluster/node-feature-discovery/module-signing/kustomization.yaml
+++ b/k8s/platform/cluster/node-feature-discovery/module-signing/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - serviceaccount.yaml
+  - role.yaml
+  - rolebinding.yaml
+  - daemonset.yaml

--- a/k8s/platform/cluster/node-feature-discovery/module-signing/role.yaml
+++ b/k8s/platform/cluster/node-feature-discovery/module-signing/role.yaml
@@ -1,0 +1,18 @@
+# No resourceNames: they cannot be wildcarded, and the object names follow the
+# node names, so pinning them would need an edit every time the fleet changes.
+# The Role therefore also reaches nfd-worker's own NodeFeature objects in this
+# namespace -- move this component to its own namespace if that ever matters,
+# nfd-master honours NodeFeature objects from anywhere.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: module-signing-labeler
+rules:
+  - apiGroups:
+      - nfd.k8s-sigs.io
+    resources:
+      - nodefeatures
+    verbs:
+      - get
+      - create
+      - patch

--- a/k8s/platform/cluster/node-feature-discovery/module-signing/rolebinding.yaml
+++ b/k8s/platform/cluster/node-feature-discovery/module-signing/rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: module-signing-labeler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: module-signing-labeler
+subjects:
+  - kind: ServiceAccount
+    name: module-signing-labeler
+    namespace: node-feature-discovery

--- a/k8s/platform/cluster/node-feature-discovery/module-signing/serviceaccount.yaml
+++ b/k8s/platform/cluster/node-feature-discovery/module-signing/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: module-signing-labeler

--- a/k8s/platform/storage/piraeus-datastore/cluster/values.yaml
+++ b/k8s/platform/storage/piraeus-datastore/cluster/values.yaml
@@ -19,10 +19,24 @@ linstorCluster:
             values:
               - secondary-vg
               - ubuntu-vg
-          # master01 has Secure Boot issues that stop the DRBD kernel module
-          # from loading, so a satellite there cannot work. It has a
-          # secondary-vg and would otherwise qualify, so it is excluded by
-          # name instead of relying on the absence of the linstor label.
+          # The constraint itself, discovered rather than hardcoded: true means
+          # the kernel rejects unsigned out-of-tree modules, which is what stops
+          # DRBD from loading. Written by the module-signing-labeler DaemonSet,
+          # see docs/reference/annotations.md.
+          #
+          # NotIn, never In [false]: NotIn also matches a node carrying no such
+          # label, so a labeler that has not run yet -- or has broken -- cannot
+          # deschedule a satellite and take its replicas offline. The cost of
+          # that direction is that a node with Secure Boot on gets a satellite
+          # that cannot load DRBD until discovery catches up.
+          - key: feature.node.kubernetes.io/module-signing-enforced
+            operator: NotIn
+            values:
+              - "true"
+          # master01 is the node that condition currently describes: Secure Boot
+          # on, lockdown integrity, sig_enforce Y, no DRBD module loaded. Kept as
+          # a by-name guard alongside the discovered rule; drop it once the label
+          # has been seen on every node, not before.
           - key: kubernetes.io/hostname
             operator: NotIn
             values:

--- a/k8s/platform/storage/piraeus-datastore/operator/values.yaml
+++ b/k8s/platform/storage/piraeus-datastore/operator/values.yaml
@@ -14,12 +14,18 @@ nodeSelector:
   linstor: "true"
 
 # Same exclusion as linstorCluster.nodeAffinity in ../cluster/values.yaml: the
-# operator itself needs no DRBD, but nothing of Piraeus should land on master01.
+# operator itself needs no DRBD, but nothing of Piraeus should land on a node
+# whose kernel rejects unsigned modules. The by-name guard is kept alongside the
+# discovered one until the label has been seen on every node.
 affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
         - matchExpressions:
+            - key: feature.node.kubernetes.io/module-signing-enforced
+              operator: NotIn
+              values:
+                - "true"
             - key: kubernetes.io/hostname
               operator: NotIn
               values:


### PR DESCRIPTION
Piraeus cannot run on master01: Secure Boot is on, so the DRBD module built inside the satellite's container is refused. Until now the only statement of that anywhere was master01's name, hardcoded in the Piraeus `nodeAffinity` (#1380). This replaces the *cause* with a discovered *condition*.

## What NFD could not do

There is no firmware or lockdown source in NFD, and nothing it already collects stands in — `feature.node.kubernetes.io/kernel-config.*` describes what the kernel was **built** to support and reads identically on all four nodes whatever the firmware is doing. So a DaemonSet reads sysfs and hands nfd-master a `NodeFeature` object, the CRD NFD offers 3rd-party extensions.

Three labels: `module-signing-enforced` is the verdict, `secureboot` and `kernel-lockdown` carry the inputs, because a `true` with no visible cause is not debuggable.

**Neither input is the verdict on its own.** The kernel rejects an unsigned module if the `sig_enforce` parameter is set **or** if lockdown is above `none` (`module_sig_check` falls through to `security_locked_down`), and lockdown can be raised from the kernel command line without Secure Boot at all. The verdict ORs both paths.

## Measured

| | master01 | master02 |
| --- | --- | --- |
| `SecureBoot` efivar | `6 0 0 0 1` → enabled | `6 0 0 0 0` → disabled |
| `/sys/kernel/security/lockdown` | `none [integrity] confidentiality` | `[none] integrity confidentiality` |
| `sig_enforce` | `Y` | `N` |
| `drbd` in NFD's `kernel.loadedmodule` | absent | present |

Same kernel on both, neither cmdline carries `lockdown=`, so Secure Boot is the cause on master01. Read with a temporary read-only pod, since the NFD worker and node-exporter are distroless. NFD's own `kernel.loadedmodule` independently agrees: `drbd` is loaded on the three Piraeus nodes and absent on master01.

## Why the by-name guard stays

`NotIn [true]`, never `In [false]`: `NotIn` also matches a node carrying no such label, so a labeler that has not run — or has broken — cannot deschedule a satellite and take its replicas offline. The cost of that direction is the opposite failure, a node getting a satellite that cannot load DRBD until discovery catches up, which is visible and harms nothing already running.

The consequence is that absence reads as permission, so dropping `kubernetes.io/hostname NotIn [master01]` in this PR would put a satellite and CSI node plugin on master01 the moment it merges, before the labeler has published anything. Evaluated against the live cluster, the term without the hostname rule selects all four nodes today and the right three once the labels exist. It comes out in a follow-up, together with the four `linstor: "true"` selectors it backs up, once the label has been seen on every node.

## Design notes

- One apply per Pod lifetime. None of the three facts can change without a reboot, and a reboot restarts the Pod; it then idles on `pause` rather than looping, so restart counts stay at zero and this never reads as a crashloop.
- Two init containers because `registry.k8s.io/kubectl` is distroless and has no shell.
- No `ownerReference`: cleanup is nfd-gc's job — it deletes `NodeFeature` objects whose node-name label no longer resolves. One pointing at the Pod would drop and re-add the labels on every restart.
- The Role reaches nfd-worker's own `NodeFeature` objects in that namespace, since `resourceNames` cannot be wildcarded. Splitting it into its own namespace is possible — nfd-master honours `NodeFeature` objects from anywhere.

## Verification

- Verdict logic exercised against six synthetic sysfs trees, including both divergence cases a single-file read gets wrong: `lockdown=none` + `sig_enforce=Y` → `true`, and `lockdown=integrity` + `sig_enforce=N` → `true`.
- The script **as extracted from the rendered DaemonSet** produces a `NodeFeature` that parses.
- `make validate` clean at 126 targets; `docs-reference-check`, `docs-lint` (0 errors), `docs-build` clean.
- Server-side dry-run against the live cluster: DaemonSet, RBAC and a rendered `NodeFeature` all accepted, no Kyverno warnings.
- `NotIn`-matches-absent-label confirmed against the live API, not just assumed.
- All nodes are amd64; busybox, kubectl and pause all cover it.

No live change expected from the placement commit: the term still matches beelink01, beelink02 and master02. The LinstorCluster-managed pod templates gain the expression, so csi-node, ha-controller and the controller Deployments roll once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)