### PR TITLE
vod-arr: give bazarr its own CNPG cluster and back up its config

### DIFF
--- a/docs/reference/helm-releases.md
+++ b/docs/reference/helm-releases.md
@@ -11,9 +11,9 @@ and why the interval matters, see
 
 | | |
 | --- | --- |
-| **Total** | 48 releases, 35 distinct charts |
+| **Total** | 49 releases, 35 distinct charts |
 | **Intervals in use** | `5m` |
-| **Charts used more than once** | `cnpg-database` ×12, `versitygw` ×2, `traefik` ×2 |
+| **Charts used more than once** | `cnpg-database` ×13, `versitygw` ×2, `traefik` ×2 |
 
 | Release | Namespace | Chart | Source | Interval | Values from | Component |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -61,6 +61,7 @@ and why the interval matters, see
 | [`topolvm`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/platform/storage/topolvm-system/topolvm/release.yaml) | `topolvm-system` | `topolvm` | `https://topolvm.github.io/topolvm` | `5m` | ConfigMap `values-topolvm` | `topolvm` |
 | [`private`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/platform/network/traefik/private/release.yaml) | `traefik` | `traefik` | `https://traefik.github.io/charts` | `5m` | ConfigMap `values-common`<br>ConfigMap `values-private` | `traefik` |
 | [`public`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/platform/network/traefik/public/release.yaml) | `traefik` | `traefik` | `https://traefik.github.io/charts` | `5m` | ConfigMap `values-common`<br>ConfigMap `values-public` | `traefik` |
+| [`postgres-bazarr`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/apps/vod-arr/bazarrdb/release.yaml) | `vod-arr` | `cnpg-database` | `oci://ghcr.io/thaum-xyz/helm-charts` | `5m` | ConfigMap `values-postgres-bazarr` | `vod-arr` |
 | [`postgres-prowlarr`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/apps/vod-arr/prowlarrdb/release.yaml) | `vod-arr` | `cnpg-database` | `oci://ghcr.io/thaum-xyz/helm-charts` | `5m` | ConfigMap `values-postgres-prowlarr` | `vod-arr` |
 | [`postgres-radarr`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/apps/vod-arr/radarrdb/release.yaml) | `vod-arr` | `cnpg-database` | `oci://ghcr.io/thaum-xyz/helm-charts` | `5m` | ConfigMap `values-postgres-radarr` | `vod-arr` |
 | [`postgres-seerr`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/apps/vod-arr/seerrdb/release.yaml) | `vod-arr` | `cnpg-database` | `oci://ghcr.io/thaum-xyz/helm-charts` | `5m` | ConfigMap `values-postgres-seerr` | `vod-arr` |

--- a/k8s/apps/vod-arr/README.md
+++ b/k8s/apps/vod-arr/README.md
@@ -144,17 +144,25 @@ the `seerrdb` release. It moved off SQLite with the one-off load in
 [`hack/seerr-sqlite-to-postgres/`](../../../hack/seerr-sqlite-to-postgres/README.md)
 (#1370). `settings.json` stays on `seerr-config`, which moved to `unifi-nas` in
 the same breath: the UNAS backs up its own shares, so that claim carries no
-K8up annotation either. `qbittorrent-config` and `cleanuparr-config` still do,
-because they are on Piraeus and nothing else copies them.
+K8up annotation either.
+
+Bazarr reads `POSTGRES_*` from the environment the same way (`app/database.py`:
+`POSTGRES_ENABLED` overrides `settings.postgresql.enabled`, and each field falls
+back to `config.yaml` individually), so it needs no init container either. It
+was the last app here on SQLite. Its `config.yaml` holds the subtitle provider
+credentials and stays on `bazarr-config`, so unlike seerr that claim keeps a
+K8up annotation -- it is on Piraeus, not the NAS. `qbittorrent-config` and
+`cleanuparr-config` keep theirs for the same reason.
 
 ### Doppler entries
 
 Reused: `VPN_USERNAME`, `VPN_PASSWORD`, `{SONARR,RADARR,PROWLARR}_DB_ADMIN_PASS`,
 `{SONARR,RADARR,PROWLARR}_DB_PASS`, `POSTGRES_S3_{ACCESS,SECRET}_KEY`.
 
-New, and required: `SEERR_DB_ADMIN_PASS`, `SEERR_DB_PASS`. The `postgres-seerr`
-release renders them into `postgres-seerr-admin` and `postgres-seerr-user`, and
-neither the cluster nor seerr starts without those Secrets.
+New, and required: `{SEERR,BAZARR}_DB_ADMIN_PASS`, `{SEERR,BAZARR}_DB_PASS`. The
+`postgres-seerr` and `postgres-bazarr` releases render them into
+`postgres-<app>-admin` and `postgres-<app>-user`, and neither the cluster nor
+the app starts without those Secrets.
 
 New, and optional — absent, each app generates its own key and only the
 automated integrations suffer: `SONARR_API_KEY`, `RADARR_API_KEY`,

--- a/k8s/apps/vod-arr/bazarr/deployment.yaml
+++ b/k8s/apps/vod-arr/bazarr/deployment.yaml
@@ -30,6 +30,29 @@ spec:
         - env:
             - name: TZ
               value: Europe/Berlin
+            # bazarr reads these directly (app/database.py:31-51): POSTGRES_ENABLED
+            # overrides settings.postgresql.enabled from config.yaml, and each
+            # field below falls back to that file individually. So no init
+            # container rewriting config on start, the way the *arrs need for
+            # config.xml -- the env is the whole of it.
+            - name: POSTGRES_ENABLED
+              value: "true"
+            - name: POSTGRES_HOST
+              value: postgres-bazarr-rw
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_DATABASE
+              value: bazarr
+            - name: POSTGRES_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-bazarr-user
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-bazarr-user
+                  key: password
           image: ghcr.io/home-operations/bazarr:1.6.0
           imagePullPolicy: IfNotPresent
           name: bazarr

--- a/k8s/apps/vod-arr/bazarr/pvc-config.yaml
+++ b/k8s/apps/vod-arr/bazarr/pvc-config.yaml
@@ -1,6 +1,18 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  annotations:
+    # Opt in to K8up. The database moved to postgres-bazarr (../bazarrdb), but
+    # config.yaml did not: it holds the subtitle provider credentials and is a
+    # plain file, so the file-level copy is a faithful one and needs no
+    # backupcommand hook.
+    k8up.io/backup: "true"
+    # log/ rotates on its own and was 5.5M of the 17M here; cache/ and
+    # releases.txt are fetched; db/ holds the SQLite file postgres replaced,
+    # which is a complete, internally consistent bazarr database frozen at the
+    # cutover -- exactly the decoy a restore should not offer. It stays on the
+    # volume as a fallback until the cutover is proven, but it is not shipped.
+    k8up.io/backup-restic-args: '["--exclude=/data/bazarr-config/log", "--exclude=/data/bazarr-config/cache", "--exclude=/data/bazarr-config/db", "--exclude=/data/bazarr-config/config/releases.txt"]'
   name: bazarr-config
 spec:
   accessModes:

--- a/k8s/apps/vod-arr/bazarrdb/kustomization.yaml
+++ b/k8s/apps/vod-arr/bazarrdb/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - release.yaml
+configMapGenerator:
+  - name: values-postgres-bazarr
+    files:
+      - values.yaml=values.yaml
+# Stable ConfigMap name: helm-controller tracks values through
+# status.lastAttemptedConfigDigest, so the hash suffix is not needed to detect
+# changes, and without it there is no name for nameReference to rewrite.
+generatorOptions:
+  disableNameSuffixHash: true

--- a/k8s/apps/vod-arr/bazarrdb/release.yaml
+++ b/k8s/apps/vod-arr/bazarrdb/release.yaml
@@ -1,0 +1,34 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: postgres-bazarr
+spec:
+  # Pinned: resource names derive from the release name, and postgres-bazarr-rw is
+  # hardcoded by this app's consumers.
+  releaseName: postgres-bazarr
+  chart:
+    spec:
+      chart: cnpg-database
+      version: "0.10.2"
+      sourceRef:
+        kind: HelmRepository
+        name: thaum-charts
+      interval: 5m
+  interval: 5m
+  timeout: 10m
+  install:
+    # Helm's waiter cannot judge a CNPG Cluster, and install remediation would
+    # uninstall the release -- deleting the Cluster and its PVCs.
+    disableWait: true
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 0
+  uninstall:
+    deletionPropagation: orphan
+  # warn, not enabled: enabled would fight CNPG's own defaulted fields forever.
+  driftDetection:
+    mode: warn
+  valuesFrom:
+    - kind: ConfigMap
+      name: values-postgres-bazarr

--- a/k8s/apps/vod-arr/bazarrdb/values.yaml
+++ b/k8s/apps/vod-arr/bazarrdb/values.yaml
@@ -1,0 +1,30 @@
+database: bazarr
+owner: bazarr
+
+cluster:
+  instances: 2
+  storage:
+    # The SQLite file this replaces was 6.4 MB with a 4.4 MB WAL when measured
+    # on 2026-09-07, and most of its 8288 rows are subtitle state bazarr
+    # re-derives by scanning. 2Gi is the same allowance the other arrs get.
+    size: 2Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+
+backup:
+  schedule: "0 7 4 * * *"
+  objectStore:
+    # Several clusters share this namespace, so each needs its own store.
+    name: versity-vod-bazarr
+    bucketPrefix: s3://cnpg/postgres
+    endpointURL: http://versitygw.cnpg-system.svc.cluster.local:7070
+    retentionPolicy: 7d
+    pathSuffix: vod-bazarr
+
+externalSecrets:
+  admin:
+    remoteKey: BAZARR_DB_ADMIN_PASS
+  user:
+    remoteKey: BAZARR_DB_PASS

--- a/k8s/apps/vod-arr/kustomization.yaml
+++ b/k8s/apps/vod-arr/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - sonarr/
   - sonarrdb/
   - bazarr/
+  - bazarrdb/
   - qbittorrent/
   - seerr/
   - seerrdb/


### PR DESCRIPTION
Closes the last real coverage gap from the #1266 work. Bazarr was the only claim left in the cluster holding irreplaceable data with **no backup of any kind**.

## What was exposed

```
/config            17M
  db/bazarr.db     6.4M   + 4.4M WAL   <- live SQLite, actively written
  log/             5.5M                <- self-rotating
  config/          280K                <- config.yaml 7.4K: provider credentials
```

The WAL being two-thirds the size of the database is the point: a file-level copy without a hook would very likely have captured a database and a WAL that were never a consistent pair, producing a backup that restores into a corrupt file.

Bazarr was also the last of the four *arrs on SQLite, sitting next to prowlarr, radarr and sonarr on CNPG — so it gets a cluster rather than a fourth `backupcommand` hook.

## Two halves, two mechanisms

**The database → `postgres-bazarr`**, barman to versitygw, `7d` retention, backup at 04:07 continuing the other four clusters' ten-minute stagger, with its own objectStore since they share the namespace.

Wiring is env-only. `app/database.py` reads `POSTGRES_ENABLED` as an override for `settings.postgresql.enabled` and falls back to `config.yaml` field by field, so unlike sonarr and friends there is no `config.xml` for an init container to rewrite.

**`config.yaml` → K8up.** It does not move to postgres, and `bazarr-config` is on Piraeus rather than the NAS, so this claim *keeps* a K8up annotation — the opposite of what [#1393](https://github.com/thaum-xyz/ankhmorpork/pull/1393) did for seerr, whose `settings.json` rode along on a share the UNAS already backs up. Plain YAML, so no hook needed.

Excluded from that copy: `log/`, `cache/`, `config/releases.txt`, and `db/` — after the cutover that last one holds a complete, internally consistent bazarr database frozen at the migration moment, the same decoy seerr's stale `db.sqlite3` turned out to be. It stays on the volume as a fallback until the cutover is proven; it just isn't shipped.

## Fresh start rather than pgloader — and what that costs you

I measured every table before deciding:

| Rows | Table | Fate on a fresh database |
| --- | --- | --- |
| 8288 | `table_episodes_subtitles` | re-derived by scanning the media dirs |
| 1366 / 439 / 33 | `table_episodes` / `_movies` / `_shows` | re-synced from sonarr and radarr |
| 187 / 129 | `table_settings_languages` / `_notifier` | catalogue bazarr repopulates |
| 83 + 71 | `table_history` + `_history_movie` | **lost** — a log of what was fetched when |
| 1 | `table_languages_profiles` | **lost** — your language profile |
| 0 | `table_blacklist_movie` | empty, nothing to lose |

The blacklist being empty is what makes this safe: that was the one table whose loss would cause bazarr to re-fetch subtitles you had explicitly rejected.

**What you will need to do after the cutover:** re-create one language profile and mass-assign it to the 33 shows and 439 movies (two bulk-edit operations). Bazarr then re-syncs from sonarr/radarr and rescans subtitles from disk, so existing subtitle files are detected as present rather than re-downloaded — no provider hammering.

The alternative is a pgloader run across 17 tables of SQLAlchemy schema with alembic-managed sequences. That buys back 154 rows of history log and saves two UI operations. I did not think that trade was worth the fragility, but the SQLite file is retained either way, so pgloader stays possible if you decide the history matters.

## Rollout

`BAZARR_DB_ADMIN_PASS` and `BAZARR_DB_PASS` are already in Doppler, so nothing blocks this.

1. Merge; the cluster bootstraps and bazarr restarts against the empty database
2. Confirm alembic built the schema and bazarr is serving
3. Confirm the first barman base backup and WAL archiving
4. Confirm the K8up file-level copy picks up `config.yaml` and honours all four excludes
5. Re-create the language profile

After this, every claim in the cluster is either backed up, self-backing-up, or deliberately excluded with the reason written down.
