### PR TITLE
pocket-id: front the database with pgbouncer

### DIFF
--- a/k8s/apps/pocket-id/postgres/values.yaml
+++ b/k8s/apps/pocket-id/postgres/values.yaml
@@ -3,6 +3,12 @@ owner: pocketid
 
 cluster:
   instances: 3
+  # Default is restart, which stops Postgres in place on the primary for every
+  # image bump -- a longer window with postgres-rw at zero endpoints than
+  # promoting an already-running replica. paperless has run this way for a
+  # while. It shortens the gap the pooler below has to cover; it does not
+  # remove it.
+  primaryUpdateMethod: switchover
   storage:
     size: 9Gi
   resources:
@@ -19,6 +25,34 @@ backup:
     retentionPolicy: 30d
     # Not the namespace name.
     pathSuffix: pocketid
+
+# pocket-id has no reconnect loop: its actor host exits the whole process on a
+# single failed database health check, and because postgres-rw selects
+# cnpg.io/instanceRole=primary -- a label no pod carries for a moment during a
+# switchover -- the Service goes to zero endpoints and the dial fails outright.
+# Every such blip is full SSO downtime, and costs two restarts rather than one,
+# since the abandoned hosts row keeps the next start out for up to its 90s
+# health-check deadline. pgbouncer keeps the client connection up across the
+# gap instead of handing pocket-id a hard error.
+pooler:
+  enabled: true
+  pgbouncer:
+    # transaction, not the chart's session default. Session pooling binds a
+    # client to one backend connection for its whole session, so a switchover
+    # breaks it anyway and the pooler buys nothing. Nothing here needs a
+    # pinned backend: francis keeps its host lock as a row in a hosts table
+    # with a timestamp deadline, and uses no advisory locks, LISTEN/NOTIFY or
+    # session state.
+    poolMode: transaction
+    parameters:
+      # pgx prepares statements by default, and pgbouncer only tracks them
+      # under transaction pooling when this is non-zero. Left at 0 the driver's
+      # prepared statements would fail once connections start being reused.
+      max_prepared_statements: "200"
+  resources:
+    requests:
+      cpu: 10m
+      memory: 64Mi
 
 externalSecrets:
   admin:


### PR DESCRIPTION
## Why

`pocket-id-0` carries **112 container restarts** — against 13 for the next-highest pod in the cluster. Investigated in this session; it is none of the usual suspects:

| Hypothesis | Verdict |
|---|---|
| kured / node reboots | beelink02 last booted before the pod was created |
| OOMKill vs the 112Mi request | peak working set 74 MiB; last termination `Error`/exit 1, never `OOMKilled` |
| Liveness probe | the app exits itself ~4s into startup, before any probe budget elapses |

Every observable fatal exit is a Postgres reachability failure, and 5 of 6 align **to the second** with a CNPG primary switchover in pocket-id's own cluster:

| pocket-id fatal exit | CNPG at that moment |
|---|---|
| 08-19 11:38:20 | 11:38:10 `Requesting fast shutdown` → 11:38:17 `I'm the target primary… promoting` |
| 08-20 10:34:47 | 10:34:37 shutdown → 10:34:40 `Promoting instance` |
| 08-23 01:56:12 | 01:56:10 `Old primary shutdown complete` |
| 08-23 18:40:47 | cluster rebuild — WAL restore, `Instance is still down` |
| 09-03 21:30:16 | `renew lock: lock renewal failed: timeout` |

**Mechanism.** `postgres-rw` selects `cnpg.io/instanceRole=primary`. Mid-switchover *no pod carries that label*, so the Service has zero endpoints and Cilium returns EHOSTUNREACH — which Go's dialer prints as `no route to host`. That wording is misleading: it is expected CNPG behaviour, not the cluster-wide datapath flap (which is real, mostly `platform-storage`, and whose bursts do not coincide with a single pocket-id crash).

pocket-id then `exit(1)`s, because its actor host has no reconnect loop, and the abandoned `hosts` row keeps the *restarted* pod out with `ErrClusterFull` until the 90s health-check deadline lapses — so one blip costs two restarts, each full SSO downtime, now including kube-apiserver OIDC.

Every other CNPG-backed app (grafana, mealie, karakeep, paperless) has 0 restarts. They reconnect.

## What this changes

- **`pooler.enabled: true`** with **`poolMode: transaction`**, not the chart's `session` default. Session pooling binds a client to one backend for its whole session, so it would break on the same switchover and buy nothing. Verified safe: francis keeps its host lock as a row in a `hosts` table keyed on `host_last_health_check`, with no advisory locks, LISTEN/NOTIFY or session state.
- **`max_prepared_statements: "200"`** — pgx prepares statements by default and pgbouncer only tracks them under transaction pooling when this is non-zero.
- **`primaryUpdateMethod: switchover`** — `restart` (the CNPG default) stops Postgres in place on the primary for every image bump, a longer zero-endpoint window than promoting a running replica. paperless already runs this way.

Adds `Pooler/pooler` and `PodMonitor/pooler-metrics`.

## Deliberately not in this PR

pocket-id still points at `postgres-rw`. The connection string moves to `pooler` only once pgbouncer is confirmed serving — the operator has yet to create `cnpg_pooler_pgbouncer`, so repointing in the same change would break auth on the apiserver auth path.

## Caveats

- This narrows the trigger; it does not fix exit-on-first-error, which is upstream's (`pocket-id#1274`, `#1549`). Filing that stays on the table.
- It also adds a failure domain: a pgbouncer pod restart breaks the connections it holds, and pocket-id will exit on that too. Whether it is a net win depends on pgbouncer pods being more stable than switchovers.
- paperless has a pooler deployed but points at `postgres-rw`, disabled by `ba8e33cf` (2025-12-20) with no recorded reason. The related alert (#769) was closed as never-triaged, so that reason is genuinely lost — but that pooler has run 2/2 with 0 restarts since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)