### PR TITLE
vod-arr: move bazarr and qbittorrent to NFS, drop prowlarr's claim

### DIFF
--- a/.claude/skills/app-deployment/SKILL.md
+++ b/.claude/skills/app-deployment/SKILL.md
@@ -44,11 +44,16 @@ The short version, in the order the questions matter:
 2. Transactional → not `unifi-nas` (`nolock`, no byte-range locking).
 3. App replicates itself (the CNPG clusters do) → `lvm-thin`.
 4. Bulk sequential → `unifi-nas`.
-5. **Everything else → `piraeus-r2-roaming`.** This is the default for application
+5. A config volume of plain files the app rewrites rarely → `unifi-nas`, for
+   scheduling freedom rather than speed: `csi-nfs` runs on all four nodes,
+   linstor on three. Not when a UI reads it a file at a time (sonarr's and
+   radarr's MediaCover), and not when it would be the app's only reason to
+   depend on the NAS — prowlarr dropped its claim instead.
+6. **Everything else → `piraeus-r2-roaming`.** This is the default for application
    data and the most used class here. Same performance as `piraeus-r2`; the only
    difference is that a Pod landing where no replica exists runs over the network
    until LINSTOR replicates to it.
-6. Over 32 GiB, or cannot tolerate that window → `piraeus-r2`.
+7. Over 32 GiB, or cannot tolerate that window → `piraeus-r2`.
 
 `lvm-thin` pins the Pod to one node, so kured means downtime on every reboot of
 that node. Use it only where the app provides its own redundancy.

--- a/docs/how-to/choose-a-storage-class.md
+++ b/docs/how-to/choose-a-storage-class.md
@@ -42,9 +42,27 @@ sensitive. **`unifi-nas`**, at about 100 MiB/s on a single 1 GbE link, which is 
 link and not the NAS.
 
 Size alone does not send you here: a large volume that needs real latency belongs
-on `piraeus-r2` in step 6.
+on `piraeus-r2` in step 7.
 
-## 5. Otherwise: `piraeus-r2-roaming`
+## 5. Is it a config volume of plain files?
+
+Settings, credentials, a fetched cache — a few files the app reads at startup and
+rewrites rarely. Step 2 has already sent anything transactional elsewhere, so what
+reaches here is genuinely plain. **`unifi-nas`.**
+
+Neither reason is speed. `csi-nfs` registers on all four nodes and
+`linstor.csi.linbit.com` on three, because master01 loads no DRBD module under
+Secure Boot — so a claim here is one fewer Pod the scheduler cannot place on it.
+And the UNAS backs up its own shares, so the claim needs no `k8up.io/backup`
+annotation, where the same files on piraeus do.
+
+Not this when a UI reads the volume a file at a time: sonarr's and radarr's
+MediaCover are served to the browser one poster per request, and stay on piraeus
+for that alone. And not this when the volume would be the app's only reason to
+depend on the NAS at all — prefer no volume, as prowlarr does, over a dependency
+bought for a cache.
+
+## 6. Otherwise: `piraeus-r2-roaming`
 
 **This is the default for ordinary application data**, and the most used class in
 the cluster. Two synchronous replicas, and the Pod is free to schedule anywhere.
@@ -56,7 +74,7 @@ That resync is also why PVCs here are **capped at 32 GiB** and denied above it.
 The mechanism and the numbers are in the
 [class comparison](../reference/storage-classes.md#piraeus-r2-and-piraeus-r2-roaming).
 
-## 6. When to use `piraeus-r2` instead
+## 7. When to use `piraeus-r2` instead
 
 Same two replicas and the same performance, but the Pod is pinned to a node
 holding one of them (`allowRemoteVolumeAccess: false`), so it can never land

--- a/k8s/apps/vod-arr/README.md
+++ b/k8s/apps/vod-arr/README.md
@@ -111,11 +111,33 @@ the data follows the Pod.
 I/O is remote until that conversion completes, which is why the class is capped
 at 32Gi by the `validate-roaming-volume-size` policy. Every volume here is 2Gi.
 
-`seerr-config` is the exception: it is on `unifi-nas`. Once its database moved
-to `postgres-seerr` the volume held only `settings.json` and rotated logs, and
-plain files over NFS are safe in a way SQLite over `nolock` is not. NFS also
-attaches from any node, where a piraeus volume needs the linstor CSI plugin and
-so needs a nodeAffinity keeping the Pod off master01.
+Which app is on which class follows from what its volume still holds now that
+every database is in CNPG:
+
+| Claim                | Class                | Why                                                  |
+| -------------------- | -------------------- | ---------------------------------------------------- |
+| `config-sonarr-0`    | `piraeus-r2-roaming` | MediaCover, read by the UI a poster at a time         |
+| `config-radarr-0`    | `piraeus-r2-roaming` | the same, and the larger library of the two           |
+| `cleanuparr-config`  | `piraeus-r2-roaming` | three live SQLite databases                           |
+| `bazarr-config`      | `unifi-nas`          | `config.yaml` and caches, no database                 |
+| `qbittorrent-config` | `unifi-nas`          | `.conf`, `categories.json`, `BT_backup`, no database  |
+| `seerr-config`       | `unifi-nas`          | `settings.json`, no database                          |
+| prowlarr             | none                 | nothing that outlives the Pod — see its StatefulSet   |
+| `recyclarr-config`   | `unifi-nas`          | a mounted `config.yaml`                               |
+
+Two things decide it. **SQLite keeps a volume on Piraeus**: this class mounts
+`nfsvers=3,nolock`, and unhonoured advisory locks are how SQLite corrupts.
+cleanuparr's three databases are in WAL mode besides, which wants an mmap of the
+`-shm` file that NFS cannot back. **Small-file read latency keeps the two *arrs
+there**: MediaCover is served to the browser one file per poster, and radarr's is
+the larger.
+
+Everything else gains by leaving. `csi-nfs` runs on all four nodes and
+`linstor.csi.linbit.com` on three — master01 loads no DRBD module under Secure
+Boot — so a claim on `unifi-nas` is one fewer Pod that cannot be placed there.
+K8up goes with it: the UNAS backs up its own shares, so a restic repo written by
+the cluster onto that same NAS would be a second copy the NAS then backs up
+again.
 
 Not `piraeus-r2`: it pins the Pod to the two nodes holding its replicas, which is
 the right trade for something latency-sensitive like plex's `/config`, but these

--- a/k8s/apps/vod-arr/bazarr/pvc-config.yaml
+++ b/k8s/apps/vod-arr/bazarr/pvc-config.yaml
@@ -1,18 +1,6 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  annotations:
-    # Opt in to K8up. The database moved to postgres-bazarr (../bazarrdb), but
-    # config.yaml did not: it holds the subtitle provider credentials and is a
-    # plain file, so the file-level copy is a faithful one and needs no
-    # backupcommand hook.
-    k8up.io/backup: "true"
-    # log/ rotates on its own and was 5.5M of the 17M here; cache/ and
-    # releases.txt are fetched; db/ holds the SQLite file postgres replaced,
-    # which is a complete, internally consistent bazarr database frozen at the
-    # cutover -- exactly the decoy a restore should not offer. It stays on the
-    # volume as a fallback until the cutover is proven, but it is not shipped.
-    k8up.io/backup-restic-args: '["--exclude=/data/bazarr-config/log", "--exclude=/data/bazarr-config/cache", "--exclude=/data/bazarr-config/db", "--exclude=/data/bazarr-config/config/releases.txt"]'
   name: bazarr-config
 spec:
   accessModes:
@@ -20,4 +8,8 @@ spec:
   resources:
     requests:
       storage: 2Gi
-  storageClassName: piraeus-r2-roaming
+  # unifi-nas, and deliberately no k8up.io/backup annotation. Both follow from
+  # what is left here -- config.yaml and fetched caches, no database. See
+  # "Config volumes" in ../README.md for the rule, and for why the UNAS backing
+  # up its own shares replaces K8up on this class.
+  storageClassName: unifi-nas

--- a/k8s/apps/vod-arr/prowlarr/statefulset.yaml
+++ b/k8s/apps/vod-arr/prowlarr/statefulset.yaml
@@ -63,8 +63,6 @@ spec:
           volumeMounts:
             - mountPath: /config
               name: config
-            - mountPath: /config/logs
-              name: logs
             - mountPath: /backup
               name: backups
               subPath: prowlarr
@@ -207,21 +205,20 @@ spec:
         - name: backups
           persistentVolumeClaim:
             claimName: backups
-        # Logs are shipped from stdout by alloy, so the files are a local convenience
-        # for the UI's Log Files tab and do not belong on the claim. The app's own
-        # rotation is the real cap -- 50 x logSizeLimit (1M) for the info ring, and
-        # the same again if LogLevel is raised to debug for an investigation. 128Mi
-        # clears both, and exceeding sizeLimit evicts the Pod.
-        - name: logs
+        # Nothing here outlives the Pod, so prowlarr has no claim at all. Its
+        # indexers, apps and history are in postgres-prowlarr, and render-config
+        # rewrites config.xml -- API key included -- from Doppler on every start.
+        # What is left is cache: Definitions/, which the image does not ship and
+        # the app re-fetches, asp/ DataProtection keys that only sign cookies for
+        # an app with AuthenticationMethod External, and the logs alloy already
+        # shipped to Loki.
+        #
+        # A warm Definitions cache would only ever pay off while the network is
+        # up, and prowlarr queries public trackers over that same network, so a
+        # cold start costs 552 small files exactly when it can afford them.
+        #
+        # 256Mi covers Definitions plus the log ring; exceeding sizeLimit evicts
+        # the Pod.
+        - name: config
           emptyDir:
-            sizeLimit: 128Mi
-  volumeClaimTemplates:
-    - metadata:
-        name: config
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 2Gi
-        storageClassName: piraeus-r2-roaming
+            sizeLimit: 256Mi

--- a/k8s/apps/vod-arr/qbittorrent/pvc-config.yaml
+++ b/k8s/apps/vod-arr/qbittorrent/pvc-config.yaml
@@ -1,14 +1,6 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  annotations:
-    # Opt in to K8up. The operator runs with skipWithoutAnnotation, so a claim
-    # without this is not backed up -- which is what keeps the six CNPG claims
-    # in this namespace out, since they self-backup via barman.
-    #
-    # No hook needed: /config/qBittorrent is JSON, .conf and the BT_backup
-    # fastresume files, with no database in it.
-    k8up.io/backup: "true"
   name: qbittorrent-config
 spec:
   accessModes:
@@ -16,4 +8,8 @@ spec:
   resources:
     requests:
       storage: 2Gi
-  storageClassName: piraeus-r2-roaming
+  # unifi-nas, and deliberately no k8up.io/backup annotation. Both follow from
+  # what is left here -- .conf, categories.json and BT_backup, no database. See
+  # "Config volumes" in ../README.md for the rule, and for why the UNAS backing
+  # up its own shares replaces K8up on this class.
+  storageClassName: unifi-nas

--- a/k8s/apps/vod-arr/seerr/pvc-config.yaml
+++ b/k8s/apps/vod-arr/seerr/pvc-config.yaml
@@ -8,27 +8,8 @@ spec:
   resources:
     requests:
       storage: 2Gi
-  # unifi-nas, not the piraeus-r2-roaming every other config claim here uses.
-  #
-  # The SQLite database that used to sit in db/ is what made NFS the wrong
-  # answer: SQLite corrupts when its advisory locks are not honoured, and this
-  # class mounts nfsvers=3,nolock. With the database in postgres-seerr all that
-  # is left is settings.json and a self-rotating log directory -- plain files,
-  # which NFS serves correctly.
-  #
-  # What it buys is scheduling freedom. The linstor CSI node plugin runs only
-  # where Piraeus does, so a piraeus-backed Pod needs a nodeAffinity to stay
-  # off master01, which cannot load the DRBD module under Secure Boot. csi-nfs
-  # runs on all four nodes, so this claim attaches anywhere and the affinity is
-  # gone from the Deployment.
-  #
-  # Deliberately no k8up.io/backup, unlike qbittorrent-config and
-  # cleanuparr-config: the UNAS backs up its own shares, so K8up here would be
-  # restic reading the NAS to write a repo onto the same NAS, and the NAS would
-  # then back up both. Removing SQLite removed the need for the backupcommand
-  # hook; moving to a medium that is already backed up removes the need for the
-  # file-level copy too.
-  #
-  # excluded_from_alerts is not set here -- mutate-nfs-pvc-alert-exclusion
-  # stamps it on every unifi-nas claim.
+  # unifi-nas, and deliberately no k8up.io/backup annotation. Both follow from
+  # what is left here -- settings.json, no database. See "Config volumes" in
+  # ../README.md for the rule, and for why the UNAS backing up its own shares
+  # replaces K8up on this class.
   storageClassName: unifi-nas


### PR DESCRIPTION
Every database in this namespace is CNPG now, which changed what the config claims hold. Following seerr (`c6133c7c`), the ones that are plain files leave piraeus.

| Claim | Class | Why |
| --- | --- | --- |
| `bazarr-config` | → `unifi-nas` | `config.yaml` and fetched caches, no database |
| `qbittorrent-config` | → `unifi-nas` | `.conf`, `categories.json`, `BT_backup`, no database |
| prowlarr | → **no claim** | nothing outlives the Pod |
| `config-sonarr-0` | unchanged | MediaCover, read by the UI a poster at a time |
| `config-radarr-0` | unchanged | the same, and 806M in 2759 files |
| `cleanuparr-config` | unchanged | three live SQLite databases, in WAL mode |

Verified on the live volumes rather than inferred: a find for `*.db`, `*.sqlite*`, `*-wal` and `*-shm` across bazarr and qbittorrent comes back empty. bazarr's `db/` has been empty since `d8c03343`, and qBittorrent keeps resume data as `BT_backup` files with `ResumeDataStorageType` at its default.

Both drop `k8up.io/backup` with the move, for the reason seerr did: the UNAS backs up its own shares, so K8up on an NFS claim is restic reading the NAS to write a repo onto the same NAS, which the NAS then backs up again.

## Why prowlarr gets no volume

Indexers, apps and history are in `postgres-prowlarr`. `render-config` rewrites `config.xml` from Doppler on every start and `prowlarr-api-key` exists, so even the API key the other apps address it by is declared. What remains is `Definitions/` — which the image does not ship, `/app` holds only `bin` and `package_info` — and `asp/` DataProtection keys that sign cookies for an app whose `AuthenticationMethod` is `External`.

A warm `Definitions` cache only pays off while the network is up, and prowlarr queries public trackers over that same network. One `emptyDir` at 256Mi covers `Definitions` plus the log ring, so the separate logs volume from `66a9622c` goes with the claim.

## Documentation

`docs/how-to/choose-a-storage-class.md` gains the step this cluster has actually been applying since seerr and recyclarr. As written, the procedure sent every non-RWX, non-sequential config volume to `piraeus-r2-roaming` at step 5 — an agent following it would have moved these straight back. The new step 5 names the real reason (`csi-nfs` registers on four nodes, linstor on three) and both exceptions: a volume a UI reads a file at a time, and a volume that would be an app's only reason to depend on the NAS.

`seerr/pvc-config.yaml`'s comment claimed "not the `piraeus-r2-roaming` every other config claim here uses" and "no `k8up.io/backup`, unlike `qbittorrent-config`" — both falsified here. The shared rationale moves to the vod-arr README as a claim → class → why table, and the three PVCs keep a pointer.

## Cutover is not automatic

`storageClassName` is immutable on a PVC and `volumeClaimTemplates` is immutable on a StatefulSet, so merging this alone leaves the Kustomization failing. Order: suspend the Kustomization, copy bazarr's and qbittorrent's volumes out, delete both PVCs and prowlarr's StatefulSet plus `config-prowlarr-0`, merge, resume, restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
