### PR TITLE
vod-arr: turn off usage analytics on the three *arrs

### DIFF
--- a/k8s/apps/vod-arr/README.md
+++ b/k8s/apps/vod-arr/README.md
@@ -160,7 +160,14 @@ The `render-config` init container rewrites `config.xml` on every start. It
 sets the Postgres connection, turns the built-in login **off**
 (`AuthenticationMethod: External` — the private ingress is the trust boundary,
 and a password nobody has is how the old namespace became unauditable), pins
-`LogLevel` to `info`, and pins the API key from Doppler when the entry exists.
+`LogLevel` to `info`, turns usage analytics **off** (`AnalyticsEnabled: False`),
+and pins the API key from Doppler when the entry exists.
+
+Analytics is the one of those that was never in `config.xml` to begin with. The
+apps default it to on and read it without persisting it, so the element has to
+be written for the telemetry to stop -- an absent key is not an off one. That is
+the difference from `LogLevel`, which was in the file and had drifted to `debug`
+from the UI.
 
 It was called `postgres-setup` while Postgres was all it did.
 

--- a/k8s/apps/vod-arr/prowlarr/statefulset.yaml
+++ b/k8s/apps/vod-arr/prowlarr/statefulset.yaml
@@ -137,6 +137,11 @@ spec:
               # k8up annotation either. ConsoleLogLevel is left alone deliberately --
               # raising it is how to put debug into Loki for an investigation.
               yq -i '(.Config.LogLevel = "info")' /config/config.xml
+              # Not drift like LogLevel was -- this key is absent from config.xml
+              # altogether. The app reads it with a built-in default of true and never
+              # persists it, so usage telemetry ships to the *arr project until the
+              # element is written. Booleans in this file are capitalised.
+              yq -i '(.Config.AnalyticsEnabled = "False")' /config/config.xml
               # Prowlarr, Bazarr and Recyclarr all address this app by API key, so the key has
               # to be declared rather than generated. Absent secret leaves whatever exists.
               if [ -n "${API_KEY:-}" ]; then

--- a/k8s/apps/vod-arr/radarr/statefulset.yaml
+++ b/k8s/apps/vod-arr/radarr/statefulset.yaml
@@ -141,6 +141,11 @@ spec:
               # k8up annotation either. ConsoleLogLevel is left alone deliberately --
               # raising it is how to put debug into Loki for an investigation.
               yq -i '(.Config.LogLevel = "info")' /config/config.xml
+              # Not drift like LogLevel was -- this key is absent from config.xml
+              # altogether. The app reads it with a built-in default of true and never
+              # persists it, so usage telemetry ships to the *arr project until the
+              # element is written. Booleans in this file are capitalised.
+              yq -i '(.Config.AnalyticsEnabled = "False")' /config/config.xml
               # Prowlarr, Bazarr and Recyclarr all address this app by API key, so the key has
               # to be declared rather than generated. Absent secret leaves whatever exists.
               if [ -n "${API_KEY:-}" ]; then

--- a/k8s/apps/vod-arr/sonarr/statefulset.yaml
+++ b/k8s/apps/vod-arr/sonarr/statefulset.yaml
@@ -141,6 +141,11 @@ spec:
               # k8up annotation either. ConsoleLogLevel is left alone deliberately --
               # raising it is how to put debug into Loki for an investigation.
               yq -i '(.Config.LogLevel = "info")' /config/config.xml
+              # Not drift like LogLevel was -- this key is absent from config.xml
+              # altogether. The app reads it with a built-in default of true and never
+              # persists it, so usage telemetry ships to the *arr project until the
+              # element is written. Booleans in this file are capitalised.
+              yq -i '(.Config.AnalyticsEnabled = "False")' /config/config.xml
               # Prowlarr, Bazarr and Recyclarr all address this app by API key, so the key has
               # to be declared rather than generated. Absent secret leaves whatever exists.
               if [ -n "${API_KEY:-}" ]; then


### PR DESCRIPTION
sonarr, radarr and prowlarr all report `"analyticsEnabled": true` from `/api/v3/config/host`, so each one posts usage telemetry to the *arr project. `render-config` already rewrites `config.xml` on every start, so this is one more line next to `LogLevel` (#1399) and for the same reason: a setting nobody declared belongs in the manifest.

## This is not drift the way `LogLevel` was

`AnalyticsEnabled` is absent from all three `config.xml` files entirely. The apps read it with a built-in default of **true** and, unlike most of the file, never persist it — so there is nothing to drift from. An absent key is not an off one; the element has to be written for the telemetry to stop. It also means the UI is otherwise the only place to turn it off, which is the state this namespace was rebuilt to get out of.

## Confirming the key name

It appears in no `config.xml` here, so it was taken from the binaries rather than assumed. In each app's `*.Core.dll`:

- a `get_AnalyticsEnabled` property getter with **no** matching setter — read-only and non-persisted, which is why it never reaches the file;
- the string `AnalyticsEnabled` exactly once as a UTF-16 user-string literal, the same signature as `AuthenticationMethod`, `BindAddress`, `ConsoleLogLevel` and `EnableSsl` — all of which *are* element names in the live file.

`False` is capitalised to match that file's own convention (`EnableSsl`, `LaunchBrowser`).

## Verification

- `make validate` → *No deprecated Flux API versions. All 127 targets render and validate cleanly.*
- The rendered kustomization carries the line three times, once per app.
- The `yq` expression was run against a representative `config.xml`: it appends `<AnalyticsEnabled>False</AnalyticsEnabled>` as valid XML, and the extension-based format detection works with no `-p xml` flag, as the existing lines rely on.

## Rollout

Nothing changes until the Pods restart with the new init container. If anyone saves **Settings → General** from the UI the app writes the element itself; `render-config` re-pins it on the next start, as it now does for `LogLevel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)