### PR TITLE
Revert "piraeus: label nodes by storage pool"

### DIFF
--- a/docs/reference/annotations.md
+++ b/docs/reference/annotations.md
@@ -170,28 +170,6 @@ than what happens to be in git.
 | **Read by** | Grafana's dashboard sidecar |
 | **Effect** | Files the dashboard under that folder |
 
-### `linbit.com/sp-<pool>`
-
-| | |
-| --- | --- |
-| **Type** | Label |
-| **Set on** | `Node` |
-| **Value** | `"true"` |
-| **Written by** | kubelet, from the topology keys the `linstor.csi.linbit.com` node plugin registers when it runs with `--label-by-storage-pool` |
-| **Effect** | Marks a node holding that LINSTOR storage pool |
-
-The companion to the driver's other topology key, `linbit.com/hostname`, and the
-reason to prefer this one in a StorageClass: its value is the same on every
-eligible node, so
-`allowedTopologies` can name one value rather than enumerating hostnames. A
-`TopologySelectorLabelRequirement` takes only a key and a list of values — there
-is no `Exists` — which makes a per-node key unusable there without a list.
-
-Enabled through `linstorCluster.patches`, since neither the chart nor the
-`LinstorCluster` CR has a field for the flag. Same caveat as its companion:
-kubelet writes topology labels at plugin registration and removes nothing when a
-plugin stops.
-
 ### `feature.node.kubernetes.io/module-signing-enforced`
 
 | | |

--- a/k8s/platform/storage/piraeus-datastore/cluster/values.yaml
+++ b/k8s/platform/storage/piraeus-datastore/cluster/values.yaml
@@ -66,9 +66,7 @@ linstorCluster:
 
   # Piraeus creates these workloads from the LinstorCluster CR rather than the
   # Helm chart, so set requests with operator patches. Values are deliberately
-  # requests-only until real cluster usage is available in Prometheus -- the one
-  # exception is LABEL_BY_STORAGE_POOL below, which the chart has no field for
-  # either.
+  # requests-only until real cluster usage is available in Prometheus.
   patches:
     - target:
         kind: Deployment
@@ -165,17 +163,6 @@ linstorCluster:
                       memory: 32Mi
               containers:
                 - name: linstor-csi
-                  # Publishes linbit.com/sp-<pool>="true" on every node holding
-                  # that pool and registers it as a CSI topology key. That gives
-                  # a StorageClass a topology key whose value is the same on
-                  # every eligible node, so allowedTopologies can say "a node
-                  # with this pool" instead of listing hostnames: the driver's
-                  # other key, linbit.com/hostname, carries a value unique per
-                  # node, and a TopologySelectorLabelRequirement has only key
-                  # and values -- no Exists.
-                  env:
-                    - name: LABEL_BY_STORAGE_POOL
-                      value: "true"
                   resources:
                     requests:
                       cpu: 20m


### PR DESCRIPTION
Reverts #1391. **Merge and reconcile this** — the cluster is currently degraded: `linstor.csi.linbit.com` is deregistered from every CSINode, so no Piraeus volume can attach on any node.

## What happened

The labels worked exactly as designed. Once the HelmRelease picked up the values:

```
beelink01  linbit.com/sp-temporary-topolvm=true
beelink02  true
master02   true
master01   (absent)
```

The node plugin around them does not. With `LABEL_BY_STORAGE_POOL=true` the `linstor-csi-node` DaemonSet never settles: Pods reach `3/3 Running`, then are killed and replaced — the DaemonSet reports `ready 3/3` against Pods only seconds old, with repeated `Killing` events — and the driver is registered on nothing:

```
beelink01: NO linstor driver
beelink02: NO linstor driver
master02:  NO linstor driver
```

Volumes already mounted keep serving I/O, so the blast radius is Pods that need an *attach*: a restart, a reschedule, a new claim. It briefly looked healthy at one point — the registrar logged `plugin_registered:true` — and then resumed cycling, so one green sample is not proof of recovery.

## Why, probably

Not yet confirmed: with this flag the driver's `NodeGetInfo` must enumerate the node's LINSTOR storage pools before it can report topology, and if that call fails registration never completes. [linstor-csi#128](https://github.com/piraeusdatastore/linstor-csi/issues/128) — *"failed to retrieve node topology: failed to get storage pools for node"* — is the same shape, and the node plugin's logs show it running without Kubernetes API access (`open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory`, twice, each time "continuing without it").

Worth chasing separately if the `sp-` key is still wanted: it needs the node plugin able to resolve pools, which may mean giving it API access or an operator-side fix.

## After merge

The values-only change is why the original merge didn't apply itself — helm-controller gets no event from a ConfigMap change, so the release sat on old values for ~2h until reconciled by hand. Same applies to the revert:

```bash
flux reconcile source git ankhmorpork
```

```bash
flux -n flux-system reconcile kustomization piraeus-datastore
```

```bash
flux -n platform-storage reconcile helmrelease linstor-cluster
```

Then confirm the driver is back on all three nodes — this is the signal that attaches work again:

```bash
kubectl get csinode -o json | jq -r '.items[]|"\(.metadata.name) \([.spec.drivers[]|select(.name=="linstor.csi.linbit.com")|.topologyKeys[]]|join(","))"'
```

Expect `kubernetes.io/hostname,linbit.com/hostname` on beelink01, beelink02 and master02, and no entry on master01. The `linbit.com/sp-temporary-topolvm` node labels will linger — kubelet writes topology labels at registration and removes nothing when they go away — so clear them by hand once the DaemonSet is stable:

```bash
kubectl label node beelink01 beelink02 master02 linbit.com/sp-temporary-topolvm-
```

If the HelmRelease ends up suspended during firefighting, unsuspend it before reconciling.

## Consequence for #1389

The `sp-` key isn't available, so #1389's `allowedTopologies` stays on `linbit.com/hostname` with the three hostnames enumerated — which is what the API forces for a key whose value is unique per node. Don't rebase it onto the `sp-` idea.

🤖 Generated with [Claude Code](https://claude.com/claude-code)