### PR TITLE
vod-arr: keep logs off the config claims, declare LogLevel

### DIFF
--- a/k8s/apps/vod-arr/README.md
+++ b/k8s/apps/vod-arr/README.md
@@ -127,13 +127,42 @@ The CNPG clusters stay on the chart's `lvm-thin`: they have their own replicatio
 and barman backups, so DRBD underneath would be a second copy of a guarantee
 Postgres already gives.
 
+### Logs
+
+Every app here writes its log to stdout, and `alloy` tails `/var/log/pods` on all
+four nodes into Loki, which keeps six months. The file copies are a local
+convenience for each app's own log viewer, so each log directory is an
+`emptyDir` rather than part of the claim:
+
+| App                        | Log directory  |
+| -------------------------- | -------------- |
+| sonarr / radarr / prowlarr | `/config/logs` |
+| bazarr                     | `/config/log`  |
+| cleanuparr                 | `/config/logs` |
+
+qBittorrent needs no volume: the image symlinks `qbittorrent.log` to
+`/proc/self/fd/1`, which is the same idea one layer down.
+
+The three *arrs are why `LogLevel` is now declared. At `debug`, where the UI had
+it, they keep a 50 × `logSizeLimit` ring of `*.debug.txt` on top of the info log,
+while `ConsoleLogLevel` stays empty and stdout carries Info only. That made the
+debug detail the one thing here with no second copy: absent from Loki, on a claim
+with no `k8up` annotation, and overwritten as the ring wraps. Raising
+`ConsoleLogLevel` for the length of an investigation puts it in Loki instead,
+where it can be searched.
+
+`sizeLimit` on each `emptyDir` sits above the app's own rotation ceiling, since
+exceeding it evicts the Pod rather than dropping a log line.
+
 ## Configuration that is declared
 
-The `postgres-setup` init container rewrites `config.xml` on every start. It
+The `render-config` init container rewrites `config.xml` on every start. It
 sets the Postgres connection, turns the built-in login **off**
 (`AuthenticationMethod: External` — the private ingress is the trust boundary,
-and a password nobody has is how the old namespace became unauditable), and
-pins the API key from Doppler when the entry exists.
+and a password nobody has is how the old namespace became unauditable), pins
+`LogLevel` to `info`, and pins the API key from Doppler when the entry exists.
+
+It was called `postgres-setup` while Postgres was all it did.
 
 A declared API key is what lets Prowlarr, Bazarr and Recyclarr be configured
 against these apps without reading a generated value back out of a database.

--- a/k8s/apps/vod-arr/bazarr/deployment.yaml
+++ b/k8s/apps/vod-arr/bazarr/deployment.yaml
@@ -82,6 +82,8 @@ spec:
           volumeMounts:
             - mountPath: /config
               name: config
+            - mountPath: /config/log
+              name: logs
             - mountPath: /backup
               name: backups
               subPath: bazarr
@@ -97,6 +99,12 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       volumes:
+        # bazarr writes the same lines to log/bazarr.log that it writes to stdout,
+        # where alloy already picks them up, so the file set was 7.3M of the claim
+        # duplicating what Loki holds. It rotates itself; 64Mi is well clear of it.
+        - name: logs
+          emptyDir:
+            sizeLimit: 64Mi
         - name: config
           persistentVolumeClaim:
             claimName: bazarr-config

--- a/k8s/apps/vod-arr/cleanuparr/deployment.yaml
+++ b/k8s/apps/vod-arr/cleanuparr/deployment.yaml
@@ -67,6 +67,8 @@ spec:
           volumeMounts:
             - mountPath: /config
               name: config
+            - mountPath: /config/logs
+              name: logs
             - mountPath: /backup
               name: backup-script
               readOnly: true
@@ -75,6 +77,11 @@ spec:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
       volumes:
+        # Same lines as stdout, which alloy ships to Loki. Off the claim they also
+        # leave the K8up backup, which is here for the three SQLite databases.
+        - name: logs
+          emptyDir:
+            sizeLimit: 64Mi
         - name: config
           persistentVolumeClaim:
             claimName: cleanuparr-config

--- a/k8s/apps/vod-arr/prowlarr/statefulset.yaml
+++ b/k8s/apps/vod-arr/prowlarr/statefulset.yaml
@@ -63,6 +63,8 @@ spec:
           volumeMounts:
             - mountPath: /config
               name: config
+            - mountPath: /config/logs
+              name: logs
             - mountPath: /backup
               name: backups
               subPath: prowlarr
@@ -128,6 +130,13 @@ spec:
                       (.Config.AuthenticationMethod = "External") |
                       (.Config.AuthenticationRequired = "DisabledForLocalAddresses")
                     ' /config/config.xml
+              # The file log only has to carry what the UI's Log Files tab shows -- the
+              # console is what reaches Loki. This had drifted to debug in the UI and was
+              # declared nowhere, which is a 50 x 1MB ring of *.debug.txt nothing reads:
+              # stdout is Info, so Loki never saw that detail, and this claim carries no
+              # k8up annotation either. ConsoleLogLevel is left alone deliberately --
+              # raising it is how to put debug into Loki for an investigation.
+              yq -i '(.Config.LogLevel = "info")' /config/config.xml
               # Prowlarr, Bazarr and Recyclarr all address this app by API key, so the key has
               # to be declared rather than generated. Absent secret leaves whatever exists.
               if [ -n "${API_KEY:-}" ]; then
@@ -165,7 +174,7 @@ spec:
                   name: prowlarr-api-key
                   optional: true
           image: mikefarah/yq:4.53.3
-          name: postgres-setup
+          name: render-config
           resources:
             limits:
               cpu: 100m
@@ -193,6 +202,14 @@ spec:
         - name: backups
           persistentVolumeClaim:
             claimName: backups
+        # Logs are shipped from stdout by alloy, so the files are a local convenience
+        # for the UI's Log Files tab and do not belong on the claim. The app's own
+        # rotation is the real cap -- 50 x logSizeLimit (1M) for the info ring, and
+        # the same again if LogLevel is raised to debug for an investigation. 128Mi
+        # clears both, and exceeding sizeLimit evicts the Pod.
+        - name: logs
+          emptyDir:
+            sizeLimit: 128Mi
   volumeClaimTemplates:
     - metadata:
         name: config

--- a/k8s/apps/vod-arr/radarr/statefulset.yaml
+++ b/k8s/apps/vod-arr/radarr/statefulset.yaml
@@ -63,6 +63,8 @@ spec:
           volumeMounts:
             - mountPath: /config
               name: config
+            - mountPath: /config/logs
+              name: logs
             - mountPath: /backup
               name: backups
               subPath: radarr
@@ -132,6 +134,13 @@ spec:
                       (.Config.AuthenticationMethod = "External") |
                       (.Config.AuthenticationRequired = "DisabledForLocalAddresses")
                     ' /config/config.xml
+              # The file log only has to carry what the UI's Log Files tab shows -- the
+              # console is what reaches Loki. This had drifted to debug in the UI and was
+              # declared nowhere, which is a 50 x 1MB ring of *.debug.txt nothing reads:
+              # stdout is Info, so Loki never saw that detail, and this claim carries no
+              # k8up annotation either. ConsoleLogLevel is left alone deliberately --
+              # raising it is how to put debug into Loki for an investigation.
+              yq -i '(.Config.LogLevel = "info")' /config/config.xml
               # Prowlarr, Bazarr and Recyclarr all address this app by API key, so the key has
               # to be declared rather than generated. Absent secret leaves whatever exists.
               if [ -n "${API_KEY:-}" ]; then
@@ -169,7 +178,7 @@ spec:
                   name: radarr-api-key
                   optional: true
           image: mikefarah/yq:4.53.3
-          name: postgres-setup
+          name: render-config
           resources:
             limits:
               cpu: 100m
@@ -203,6 +212,14 @@ spec:
         - name: downloads
           persistentVolumeClaim:
             claimName: vod-downloads
+        # Logs are shipped from stdout by alloy, so the files are a local convenience
+        # for the UI's Log Files tab and do not belong on the claim. The app's own
+        # rotation is the real cap -- 50 x logSizeLimit (1M) for the info ring, and
+        # the same again if LogLevel is raised to debug for an investigation. 128Mi
+        # clears both, and exceeding sizeLimit evicts the Pod.
+        - name: logs
+          emptyDir:
+            sizeLimit: 128Mi
   volumeClaimTemplates:
     - metadata:
         name: config

--- a/k8s/apps/vod-arr/sonarr/statefulset.yaml
+++ b/k8s/apps/vod-arr/sonarr/statefulset.yaml
@@ -63,6 +63,8 @@ spec:
           volumeMounts:
             - mountPath: /config
               name: config
+            - mountPath: /config/logs
+              name: logs
             - mountPath: /backup
               name: backups
               subPath: sonarr
@@ -132,6 +134,13 @@ spec:
                       (.Config.AuthenticationMethod = "External") |
                       (.Config.AuthenticationRequired = "DisabledForLocalAddresses")
                     ' /config/config.xml
+              # The file log only has to carry what the UI's Log Files tab shows -- the
+              # console is what reaches Loki. This had drifted to debug in the UI and was
+              # declared nowhere, which is a 50 x 1MB ring of *.debug.txt nothing reads:
+              # stdout is Info, so Loki never saw that detail, and this claim carries no
+              # k8up annotation either. ConsoleLogLevel is left alone deliberately --
+              # raising it is how to put debug into Loki for an investigation.
+              yq -i '(.Config.LogLevel = "info")' /config/config.xml
               # Prowlarr, Bazarr and Recyclarr all address this app by API key, so the key has
               # to be declared rather than generated. Absent secret leaves whatever exists.
               if [ -n "${API_KEY:-}" ]; then
@@ -169,7 +178,7 @@ spec:
                   name: sonarr-api-key
                   optional: true
           image: mikefarah/yq:4.53.3
-          name: postgres-setup
+          name: render-config
           resources:
             limits:
               cpu: 100m
@@ -203,6 +212,14 @@ spec:
         - name: downloads
           persistentVolumeClaim:
             claimName: vod-downloads
+        # Logs are shipped from stdout by alloy, so the files are a local convenience
+        # for the UI's Log Files tab and do not belong on the claim. The app's own
+        # rotation is the real cap -- 50 x logSizeLimit (1M) for the info ring, and
+        # the same again if LogLevel is raised to debug for an investigation. 128Mi
+        # clears both, and exceeding sizeLimit evicts the Pod.
+        - name: logs
+          emptyDir:
+            sizeLimit: 128Mi
   volumeClaimTemplates:
     - metadata:
         name: config


### PR DESCRIPTION
alloy tails `/var/log/pods` on all four nodes into Loki, which keeps six months, so every line these apps write to stdout is already durable and searchable. The file copies are a local convenience for each app's own log viewer. Each log directory becomes an `emptyDir`.

| App | Path | `sizeLimit` |
| --- | --- | --- |
| sonarr / radarr / prowlarr | `/config/logs` | 128Mi |
| bazarr | `/config/log` | 64Mi |
| cleanuparr | `/config/logs` | 64Mi |

qbittorrent needs nothing — verified 0 bytes and 0 real files, because the image already symlinks `qbittorrent.log` to `/proc/self/fd/1`.

## Two different problems

For **bazarr** (7.3M) and **cleanuparr** (916K) the files duplicated stdout line for line, so this only stops the claim carrying a second copy. cleanuparr's K8up backup, which exists for the three SQLite databases, gets smaller with it.

The three **\*arrs** were the opposite case. `LogLevel` was `debug` — set in the UI, declared nowhere — which keeps a 50 × `logSizeLimit` ring of `*.debug.txt`: 51M of 53M on sonarr, 52M of 55M on radarr, 16M of 19M on prowlarr. `ConsoleLogLevel` is empty, so stdout carries Info only, and these claims have no `k8up` annotation. That made the debug detail the one thing in the namespace with no second copy, overwritten roughly every 25 hours. Nothing read it.

So `render-config` now pins `LogLevel` to `info`, next to `AuthenticationMethod` and for the same reason: a setting that drifted in the UI belongs in the manifest.

## Why ConsoleLogLevel is left alone

Raising it to `debug` would put that detail in Loki, but at ~48M a day for sonarr alone against a `4320h` retention that is six months of noise for logs useful for hours. Raising it for the length of an investigation is the intended path. Ingest was never the constraint — ~1.2KB/s against a 3MB/s per-stream default.

## Rename

`postgres-setup` → `render-config`. It has not been just Postgres since it took over authentication and the API key, and this adds a third thing.

## Not included

The log files already written to the five claims are hidden under the new mounts, not removed. One-time cleanup, before or after the rollout:

```
kubectl exec -n vod-arr sonarr-0 -c sonarr -- rm -rf /config/logs
```

and the same for `radarr-0`, `prowlarr-0`, `deploy/bazarr` (`/config/log`) and `deploy/cleanuparr`. Doing it from the init container would leave a permanent `rm` whose blast radius grows the day someone removes the emptyDir.

## Validation

`make validate` (127 targets), `validate-flux` (49 paths), `validate-configmaps` and `docs-lint` (0 errors) all pass. Rendered output checked rather than the diff: the main container gets the log mount, the init container still mounts only the PV, and the emptyDir lands with its `sizeLimit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
