### PR TITLE
cnpg: finish every backup before the offsite copy starts

### DIFF
--- a/k8s/apps/photos/db/values.yaml
+++ b/k8s/apps/photos/db/values.yaml
@@ -32,7 +32,9 @@ cluster:
       - 'CREATE EXTENSION IF NOT EXISTS earthdistance WITH SCHEMA public;'
 
 backup:
-  schedule: "0 13 2 * * *"
+  # Ends before 01:30 UTC, which is 03:30 Warsaw in summer -- when the UNAS
+  # copies these backups offsite. Later, and the copy ships yesterday's.
+  schedule: "0 43 23 * * *"
   objectStore:
     retentionPolicy: 14d
     pathSuffix: photos

--- a/k8s/apps/vod-arr/bazarrdb/values.yaml
+++ b/k8s/apps/vod-arr/bazarrdb/values.yaml
@@ -14,7 +14,9 @@ cluster:
       memory: 256Mi
 
 backup:
-  schedule: "0 7 4 * * *"
+  # Ends before 01:30 UTC, which is 03:30 Warsaw in summer -- when the UNAS
+  # copies these backups offsite. Later, and the copy ships yesterday's.
+  schedule: "0 37 0 * * *"
   objectStore:
     # Several clusters share this namespace, so each needs its own store.
     name: versity-vod-bazarr

--- a/k8s/apps/vod-arr/prowlarrdb/values.yaml
+++ b/k8s/apps/vod-arr/prowlarrdb/values.yaml
@@ -15,7 +15,9 @@ cluster:
       - ALTER DATABASE logs OWNER TO prowlarr;
 
 backup:
-  schedule: "0 47 3 * * *"
+  # Ends before 01:30 UTC, which is 03:30 Warsaw in summer -- when the UNAS
+  # copies these backups offsite. Later, and the copy ships yesterday's.
+  schedule: "0 17 0 * * *"
   objectStore:
     # Several clusters share this namespace, so each needs its own store.
     name: versity-vod-prowlarr

--- a/k8s/apps/vod-arr/radarrdb/values.yaml
+++ b/k8s/apps/vod-arr/radarrdb/values.yaml
@@ -15,7 +15,9 @@ cluster:
       - ALTER DATABASE logs OWNER TO radarr;
 
 backup:
-  schedule: "0 37 3 * * *"
+  # Ends before 01:30 UTC, which is 03:30 Warsaw in summer -- when the UNAS
+  # copies these backups offsite. Later, and the copy ships yesterday's.
+  schedule: "0 7 0 * * *"
   objectStore:
     # Several clusters share this namespace, so each needs its own store.
     name: versity-vod-radarr

--- a/k8s/apps/vod-arr/seerrdb/values.yaml
+++ b/k8s/apps/vod-arr/seerrdb/values.yaml
@@ -14,7 +14,9 @@ cluster:
       memory: 256Mi
 
 backup:
-  schedule: "0 57 3 * * *"
+  # Ends before 01:30 UTC, which is 03:30 Warsaw in summer -- when the UNAS
+  # copies these backups offsite. Later, and the copy ships yesterday's.
+  schedule: "0 27 0 * * *"
   objectStore:
     # Several clusters share this namespace, so each needs its own store.
     name: versity-vod-seerr

--- a/k8s/apps/vod-arr/sonarrdb/values.yaml
+++ b/k8s/apps/vod-arr/sonarrdb/values.yaml
@@ -15,7 +15,9 @@ cluster:
       - ALTER DATABASE logs OWNER TO sonarr;
 
 backup:
-  schedule: "0 27 3 * * *"
+  # Ends before 01:30 UTC, which is 03:30 Warsaw in summer -- when the UNAS
+  # copies these backups offsite. Later, and the copy ships yesterday's.
+  schedule: "0 57 23 * * *"
   objectStore:
     # Several clusters share this namespace, so each needs its own store.
     name: versity-vod-sonarr


### PR DESCRIPTION
Pairs with moving the UNAS offsite copy to **03:30 Warsaw** — 01:30 UTC in summer, 02:30 in winter.

## The problem

Six CNPG clusters ran after that time: `photos` at 02:13 and the five `vod-arr` clusters from 03:27 to 04:07. Their base backups would have been copied offsite a day late, every day.

Nothing was at risk of corruption. Barman writes immutable objects and never rewrites them, so a copy taken mid-backup gives one partial base backup with every earlier one intact — staleness, not damage. But there's no reason to pay it when the fix is six cron lines.

## The nightly window afterwards, in UTC

```
21:15 - 22:16   K8up restic backups, 5 namespaces
22:36           paperless document_exporter + paperless CNPG
23:17           atuin, grafana, mealie, pocket-id CNPG
23:30           ai-gateway, mended-drum CNPG
23:43           photos CNPG            <- was 02:13
23:57           sonarr CNPG            <- was 03:27
00:07           radarr CNPG            <- was 03:37
00:17           prowlarr CNPG          <- was 03:47
00:27           seerr CNPG             <- was 03:57
00:37           bazarr CNPG            <- was 04:07
00:38           last write lands
--------------------------------------------------
01:30           UNAS offsite copy starts (summer)
```

52 minutes of margin in summer, 1h52m in winter. The vod-arr ten-minute stagger is preserved, and photos slots into the block the other seven clusters already occupy.

## Why the restic side needed no change

It is the reason the window matters at all. Unlike barman, a restic repository is only consistent at rest, and `prune` rewrites and deletes pack files — copy one mid-prune and the offsite gets an index pointing at packs that are gone, which you discover at restore time.

K8up's backups end at 22:16 and its prunes are Sunday 07:15–08:15. Both are far clear of the new copy window — **further clear than they were of the old 00:30 Warsaw copy**, which left only fourteen minutes after the last restic write. Moving the copy later fixes that margin as a side effect.

Measured while sizing this: CNPG backups take ~30s each (max observed 72s), K8up backup jobs 5–40s, and the paperless exporter 118s. So the 52-minute margin is roughly fifty times the longest job.

## Not changed

`recyclarr`'s 04:00 CronJob still writes to its NFS claim after the copy begins. Left alone deliberately — it holds cloned guide repos and config that recyclarr rebuilds from scratch, so a day-old offsite copy of it costs nothing.

## Rollout

Values-only change; the `cnpg-database` chart renders these into `ScheduledBackup` objects. No cluster is touched and no backup is skipped — the next run for each simply happens at the new time.
