### PR TITLE
[blocked: needs csi-node re-registration] piraeus: roaming PVs carry node affinity from the NFD label

### DIFF
--- a/docs/reference/storage-classes.md
+++ b/docs/reference/storage-classes.md
@@ -99,6 +99,23 @@ because the chart's template does not render that field. Under
 new volume is steered to a node that can serve it — it does nothing for a claim
 that is already bound.
 
+`piraeus-r2-roaming` narrows "anywhere" with `allowRemoteVolumeAccess:
+fromSame` on `feature.node.kubernetes.io/module-signing-enforced`, so a **newly
+created** roaming PV carries `nodeAffinity` for nodes sharing the placing node's
+value — and master01, the one node reading `true`, is refused by the scheduler
+before a Pod is placed. `fromSame` freezes the placing node's *value* into the
+PV, which is why the key has to be one whose value is shared across satellites
+rather than `linbit.com/hostname`.
+
+!!! warning "Only volumes created after that change"
+
+    `PV.spec.nodeAffinity` is immutable, so every roaming volume predating it
+    keeps none, and nothing but a Pod-level rule keeps those off a node with no
+    CSI plugin. The key is also only reported at plugin *registration*, so a
+    csi-node restart is required after it first appears on a node; a class naming
+    a key that is not advertised intersects to nothing and provisions volumes
+    with no affinity at all, without erroring.
+
 The size cap is a resync budget: a moved Pod resyncs the volume across the node
 network, and a full 32 GiB is roughly five more minutes at 1 Gb/s.
 `rs-discard-granularity` keeps unallocated blocks off the wire, but requested size

--- a/k8s/platform/storage/piraeus-datastore/cluster/values.yaml
+++ b/k8s/platform/storage/piraeus-datastore/cluster/values.yaml
@@ -315,7 +315,25 @@ storageClasses:
       csi.storage.k8s.io/fstype: xfs
       linstor.csi.linbit.com/autoPlace: "2"
       linstor.csi.linbit.com/storagePool: temporary-topolvm
-      linstor.csi.linbit.com/allowRemoteVolumeAccess: "true"
+      # "true" means accessible from anywhere, which is why every roaming PV
+      # created before this carries no nodeAffinity at all -- and why a Pod could
+      # be scheduled onto master01 and then wait forever on "CSINode master01
+      # does not contain driver linstor.csi.linbit.com".
+      #
+      # fromSame narrows "anywhere" to "nodes whose module-signing-enforced value
+      # matches the placing node's", i.e. false -- so a new volume's PV carries
+      # nodeAffinity the scheduler enforces, and master01 (true) is refused
+      # before the Pod is placed rather than after.
+      #
+      # Verified on a scratch class 2026-09-07: PV came out with
+      # `module-signing-enforced In [false]`, and a Pod pinned to master01 stayed
+      # Pending with "didn't match PersistentVolume's node affinity".
+      #
+      # Only applies to volumes created from here on. PV nodeAffinity is
+      # immutable, so the 13 roaming volumes that predate this keep none.
+      linstor.csi.linbit.com/allowRemoteVolumeAccess: |
+        - fromSame:
+            - feature.node.kubernetes.io/module-signing-enforced
       property.linstor.csi.linbit.com/DrbdOptions/auto-diskful: "5"
       # DRBD writes activity-log metadata synchronously whenever a write lands in
       # an extent it is not already tracking. The default 1237 extents cover


### PR DESCRIPTION
Follow-up to #1394, which is merged. **Do not merge until the gate passes**: `feature.node.kubernetes.io/module-signing-enforced` visible in `CSINode.spec.drivers[].topologyKeys` on beelink01, beelink02 and master02. That needs the HelmRelease reconciled and csi-node re-registered — see #1394's runbook.

Switches `piraeus-r2-roaming` from `allowRemoteVolumeAccess: "true"` to:

```yaml
linstor.csi.linbit.com/allowRemoteVolumeAccess: |
  - fromSame:
      - feature.node.kubernetes.io/module-signing-enforced
```

A newly created roaming PV then carries `nodeAffinity` for nodes sharing the placing node's value (`false`), and master01 is refused **by the scheduler** instead of hanging on attach afterwards.

## Verified on a scratch class

```
PV nodeAffinity:  module-signing-enforced In [false]
Pod → master01:   Pending, "1 node(s) didn't match PersistentVolume's node affinity"
```

Contrast with the earlier run where the key was not yet advertised: the volume provisioned **successfully, with no affinity and no error**. That silent mode is exactly why this PR is gated rather than merged alongside #1394.

## This needs a manual step — it cannot apply by upgrade

`parameters` is immutable. Proof, dry-run against the live API:

```
The StorageClass "piraeus-r2-roaming" is invalid: parameters: ... field is immutable
```

After merging, delete the class and let Helm recreate it:

```bash
kubectl get storageclass piraeus-r2-roaming -o yaml > /tmp/piraeus-r2-roaming.bak.yaml
```

```bash
kubectl delete storageclass piraeus-r2-roaming
```

```bash
flux -n flux-system reconcile kustomization piraeus-datastore
```

```bash
flux -n platform-storage reconcile helmrelease linstor-cluster
```

Bound volumes are unaffected — a PV carries its own copy of the class settings. New claims fail only for the seconds between delete and recreate. Then confirm:

```bash
kubectl get storageclass piraeus-r2-roaming -o jsonpath='{.parameters}'
```

The end-to-end check is a fresh 1 GiB claim on the class: its PV should show `module-signing-enforced In [false]`. If it shows `null`, the key is not advertised — stop and re-check the gate rather than assuming it worked.

## Two limits, documented rather than hidden

- **Only new volumes.** `PV.spec.nodeAffinity` is immutable, so the 13 roaming volumes predating this keep none. Those workloads remain exposed to the master01 failure and only a Pod-level rule fixes them; this PR does not.
- **Registration timing.** The key is reported during `NodeGetInfo`, which kubelet calls at plugin registration only — so a csi-node restart is needed after the label first appears on a node, including any node added later.

`make validate` (126 targets), `docs-lint` (0 errors), `docs-build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)