### PR TITLE
kured: run on every node, drop the label opt-in

### DIFF
--- a/docs/reference/annotations.md
+++ b/docs/reference/annotations.md
@@ -96,8 +96,12 @@ bare host, silently. Remove the label instead.
 
 **Output, not input.** kured adds it on its own and removes it when the reboot
 finishes or the window closes; setting it by hand only lasts until kured's next
-pass. To stop a node rebooting, relabel it `kured=disabled` instead — that
-selector is what the DaemonSet schedules on.
+pass.
+
+There is no per-node opt-out to reach for instead: the DaemonSet carries no
+`nodeSelector`, so every node reboots. Cordoning one does stop reboots, but
+cluster-wide rather than for that node — a node unschedulable for 45 minutes
+raises `NodeUnschedulable`, which is one of the alerts the gate blocks on.
 
 Both readers are configured with this exact string, and neither fails loudly if
 it stops matching: renaming the taint would leave the drain gate open and the

--- a/k8s/platform/cluster/system-kured/values.yaml
+++ b/k8s/platform/cluster/system-kured/values.yaml
@@ -92,11 +92,8 @@ resources:
     cpu: 3m
     memory: 64Mi
 
-# Per-node kill switch: relabel a node kured=disabled to stop it rebooting.
-# Turning one back on: relabel first, then clear the DaemonSet's
-# weave.works/kured-node-lock annotation -- that order, or it reboots at once.
-nodeSelector:
-  kured: enabled
+# No nodeSelector: kured runs on every node, including new ones, without a
+# labelling step that is easy to forget.
 
 metrics:
   create: true


### PR DESCRIPTION
The `kured: enabled` nodeSelector made reboot coverage depend on a labelling step applied **by hand** — nothing in `metal/` sets it. A node added later would silently never reboot, and nothing would report that.

Every node carries the label today, so this changes no scheduling right now. It removes the way to get it wrong later.

## What is lost

The per-node kill switch, and there is no replacement. `docs/reference/annotations.md` now says so plainly instead of pointing at a selector that no longer exists.

Cordoning a node still stops reboots, but **cluster-wide** rather than for that node: 45 minutes unschedulable raises `NodeUnschedulable`, which is one of the alerts the gate in #1382 blocks on. That is a coarser instrument than a label, and worth knowing before reaching for it.

If a per-node opt-out is wanted back later, the honest version is a taint the DaemonSet does not tolerate, not a selector — a selector fails open on a *missing* label, which is exactly the failure this PR is removing.

## Checks

The chart *merges* `nodeSelector` rather than replacing it, so the DaemonSet keeps the chart's own `kubernetes.io/os: linux`:

```
before:  kubernetes.io/os: linux + kured: enabled
after:   kubernetes.io/os: linux
```

```
make validate    126 targets render and validate cleanly
make docs-lint   27 pages, 0 errors, 6 warnings — all pre-existing
make docs-build  No issues found
```

## Rollout order

**This has to land before the labels are stripped from the nodes.** The other order evicts the DaemonSet from every node in the gap between the two steps. Once Flux has applied this, the labels are inert and can be removed with:

```bash
kubectl label nodes --all kured-
```

I could not run that in this session — Tailscale is stopped on the machine I am on, so the cluster is unreachable. Verification once it is back:

```bash
kubectl -n system-kured get ds kured -o jsonpath='{.spec.template.spec.nodeSelector}{"\n"}'
kubectl get nodes --show-labels | grep -c kured=
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
