### PR TITLE
Label LINSTOR nodes by storage pool

### DIFF
--- a/docs/reference/annotations.md
+++ b/docs/reference/annotations.md
@@ -166,6 +166,28 @@ than what happens to be in git.
 | **Read by** | Grafana's dashboard sidecar |
 | **Effect** | Files the dashboard under that folder |
 
+### `linbit.com/sp-<pool>`
+
+| | |
+| --- | --- |
+| **Type** | Label |
+| **Set on** | `Node` |
+| **Value** | `"true"` |
+| **Written by** | kubelet, from the topology keys the `linstor.csi.linbit.com` node plugin registers when it runs with `--label-by-storage-pool` |
+| **Effect** | Marks a node holding that LINSTOR storage pool |
+
+The companion to the driver's other topology key, `linbit.com/hostname`, and the
+reason to prefer this one in a StorageClass: its value is the same on every
+eligible node, so
+`allowedTopologies` can name one value rather than enumerating hostnames. A
+`TopologySelectorLabelRequirement` takes only a key and a list of values — there
+is no `Exists` — which makes a per-node key unusable there without a list.
+
+Enabled through `linstorCluster.patches`, since neither the chart nor the
+`LinstorCluster` CR has a field for the flag. Same caveat as its companion:
+kubelet writes topology labels at plugin registration and removes nothing when a
+plugin stops.
+
 ### `feature.node.kubernetes.io/module-signing-enforced`
 
 | | |

--- a/k8s/platform/storage/piraeus-datastore/cluster/values.yaml
+++ b/k8s/platform/storage/piraeus-datastore/cluster/values.yaml
@@ -66,7 +66,9 @@ linstorCluster:
 
   # Piraeus creates these workloads from the LinstorCluster CR rather than the
   # Helm chart, so set requests with operator patches. Values are deliberately
-  # requests-only until real cluster usage is available in Prometheus.
+  # requests-only until real cluster usage is available in Prometheus -- the one
+  # exception is LABEL_BY_STORAGE_POOL below, which the chart has no field for
+  # either.
   patches:
     - target:
         kind: Deployment
@@ -163,6 +165,17 @@ linstorCluster:
                       memory: 32Mi
               containers:
                 - name: linstor-csi
+                  # Publishes linbit.com/sp-<pool>="true" on every node holding
+                  # that pool and registers it as a CSI topology key. That gives
+                  # a StorageClass a topology key whose value is the same on
+                  # every eligible node, so allowedTopologies can say "a node
+                  # with this pool" instead of listing hostnames: the driver's
+                  # other key, linbit.com/hostname, carries a value unique per
+                  # node, and a TopologySelectorLabelRequirement has only key
+                  # and values -- no Exists.
+                  env:
+                    - name: LABEL_BY_STORAGE_POOL
+                      value: "true"
                   resources:
                     requests:
                       cpu: 20m


### PR DESCRIPTION
Groundwork for #1389, from the review question there: can `allowedTopologies` use `linbit.com/hostname` without listing values?

**No.** Server dry-run rejects both forms:

```
values: []      → allowedTopologies[0].matchLabelExpressions[0].values: Required value
values omitted  → allowedTopologies[0].matchLabelExpressions[0].values: Required value
```

A `TopologySelectorLabelRequirement` has only `key` and `values` — no `operator`, so no `Exists`. With a key whose value is unique per node, a list is unavoidable.

**So change the key.** The linstor CSI node plugin already runs with `--label-by-storage-pool=$(LABEL_BY_STORAGE_POOL)`, currently `false`. Turned on, it publishes `linbit.com/sp-<pool>="true"` on every node holding that pool and registers it as a topology key ([prefix and value confirmed in the driver](https://github.com/piraeusdatastore/linstor-csi/blob/master/pkg/topology/topology.go)). That value is identical on every eligible node, so #1389 can say *a node with the `temporary-topolvm` pool* instead of naming three machines — and it's the tighter statement of intent anyway.

## Why a patch and not a value

The `linstor-csi-node` DaemonSet is created by the operator from the `LinstorCluster` CR (`owner=LinstorCluster`), so a direct edit is reverted, and neither the chart nor the CR has a field for this flag. It goes through `linstorCluster.patches`, extending the patch that already targets this DaemonSet rather than adding a second one for the same target.

## Verification

Simulated with kustomize against the live object — the same machinery the operator uses:

```
env:       LABEL_BY_STORAGE_POOL=true   (was false)
env count: 5 before, 5 after            (merged by name, nothing appended)
resources: {requests: {cpu: 20m, memory: 64Mi}}   unchanged
args:      --label-by-storage-pool=$(LABEL_BY_STORAGE_POOL)  unchanged
```

The rendered `LinstorCluster` CR server-side dry-ran clean, so the patch list validates against the CRD schema. `make validate` (126 targets), `docs-reference-check`, `docs-lint` (0 errors), `docs-build` all clean.

## Rollout and what to check after

csi-node rolls and re-registers; kubelet stamps the label at registration.

```
kubectl get nodes -L linbit.com/sp-temporary-topolvm
kubectl get csinode -o json | jq -r '.items[]|"\(.metadata.name) \([.spec.drivers[]|select(.name=="linstor.csi.linbit.com")|.topologyKeys[]]|join(","))"'
```

Expect `"true"` on beelink01, beelink02 and master02, and the new key alongside the two existing ones in each CSINode.

One thing worth confirming before #1389 switches: that a freshly provisioned `piraeus-r2` volume still gets hostname-based PV node affinity. Enabling the extra key changes what the driver reports as accessible topology for new volumes, and `allowRemoteVolumeAccess: false` depends on that affinity pinning the Pod to its two replica holders. Existing PVs are unaffected either way — their affinity is already written and immutable.

Nothing consumes the new key in this PR. #1389 cannot switch to it until the label exists on every node: a selector naming a key nobody carries matches nothing and would block provisioning on both classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)