### PR TITLE
vod-arr: move seerr-config to unifi-nas and off K8up

### DIFF
--- a/k8s/apps/vod-arr/README.md
+++ b/k8s/apps/vod-arr/README.md
@@ -111,6 +111,12 @@ the data follows the Pod.
 I/O is remote until that conversion completes, which is why the class is capped
 at 32Gi by the `validate-roaming-volume-size` policy. Every volume here is 2Gi.
 
+`seerr-config` is the exception: it is on `unifi-nas`. Once its database moved
+to `postgres-seerr` the volume held only `settings.json` and rotated logs, and
+plain files over NFS are safe in a way SQLite over `nolock` is not. NFS also
+attaches from any node, where a piraeus volume needs the linstor CSI plugin and
+so needs a nodeAffinity keeping the Pod off master01.
+
 Not `piraeus-r2`: it pins the Pod to the two nodes holding its replicas, which is
 the right trade for something latency-sensitive like plex's `/config`, but these
 are small single-replica apps where being able to land anywhere is worth more
@@ -136,8 +142,10 @@ Seerr reads its database connection from `DB_*` environment variables, so it
 has no init container: `postgres-seerr-user` goes straight into the pod from
 the `seerrdb` release. It moved off SQLite with the one-off load in
 [`hack/seerr-sqlite-to-postgres/`](../../../hack/seerr-sqlite-to-postgres/README.md)
-(#1370). `settings.json` stays on `seerr-config`, which is why that claim keeps
-its K8up annotation while the CNPG claims carry none.
+(#1370). `settings.json` stays on `seerr-config`, which moved to `unifi-nas` in
+the same breath: the UNAS backs up its own shares, so that claim carries no
+K8up annotation either. `qbittorrent-config` and `cleanuparr-config` still do,
+because they are on Piraeus and nothing else copies them.
 
 ### Doppler entries
 

--- a/k8s/apps/vod-arr/seerr/deployment.yaml
+++ b/k8s/apps/vod-arr/seerr/deployment.yaml
@@ -138,33 +138,6 @@ spec:
           volumeMounts:
             - mountPath: /app/config
               name: config
-      # seerr-config is a piraeus-r2-roaming volume, and that class has no node
-      # affinity on the PV -- being able to attach from anywhere is the point of
-      # the roaming variant. What it still needs is the linstor CSI node plugin,
-      # which runs only where Piraeus does. master01 cannot load the DRBD module
-      # (Secure Boot), so it carries no satellite and no plugin; a Pod scheduled
-      # there fails to attach forever with "CSINode master01 does not contain
-      # driver linstor.csi.linbit.com". Nothing stopped that until master01 was
-      # uncordoned, at which point the scheduler picked it every time -- it holds
-      # the least of anything in the cluster.
-      #
-      # linbit.com/hostname is one of the topology keys the linstor CSI node
-      # plugin registers, so kubelet stamps it on exactly the nodes where that
-      # plugin has come up -- the condition this Pod actually needs. It replaced
-      # a `linstor: "true"` nodeSelector, a hand-applied label that stopped
-      # meaning anything once Piraeus stopped reading it, and it is preferred
-      # over restating Piraeus's own placement rule here, which would silently
-      # diverge the day that rule gains a condition.
-      #
-      # Exists, because the value is the node's own hostname. That needs
-      # affinity: a nodeSelector can only compare a key to one fixed value.
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: linbit.com/hostname
-                    operator: Exists
       restartPolicy: Always
       # The image is already USER node:node, which is uid 1000.
       securityContext:

--- a/k8s/apps/vod-arr/seerr/pvc-config.yaml
+++ b/k8s/apps/vod-arr/seerr/pvc-config.yaml
@@ -1,15 +1,6 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  annotations:
-    # Opt in to K8up. The operator runs with skipWithoutAnnotation, so a claim
-    # without this is not backed up -- which is what keeps the CNPG claims in
-    # this namespace out, since they self-backup via barman.
-    #
-    # What is left here is settings.json: plain files, so the file-level copy
-    # is a faithful one. The database lives in postgres-seerr (../seerrdb) and
-    # is barman's to back up.
-    k8up.io/backup: "true"
   name: seerr-config
 spec:
   accessModes:
@@ -17,4 +8,27 @@ spec:
   resources:
     requests:
       storage: 2Gi
-  storageClassName: piraeus-r2-roaming
+  # unifi-nas, not the piraeus-r2-roaming every other config claim here uses.
+  #
+  # The SQLite database that used to sit in db/ is what made NFS the wrong
+  # answer: SQLite corrupts when its advisory locks are not honoured, and this
+  # class mounts nfsvers=3,nolock. With the database in postgres-seerr all that
+  # is left is settings.json and a self-rotating log directory -- plain files,
+  # which NFS serves correctly.
+  #
+  # What it buys is scheduling freedom. The linstor CSI node plugin runs only
+  # where Piraeus does, so a piraeus-backed Pod needs a nodeAffinity to stay
+  # off master01, which cannot load the DRBD module under Secure Boot. csi-nfs
+  # runs on all four nodes, so this claim attaches anywhere and the affinity is
+  # gone from the Deployment.
+  #
+  # Deliberately no k8up.io/backup, unlike qbittorrent-config and
+  # cleanuparr-config: the UNAS backs up its own shares, so K8up here would be
+  # restic reading the NAS to write a repo onto the same NAS, and the NAS would
+  # then back up both. Removing SQLite removed the need for the backupcommand
+  # hook; moving to a medium that is already backed up removes the need for the
+  # file-level copy too.
+  #
+  # excluded_from_alerts is not set here -- mutate-nfs-pvc-alert-exclusion
+  # stamps it on every unifi-nas claim.
+  storageClassName: unifi-nas


### PR DESCRIPTION
Follow-on to the postgres cutover. Now that seerr's database lives in `postgres-seerr`, `seerr-config` holds only `settings.json` and a self-rotating log directory — and that changes both the right medium for it and whether K8up should touch it.

## Why NFS is now the right medium

The SQLite database was the reason it wasn't. `unifi-nas` mounts `nfsvers=3,nolock`, and unhonoured advisory locks are exactly how SQLite corrupts. Plain JSON has no such requirement.

## What it buys

`piraeus-r2-roaming` puts no nodeAffinity on the PV — attaching from anywhere is the point of the roaming class — but the Pod still needs the linstor CSI node plugin, which runs only where Piraeus does. That is why f6777b36 had to pin seerr to `linbit.com/hostname`, keeping it off master01, which cannot load the DRBD module under Secure Boot.

`csi-nfs-node` runs on all four nodes, master01 included. So the affinity and its twenty lines of explanation are both gone, and seerr schedules freely.

## Why the K8up annotation goes too

The UNAS backs up its own shares. K8up on an NFS claim would be restic reading the NAS to write a repo onto the same NAS, with the NAS then backing up both.

Worth separating the two reasons this volume shed backup machinery, because they are different problems: removing SQLite removed the need for the **`backupcommand` hook** (consistency — torn reads), and moving to an already-backed-up medium removes the need for the **file-level copy** (durability). `qbittorrent-config` and `cleanuparr-config` keep their annotations — they are on Piraeus, and nothing else copies them.

## Verified before the swap

A Pod carrying seerr's exact securityContext — uid/gid 1000, `runAsNonRoot: true`, `fsGroup: 1000`, `capabilities: drop [ALL]` — created files and a subdirectory on a fresh `unifi-nas` claim:

```
drwxrwsr-x    1 977      988    logs
-rw-r--r--    1 977      988    settings.json
uid=1000 gid=1000 groups=1000
WRITE-OK
```

The export squashes ownership to 977:988 and the write still succeeds, so no `chmod` init container is needed. `recyclarr-config` is the standing precedent — same class, same uid, no init container, 187M written.

`ReadWriteOnce` and no hand-set `excluded_from_alerts`, both matching `recyclarr-config`; the label is stamped on CREATE by `mutate-nfs-pvc-alert-exclusion`, whose match condition is `storageClassName == "unifi-nas"`.

## Rollout

`storageClassName` is immutable, so this is a delete-and-recreate of the claim, done with the Kustomization suspended so nothing starts seerr against an empty volume:

1. Suspend the `vod-arr` Kustomization, scale seerr to 0
2. Old PV to `Retain`, delete the claim
3. Recreate on `unifi-nas`, restore `settings.json`, `settings.json.bak`, `settings.old.json` and `logs/` — **not** `db/`
4. Scale up, confirm seerr is serving and still on postgres
5. Resume the Kustomization

A local copy of the whole volume (875 KB) is held outside the cluster for the duration, and the old PV is retained as a second fallback. The stale `db/db.sqlite3` is deliberately not carried across — it is a complete, internally consistent seerr database frozen at the cutover, and leaving it in the restore path is a decoy.

Closes nothing on its own; follows #1370.
