### PR TITLE
Piraeus placement from discovered labels, and topology on the StorageClasses

### DIFF
--- a/docs/reference/annotations.md
+++ b/docs/reference/annotations.md
@@ -166,6 +166,29 @@ than what happens to be in git.
 | **Read by** | Grafana's dashboard sidecar |
 | **Effect** | Files the dashboard under that folder |
 
+### `linbit.com/hostname`
+
+| | |
+| --- | --- |
+| **Type** | Label |
+| **Set on** | `Node` |
+| **Value** | That node's own hostname |
+| **Written by** | kubelet, from the topology keys the `linstor.csi.linbit.com` node plugin registers |
+| **Effect** | Marks a node where a Piraeus volume can actually be attached |
+
+Select it with `Exists` in a `nodeAffinity`, never as a `nodeSelector` — the
+value differs per node, and a selector can only compare a key to one fixed
+value. Use it for any Pod mounting a `piraeus-*` volume: the roaming classes put
+no node affinity on the PV, so nothing else stops the scheduler picking a node
+with no CSI plugin, where the Pod then waits forever on `CSINode <node> does not
+contain driver linstor.csi.linbit.com`.
+
+Prefer it over restating Piraeus's placement rule in the consumer, which
+diverges silently the day that rule changes. Its one weakness is the mirror
+image: kubelet writes topology labels at plugin registration and removes nothing
+when a plugin stops, so a node that has *stopped* running Piraeus keeps the
+label until something clears it.
+
 ### `feature.node.kubernetes.io/module-signing-enforced`
 
 | | |

--- a/docs/reference/storage-classes.md
+++ b/docs/reference/storage-classes.md
@@ -83,6 +83,22 @@ xfs, and carry the same DRBD tuning. They differ only in where the Pod may run:
 | `auto-diskful` delay | — | **5 minutes**, then a local replica, surplus dropped |
 | Max PVC size | unbounded | **32 GiB**, denied above |
 
+How the "Pod may schedule on" row is enforced differs, and the difference bites.
+`piraeus-r2` PVs carry node affinity for their two replica holders, written by
+the driver, so the scheduler honours that row on its own. `piraeus-r2-roaming`
+PVs carry no node affinity at all — being attachable from anywhere is the point —
+so once the claim is bound, nothing keeps a Pod off a node with no CSI node
+plugin, where it waits forever on `CSINode <node> does not contain driver
+linstor.csi.linbit.com`. A Pod mounting a roaming volume needs its own
+[`linbit.com/hostname`](annotations.md) affinity.
+
+Both classes restrict *provisioning* through `allowedTopologies` on
+`linbit.com/hostname`, patched in through the HelmRelease's `postRenderers`
+because the chart's template does not render that field. Under
+`WaitForFirstConsumer` the scheduler applies it while the claim is unbound, so a
+new volume is steered to a node that can serve it — it does nothing for a claim
+that is already bound.
+
 The size cap is a resync budget: a moved Pod resyncs the volume across the node
 network, and a full 32 GiB is roughly five more minutes at 1 Gb/s.
 `rs-discard-granularity` keeps unallocated blocks off the wire, but requested size

--- a/k8s/apps/vod-arr/seerr/deployment.yaml
+++ b/k8s/apps/vod-arr/seerr/deployment.yaml
@@ -148,11 +148,23 @@ spec:
       # uncordoned, at which point the scheduler picked it every time -- it holds
       # the least of anything in the cluster.
       #
-      # Selecting on the label rather than excluding a hostname: this is the same
-      # label the Piraeus component uses to place its own workloads, so it tracks
-      # which nodes can serve these volumes instead of restating today's answer.
-      nodeSelector:
-        linstor: "true"
+      # linbit.com/hostname is one of the topology keys the linstor CSI node
+      # plugin registers, so kubelet stamps it on exactly the nodes where that
+      # plugin has come up -- the condition this Pod actually needs. It replaced
+      # a `linstor: "true"` nodeSelector, a hand-applied label that stopped
+      # meaning anything once Piraeus stopped reading it, and it is preferred
+      # over restating Piraeus's own placement rule here, which would silently
+      # diverge the day that rule gains a condition.
+      #
+      # Exists, because the value is the node's own hostname. That needs
+      # affinity: a nodeSelector can only compare a key to one fixed value.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: linbit.com/hostname
+                    operator: Exists
       restartPolicy: Always
       # The image is already USER node:node, which is uid 1000.
       securityContext:

--- a/k8s/platform/storage/piraeus-datastore/cluster/release.yaml
+++ b/k8s/platform/storage/piraeus-datastore/cluster/release.yaml
@@ -59,6 +59,45 @@ spec:
               - op: replace
                 path: /spec/groups/1/rules/6/labels/severity
                 value: warning
+          # allowedTopologies has to be patched in: the chart's storageclass.yaml
+          # renders name, annotations, labels, provisioner, reclaimPolicy,
+          # volumeBindingMode, allowVolumeExpansion and parameters, and nothing
+          # else. Setting it in values.yaml reads as configuration and is
+          # silently inert.
+          #
+          # What it buys, with WaitForFirstConsumer: the scheduler will not place
+          # a Pod holding an unbound claim of these classes on a node outside the
+          # list, so a new volume is steered to a node that can serve it instead
+          # of the claim sitting Pending forever because the selected node has no
+          # linstor entry in its CSINode.
+          #
+          # What it does not buy: anything for an already-bound volume.
+          # piraeus-r2-roaming PVs carry no node affinity by design, so their
+          # consumers still need their own `linbit.com/hostname` affinity for
+          # every reschedule after the first.
+          #
+          # Hostnames rather than a label test, because a
+          # TopologySelectorLabelRequirement takes a key and a list of values --
+          # there is no Exists. Keep this in step with the nodes carrying
+          # linbit.com/hostname; one missing here is never provisioned onto,
+          # which is degraded rather than broken. The field is mutable, so a
+          # change here is an ordinary upgrade and not the delete-and-recreate
+          # dance the immutable StorageClass fields need.
+          - target:
+              group: storage.k8s.io
+              version: v1
+              kind: StorageClass
+              name: piraeus-r2.*
+            patch: |-
+              - op: add
+                path: /allowedTopologies
+                value:
+                  - matchLabelExpressions:
+                      - key: linbit.com/hostname
+                        values:
+                          - beelink01
+                          - beelink02
+                          - master02
   valuesFrom:
     - kind: ConfigMap
       name: values-linstor-cluster

--- a/k8s/platform/storage/piraeus-datastore/cluster/values.yaml
+++ b/k8s/platform/storage/piraeus-datastore/cluster/values.yaml
@@ -1,12 +1,15 @@
 # Config reference: https://github.com/piraeusdatastore/helm-charts/blob/main/charts/linstor-cluster/values.yaml
 
 linstorCluster:
-  # A node has to match both nodeSelector and nodeAffinity to run any Piraeus
-  # component. The operator applies them to the satellite, CSI node plugin and
-  # HA controller DaemonSets and to the controller Deployments alike, and a node
-  # they exclude also cannot run a Pod that mounts a Piraeus volume.
-  nodeSelector:
-    linstor: "true"
+  # nodeAffinity alone decides where Piraeus runs. The operator applies it to
+  # the satellite, CSI node plugin and HA controller DaemonSets and to the
+  # controller Deployments alike, and a node it excludes also cannot run a Pod
+  # that mounts a Piraeus volume.
+  #
+  # There was a `nodeSelector: linstor: "true"` here as well, hand-applied to
+  # three nodes and defined nowhere. Both expressions below are discovered, so
+  # a new node with a thin pool joins the cluster correctly labelled or not at
+  # all -- nothing to remember.
   nodeAffinity:
     nodeSelectorTerms:
       # Expressions inside one term are ANDed; a second term would be an OR.
@@ -33,14 +36,6 @@ linstorCluster:
             operator: NotIn
             values:
               - "true"
-          # master01 is the node that condition currently describes: Secure Boot
-          # on, lockdown integrity, sig_enforce Y, no DRBD module loaded. Kept as
-          # a by-name guard alongside the discovered rule; drop it once the label
-          # has been seen on every node, not before.
-          - key: kubernetes.io/hostname
-            operator: NotIn
-            values:
-              - master01
   tolerations:
     - key: node-role.kubernetes.io/control-plane
       operator: Exists
@@ -250,7 +245,6 @@ linstorSatelliteConfigurations:
                 memory: 32Mi
   - name: secondary-vg
     nodeSelector:
-      linstor: "true"
       devices.topolvm.io/vg: secondary-vg
     storagePools:
       - name: temporary-topolvm
@@ -259,7 +253,6 @@ linstorSatelliteConfigurations:
           thinPool: thin-pool0
   - name: ubuntu-vg
     nodeSelector:
-      linstor: "true"
       devices.topolvm.io/vg: ubuntu-vg
     storagePools:
       - name: temporary-topolvm

--- a/k8s/platform/storage/piraeus-datastore/operator/values.yaml
+++ b/k8s/platform/storage/piraeus-datastore/operator/values.yaml
@@ -10,9 +10,6 @@ operator:
 
 priorityClassName: system-cluster-critical
 
-nodeSelector:
-  linstor: "true"
-
 # Same exclusion as linstorCluster.nodeAffinity in ../cluster/values.yaml: the
 # operator itself needs no DRBD, but nothing of Piraeus should land on a node
 # whose kernel rejects unsigned modules. The by-name guard is kept alongside the
@@ -26,10 +23,6 @@ affinity:
               operator: NotIn
               values:
                 - "true"
-            - key: kubernetes.io/hostname
-              operator: NotIn
-              values:
-                - master01
 
 # A single operator replica does not benefit from a PDB and minAvailable: 1
 # would prevent voluntary eviction during a node drain.


### PR DESCRIPTION
Follow-up to #1386, which merged and whose labels are live and correct: master01 reports `module-signing-enforced=true` / `secureboot=enabled` / `kernel-lockdown=integrity`, the other three the opposite. That was the gate for removing the hand-applied `linstor: "true"` label, so this removes it — and finds a second consumer on the way out.

Three commits, each standing on its own.

### 1. `piraeus: place on the discovered condition alone`

Drops the `linstor: "true"` nodeSelector from the cluster and operator values and from both satellite configurations, plus the by-name master01 exclusion #1386 deliberately kept as a guard. VG + `module-signing-enforced NotIn [true]` selects exactly the same three nodes.

The satellite configurations are safe on the VG label alone: they decide which satellites get a storage pool, and master01 gets no satellite, so a pool config matching its `secondary-vg` applies to nothing. Both charts default these keys to empty (`linstorCluster: {}`, operator `nodeSelector: { }`), so removing them inherits nothing back through Helm's map merge.

### 2. `seerr: schedule on the CSI topology label`

seerr selected the same label, and its comment said why: it *"tracks which nodes can serve these volumes"* because Piraeus used it too. True until commit 1, after which nothing would define that label at all.

`linbit.com/hostname` is one of the topology keys the linstor CSI node plugin registers, so kubelet stamps it on exactly the nodes where that plugin came up:

```
master02:  linstor.csi.linbit.com  topologyKeys=kubernetes.io/hostname,linbit.com/hostname
beelink01: linstor.csi.linbit.com  topologyKeys=kubernetes.io/hostname,linbit.com/hostname
master01:  (no linstor.csi.linbit.com entry at all)
```

That is the condition the Pod needs, and it beats restating Piraeus's placement rule in the consumer, which would diverge silently the day that rule gains a condition. `Exists`, because the value is the node's own hostname — which is also why it has to be affinity rather than a nodeSelector.

Documented with its one weakness: kubelet writes topology labels at plugin registration and removes nothing when a plugin stops, so a node that has *stopped* running Piraeus keeps the label until something clears it.

### 3. `piraeus: restrict provisioning with allowedTopologies`

Under `WaitForFirstConsumer` the scheduler applies `allowedTopologies` while the claim is unbound, so a Pod with a new claim is steered to a node that can serve the volume instead of the claim sitting Pending because the chosen node has no linstor entry in its CSINode.

Patched through `postRenderers`, not set in `values.yaml`: the chart's `storageclass.yaml` renders name, annotations, labels, provisioner, reclaimPolicy, volumeBindingMode, allowVolumeExpansion and parameters, and nothing else — the field would have been silently inert.

Hostnames rather than a label test, because a `TopologySelectorLabelRequirement` takes a key and a list of values; there is no `Exists`. Drift fails soft — a LINSTOR node missing from the list is never provisioned onto rather than broken. It buys nothing for an already-bound volume, which is what commit 2 covers.

## Verification

- Node sets agree three ways: `linstor=true`, VG + `module-signing-enforced NotIn [true]`, and `linbit.com/hostname` all select beelink01, beelink02, master02.
- `allowedTopologies` is mutable — server dry-run patch accepted, the same dry-run on `reclaimPolicy` rejected as the control. No delete-and-recreate dance.
- The postRenderer was simulated against the real chart: templated 1.2.0 with these values, applied the patch list as Flux would, both classes come out with the field and the existing index-based severity patch still resolves.
- Rendered StorageClasses server-side dry-ran clean.
- `make validate` (126 targets), `docs-reference-check`, `docs-lint` (0 errors), `docs-build` all clean.

## Rollout

Reconcile the Kustomization before each HelmRelease, or Helm uses the stale values ConfigMap. The LinstorCluster pod templates change, so csi-node, ha-controller and the controller Deployments roll once; seerr rolls with `strategy: Recreate`, so a few seconds of downtime and no multi-attach stall. seerr's current node is in the allowed set, so it does not move.

**After merge**, and not before, the label comes off the nodes:

```
kubectl label node beelink01 beelink02 master02 linstor-
```

Doing that between commits 1 and 2 would strand seerr, which is why they travel together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)