### PR TITLE
prowlarr: declare the port exportarr reads from config.xml

### DIFF
--- a/k8s/apps/vod-arr/prowlarr/statefulset.yaml
+++ b/k8s/apps/vod-arr/prowlarr/statefulset.yaml
@@ -140,6 +140,15 @@ spec:
               # persists it, so usage telemetry ships to the *arr project until the
               # element is written. Booleans in this file are capitalised.
               yq -i '(.Config.AnalyticsEnabled = "False")' /config/config.xml
+              # exportarr reads this file once, at startup, and its XML parser only
+              # overrides the port in URL when <Port> is present -- with URL set to
+              # http://localhost and the element missing it scrapes port 80. prowlarr
+              # does write its own default here, but not until after it has started,
+              # which the config claim used to hide: config.xml came back from the
+              # previous run with <Port> in it already. On an emptyDir the file is new
+              # every start and exportarr loses that race, so the port the two
+              # containers have to agree on is declared rather than defaulted.
+              yq -i '(.Config.Port = "9696")' /config/config.xml
               # Prowlarr, Bazarr and Recyclarr all address this app by API key, so the key has
               # to be declared rather than generated. Absent secret leaves whatever exists.
               if [ -n "${API_KEY:-}" ]; then


### PR DESCRIPTION
Fixes #1403.

## Cause

`exportarr` reads prowlarr's `config.xml` **once, at startup**, and per its [XML parser](https://github.com/onedr0p/exportarr/blob/v2.3.0/internal/arr/config/xml_parser.go) overrides the port in `URL` **only when `<Port>` is present**. `URL` is `http://localhost` with no port, so a missing element leaves it scraping port 80:

```
ERROR Error getting health: ... Get "http://localhost/api/v1/health":
      dial tcp [::1]:80: connect: connection refused
```

`render-config` has never written `<Port>`. prowlarr writes its own default, but not until it has started, and the claim dropped in c1f7c742 used to paper over the gap — `config.xml` came back from the previous run with the element already in it, so `exportarr` always won the race. On an `emptyDir` the file is new every start and `exportarr` loses it by two seconds:

| event | time |
|---|---|
| `render-config` finished | 18:18:46Z |
| `prowlarr` started | 18:19:13Z |
| `exportarr` read `config.xml` | 18:19:15Z |
| `TargetDown` fired | 18:28:58Z |

The live `config.xml` does contain `<Port>9696</Port>` — prowlarr wrote it seconds too late, and `exportarr` never re-reads. Prometheus confirms it is scoped to this Pod: the previous Pod IPs (`10.42.0.139`, `10.42.0.233`) were `up==1` within 24h; only `10.42.2.250`, the Pod the refactor created, is down.

## Not IPv6

The initial reading was that the IPv6 disablement went live on a kured reboot. It does not hold:

- `::1/128` is up on `lo` in the Pod, `disable_ipv6=0`
- `http://[::1]:9696/api/v1/health` → **401**, i.e. it connected and prowlarr answered
- master01 last rebooted **07:26Z**, eleven hours before the target went down
- no IPv6 disablement in the repo — `metal/roles/k3s-prereq` *enables* `net.ipv6.conf.all.forwarding`

Port 80 was the whole fault. The `::1` in the error is Go picking a family for a port nothing listens on; `127.0.0.1:80` refuses identically.

## Fix

Declare the port in `render-config` rather than relying on prowlarr's lazy default, alongside the `containerPort` and Service `targetPort` that already name it. Not in the `exportarr` `URL` — `<Port>` overrides that whenever present, which makes the env var the weaker of the two places to say it.

## Verification

- Replayed render-config's full `yq` sequence on an empty file: output is valid XML ending in `<Port>9696</Port>` (yq auto-detects XML from the extension; confirmed independently by the live `<ApiKey>` matching the Doppler secret byte-for-byte)
- `kubectl kustomize k8s/apps/vod-arr/prowlarr` builds clean
- All four collector endpoints return **200** on `http://localhost:9696` with that API key: `system/status`, `health`, `indexer`, `history`

## Known follow-up, not in this PR

`sonarr` and `radarr` carry the same latent bug — same portless `URL`, same undeclared `Config.Port` — and work only because they kept their `volumeClaimTemplates`. Dropping either claim reproduces this exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
