### PR TITLE
Import the module-signing label into LINSTOR topology

### DIFF
--- a/docs/reference/annotations.md
+++ b/docs/reference/annotations.md
@@ -230,6 +230,15 @@ node classifies surprisingly:
     describes what the running kernel was *built* to support and reads identically
     on every node here whatever the firmware is doing.
 
+It is also imported into LINSTOR as `Aux/topology/feature.node.kubernetes.io/module-signing-enforced`
+by the `common` satellite configuration. Anything under `Aux/topology/` is
+stripped of that prefix and reported by the driver as a CSI topology key, which
+makes this label usable in a `piraeus-*` StorageClass's `allowRemoteVolumeAccess`
+— see [storage classes](storage-classes.md). Two consequences worth knowing:
+the key is only advertised at plugin *registration*, so a csi-node restart is
+needed after the label first appears on a node; and a node without the label
+gets no property, so the topology key is simply absent there.
+
 Exclude with `NotIn [true]` rather than selecting on `false`: a node whose label
 is missing — labeler not run, discovery broken — then still matches, so a failure
 of discovery cannot deschedule a storage workload that was running.

--- a/k8s/platform/storage/piraeus-datastore/cluster/values.yaml
+++ b/k8s/platform/storage/piraeus-datastore/cluster/values.yaml
@@ -210,6 +210,23 @@ linstorCluster:
 linstorSatelliteConfigurations:
   - name: common
     deletionPolicy: Evacuate
+    # Import the NFD label into LINSTOR's topology namespace. Anything under
+    # Aux/topology/ is stripped of that prefix and reported by the driver as a
+    # CSI topology key (linstor-csi GetNodeTopologies), which is how it reaches
+    # a PV's nodeAffinity through allowRemoteVolumeAccess below.
+    #
+    # This key rather than linbit.com/hostname because fromSame freezes the
+    # placing node's *value* into the PV, so the key has to carry the same value
+    # on every eligible node. hostname is unique per node, which would pin each
+    # volume to one machine.
+    #
+    # optional: a node with no such label gets no property, rather than an empty
+    # one.
+    properties:
+      - name: Aux/topology/feature.node.kubernetes.io/module-signing-enforced
+        valueFrom:
+          nodeFieldRef: metadata.labels['feature.node.kubernetes.io/module-signing-enforced']
+        optional: true
     podTemplate:
       spec:
         # DRBD replication should use the node network directly instead of the


### PR DESCRIPTION
Groundwork for making new `piraeus-r2-roaming` volumes carry node affinity, derived from NFD instead of a hand-stamped label. **Inert on its own** — no StorageClass changes here, nothing names the new key yet.

## The chain, verified end to end

```
labeler DaemonSet → node label → nodeFieldRef import → LINSTOR Aux/topology/* prop
  → GetNodeTopologies segment → CSINode topologyKeys → fromSame → PV nodeAffinity
```

Each hop was checked rather than assumed: the import format from the operator's own live defaults on `LinstorSatellite/master02`, the segment construction from `linstor-csi/pkg/client/linstor.go`, and the last two hops from a scratch-class experiment on 2026-09-07 — the PV came out with `module-signing-enforced In [false]` and a Pod pinned to master01 stayed `Pending` with *"didn't match PersistentVolume's node affinity"* instead of being scheduled and then failing to attach.

## Why this key

`fromSame` freezes the **placing node's value** into the PV, so it only expresses "any eligible node" when the key's value is shared across them. `linbit.com/hostname` is unique per node, which would pin every volume to one machine. The NFD label reads `false` on all three satellites and `true` on master01.

It says "this kernel would load DRBD" rather than "a satellite is here" — close enough that master01 is excluded correctly, and the semantically exact key (`linbit.com/sp-<pool>`, satellites-only and driver-published) needs `--label-by-storage-pool`, which took the driver down cluster-wide earlier today.

## After merge, in this order

```bash
flux -n platform-storage reconcile helmrelease linstor-cluster
```

```bash
kubectl -n platform-storage exec deploy/linstor-controller -- linstor node list-properties master02 | grep module-signing
```

Then re-register csi-node **one pod at a time**, waiting for the driver to be registered on all three nodes between each:

```bash
kubectl -n platform-storage delete pod -l app.kubernetes.io/component=linstor-csi-node --wait
```

(one at a time is safer — deleting all three at once leaves no driver registered anywhere, which is a cluster-wide attach outage for as long as it lasts)

```bash
kubectl get csinode -o json | jq -r '.items[]|"\(.metadata.name) \([.spec.drivers[]|select(.name=="linstor.csi.linbit.com")|.topologyKeys[]]|join(","))"'
```

The gate: `feature.node.kubernetes.io/module-signing-enforced` must appear alongside `kubernetes.io/hostname` and `linbit.com/hostname` on beelink01, beelink02 and master02, and **not** on master01. The follow-up PR must not merge until that is true — a class naming an unadvertised key intersects to nothing and provisions volumes with no affinity, silently.

## Verification here

`make validate` (126 targets), `docs-reference-check`, `docs-lint` (0 errors), `docs-build` clean. The rendered `LinstorSatelliteConfiguration` server-side dry-ran clean against the live API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)