### PR TITLE
csi-nfs: warn on k8up.io annotations on unifi-nas claims

### DIFF
--- a/docs/reference/admission-policies.md
+++ b/docs/reference/admission-policies.md
@@ -17,6 +17,7 @@ schedule against objects that already exist.
 | [`require-resource-requests`](#require-resource-requests) | `pods` | **Warn** | `kyverno-policies` |
 | [`validate-helm-chart-version`](#validate-helm-chart-version) | `helmreleases` | **Deny** | `kyverno-policies` |
 | [`validate-ingress-contract`](#validate-ingress-contract) | `ingresses` | **Deny** | `kyverno-policies` |
+| [`validate-nfs-k8up-annotations`](#validate-nfs-k8up-annotations) | `persistentvolumeclaims`, `persistentvolumes` | **Warn** | `csi-nfs` |
 | [`validate-pdb-drain-safety`](#validate-pdb-drain-safety) | `poddisruptionbudgets` | **Warn** | `kyverno-policies` |
 | [`validate-roaming-volume-size`](#validate-roaming-volume-size) | `persistentvolumeclaims` | **Deny** | `piraeus-datastore` |
 
@@ -113,6 +114,23 @@ Rules enforced:
 - Public and private Ingresses must configure TLS.
 - Public and private Ingresses must use an approved cert-manager ClusterIssuer.
 - Every Ingress TLS entry must specify a Secret name.
+
+## `validate-nfs-k8up-annotations`
+
+| | |
+| --- | --- |
+| **Kind** | `ValidatingPolicy` |
+| **Applies to** | `persistentvolumeclaims`, `persistentvolumes` |
+| **On** | `CREATE`, `UPDATE` |
+| **Effect** | **Warn** |
+| **failurePolicy** | `Ignore` — a policy error skips the rule silently |
+| **Only when** | `object.spec.?storageClassName.orValue("") == "unifi-nas"` |
+| **Shipped by** | `csi-nfs` |
+| **Source** | [`k8s/platform/storage/csi-nfs/validatingpolicy.yaml`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/platform/storage/csi-nfs/validatingpolicy.yaml) |
+
+Rules enforced:
+
+- k8up.io/* annotations do not belong on unifi-nas. The class provisions each claim as a subdirectory of the NAS's own k8snfscsi share, which the UNAS already backs up offsite nightly, so a K8up backup here reads the NAS to write a restic repository back onto the same disk. Leave the claim unannotated, or move it to piraeus-r2 and back it up there.
 
 ## `validate-pdb-drain-safety`
 

--- a/docs/reference/annotations.md
+++ b/docs/reference/annotations.md
@@ -129,6 +129,11 @@ media volumes, onto the NAS they already live on.
 Related, same object: `k8up.io/backupcommand` for an application-consistent dump
 instead of a file copy, and `k8up.io/backup-restic-args` for per-claim excludes.
 
+**Never on `unifi-nas`.** Those claims are subdirectories of a share the NAS
+backs up itself, so restic would only copy the NAS onto the NAS;
+[`validate-nfs-k8up-annotations`](admission-policies.md#validate-nfs-k8up-annotations)
+warns on any `k8up.io/*` key that reaches one.
+
 ### `excluded_from_alerts`
 
 | | |

--- a/k8s/platform/storage/csi-nfs/kustomization.yaml
+++ b/k8s/platform/storage/csi-nfs/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - namespace.yaml
   - release.yaml
   - mutatingpolicy.yaml
+  - validatingpolicy.yaml
 configMapGenerator:
   - name: values-csi-nfs
     files:

--- a/k8s/platform/storage/csi-nfs/validatingpolicy.yaml
+++ b/k8s/platform/storage/csi-nfs/validatingpolicy.yaml
@@ -1,0 +1,61 @@
+apiVersion: policies.kyverno.io/v1
+kind: ValidatingPolicy
+metadata:
+  # Lives with this provisioner rather than with kyverno for the same reason as
+  # the MutatingPolicy beside it: it says what this class means, not what the
+  # cluster requires in general. K8up is fine everywhere else; it is redundant
+  # here because of where this driver puts the data. The rule moves or dies with
+  # the class.
+  #
+  # Cluster-scoped. Kustomize cannot know that for a CRD kind and stamps the
+  # component's namespace on the rendered output; the API server ignores the
+  # field for cluster-scoped resources.
+  name: validate-nfs-k8up-annotations
+spec:
+  evaluation:
+    background:
+      enabled: false
+  # Ignore, where the two Warn policies under kyverno-policies use Fail. Match
+  # conditions are evaluated inside kyverno, not by the API server, so Fail
+  # would mean an unavailable admission controller rejects every PVC and PV
+  # write in the cluster -- including the PVs external-provisioner creates for
+  # every class -- in order to enforce a rule that never denies anything.
+  failurePolicy: Ignore
+  # Advisory. The warning reaches whoever submitted the object; there is no
+  # PolicyReport behind it, because every reports feature is off in this
+  # cluster (controllers/values.yaml), which also makes an Audit action a no-op.
+  validationActions:
+    - Warn
+  matchConstraints:
+    resourceRules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - persistentvolumeclaims
+          # K8up reads the annotation off the claim and never off the volume, so
+          # on a PV it is not merely redundant but inert -- the failure mode is
+          # someone believing a backup exists. A PV on this class is one this
+          # driver provisioned, so the annotation can only have been added by
+          # hand.
+          - persistentvolumes
+  matchConditions:
+    - name: only-nfs-storage-class
+      expression: >-
+        object.spec.?storageClassName.orValue("") == "unifi-nas"
+  validations:
+    - expression: >-
+        !object.metadata.?annotations.orValue({}).exists(
+          key,
+          key.startsWith("k8up.io/")
+        )
+      message: >-
+        k8up.io/* annotations do not belong on unifi-nas. The class provisions
+        each claim as a subdirectory of the NAS's own k8snfscsi share, which the
+        UNAS already backs up offsite nightly, so a K8up backup here reads the
+        NAS to write a restic repository back onto the same disk. Leave the
+        claim unannotated, or move it to piraeus-r2 and back it up there.


### PR DESCRIPTION
A claim on `unifi-nas` is a subdirectory of the NAS's own `k8snfscsi` share, and the NAS backs that share up itself at 03:30 Warsaw. Annotating such a claim `k8up.io/backup` makes restic read the NAS to write a repository back onto the same disk — which is why `seerr-config` dropped its annotation when it moved to this class (#1401) while `bazarr-config` kept one while it was on Piraeus. The rule lives in a comment per claim today; this puts it where admission can see it.

## Warn, not Deny

The annotation is wasteful rather than dangerous, and denying a PVC on the class every backup target in the cluster is provisioned from buys nothing over telling the author. There is no PolicyReport behind the warning either: every reports feature is off in the kyverno component's values, which also makes an `Audit` action a no-op.

## `failurePolicy: Ignore`

This deviates from the two `Warn` policies under `kyverno-policies`, which use `Fail`. Match conditions are evaluated inside kyverno rather than by the API server, so `Fail` would let an unavailable admission controller reject **every** PVC and PV write in the cluster — including the PVs `external-provisioner` creates for every other class — in order to enforce a rule that never denies anything.

## Why PersistentVolumes too

K8up reads the annotation off the claim and never off the volume, so on a PV it is not merely redundant but inert: the failure mode is someone believing a backup exists. A PV on this class is one this driver provisioned, so the annotation can only have been added by hand.

It lives with the provisioner rather than with kyverno, like the `MutatingPolicy` beside it — it describes what this class means, not what the cluster requires in general.

## Verification

- `kyverno apply` (CLI 1.19.0) over seven crafted objects: flags the annotated `unifi-nas` PVC and PV, skips a `k8up.io`-annotated `piraeus-r2-roaming` claim and one with no class at all, passes three clean objects.
- `kubectl apply --dry-run=server`: accepted by the CRD as written.
- `make validate` → *No deprecated Flux API versions. All 127 targets render and validate cleanly.*
- `make docs-lint` → 0 errors; `make docs-reference-check` clean.
- Live cluster: 26 `unifi-nas` PVCs and PVs, none of them carrying a `k8up.io/*` key, so this warns on nothing that exists today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)