### PR TITLE
cnpg: treat kured's reboot taint as a drain signal

### DIFF
--- a/k8s/platform/storage/cnpg-system/operator/values.yaml
+++ b/k8s/platform/storage/cnpg-system/operator/values.yaml
@@ -15,3 +15,19 @@ nodeSelector: {}
 config:
   data:
     INHERITED_LABELS: "app.kubernetes.io/*"
+    # Taints the operator treats as "this node is being drained", which makes it
+    # switch a primary away before the eviction arrives. Adding kured's reboot
+    # taint buys the databases a head start: kured applies it as soon as a node
+    # wants a reboot but finds the lock held, so the switchover happens while
+    # the node is still queued rather than after it is cordoned.
+    #
+    # This REPLACES the operator's defaults rather than adding to them --
+    # configparser only falls back to them when the value is empty. The first
+    # four are therefore upstream's list, copied verbatim; only the last is
+    # ours. Dropping `node.kubernetes.io/unschedulable` would silently disable
+    # switchover-on-cordon, which is what makes an ordinary drain work at all.
+    #
+    # The autoscaler and karpenter taints are inert on bare metal. They are kept
+    # so this stays "upstream's defaults plus one" and cannot rot into a
+    # surprise if that ever changes.
+    DRAIN_TAINTS: "node.kubernetes.io/unschedulable,ToBeDeletedByClusterAutoscaler,karpenter.sh/disrupted,karpenter.sh/disruption,thaum.xyz/kured-node-reboot"


### PR DESCRIPTION
Follow-up to #1382, which deliberately left this out.

## What it does

The CNPG operator already switches a primary away from a node that is cordoned **or** carries a taint listed in `DRAIN_TAINTS` ([`replicas.go:70-78`](https://github.com/cloudnative-pg/cloudnative-pg/blob/v1.30.0/internal/controller/replicas.go#L70-L78)). Adding kured's `thaum.xyz/kured-node-reboot` taint means the switchover happens while the node is still **queued for the reboot lock**, rather than after it has been cordoned and the drain is already blocking on the primary PDB.

That PDB is the whole reason #1382 exists: `disruptionsAllowed` is permanently 0, and it only clears when the operator switches over. Today that race starts when the drain does.

## Why now

`beelink02` currently holds **9 of the 12 primaries** and is pending a reboot — it and `beelink01` both missed today's window, so they go first on Monday:

```
primaries per node:  beelink02 9   beelink01 2   master01 1
```

Draining beelink02 means nine switchovers inside a 20m `drainTimeout`. Doing them while it waits behind the lock, instead of during the drain, is the difference between a queue and a race. (The 9-on-one concentration is pre-existing, not caused by this — it is what cordon-triggered switchover already produces as nodes reboot in turn.)

## The trap this had to avoid

`DRAIN_TAINTS` **replaces** the operator's defaults rather than extending them — [`configparser.go:172-180`](https://github.com/cloudnative-pg/cloudnative-pg/blob/v1.30.0/pkg/configparser/configparser.go#L172-L180) falls back to the default slice only when the supplied value is empty. So the first four entries here are upstream's list copied verbatim and only the last is ours.

Dropping `node.kubernetes.io/unschedulable` would silently disable switchover-on-cordon — the mechanism that makes an *ordinary* drain work — and nothing would fail until a drain hung. The two karpenter taints and the autoscaler one are inert on bare metal; they are kept so this reads as "upstream's defaults plus one" and cannot rot into a surprise.

## Rollout

No restart plumbing needed. The operator reads its ConfigMap once at startup ([`controller.go:202`](https://github.com/cloudnative-pg/cloudnative-pg/blob/v1.30.0/internal/cmd/manager/controller/controller.go#L202)) and does not watch it, but the chart stamps a `checksum/config` annotation into the pod template, so changing `config.data` rolls the Deployment by itself:

```
checksum/config: 03505cc4…  ->  2d73bdad…
```

Rolling the operator does not touch running Postgres instances; only reconciliation pauses for a few seconds.

## Two limits worth knowing

- **The first node still gets no head start.** kured applies the taint only when a node wants a reboot and finds the lock *already held*, so whichever node wins the lock goes straight to cordon and drain. On Monday that is likely `beelink01` (it polls at :58, beelink02 at :03), which puts the 9-primary node in the queued-and-tainted position — the good case, but by luck rather than design. `drainDelay` is not a fix: it sleeps *before* the cordon, so it buys the operator nothing.
- **It degrades to a no-op, not to something wrong.** The operator excludes candidates on tainted nodes too, so if every remaining node is tainted it simply finds no target and leaves the primary where it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
