### PR TITLE
pocket-id: connect through the pooler

### DIFF
--- a/k8s/apps/pocket-id/app/pg-connection.yaml
+++ b/k8s/apps/pocket-id/app/pg-connection.yaml
@@ -14,4 +14,11 @@ spec:
   target:
     template:
       data:
-        connectionString: "postgresql://pocketid:{{ .password }}@postgres-rw:5432/pocketid"
+        # pgbouncer, not postgres-rw. postgres-rw selects
+        # cnpg.io/instanceRole=primary, a label no pod carries for a moment
+        # during a switchover, so it goes to zero endpoints and the dial fails
+        # outright -- and pocket-id exits the process rather than reconnect.
+        # See postgres/values.yaml. The chart feeds this through valuesFrom
+        # into the pocket-id Secret, which the pod reads with envFrom, so a
+        # change here does not reach a running pod: it needs a restart.
+        connectionString: "postgresql://pocketid:{{ .password }}@pooler:5432/pocketid"


### PR DESCRIPTION
Phase two of the pgbouncer cutover started in #1419.

## Pre-flight, on the live cluster

The Pooler from `7503e54d` is up and was verified before writing this:

| Check | Result |
|---|---|
| Pooler phase | `active`, `type: rw` |
| Replicas | 2/2 Ready, on beelink01 and beelink02 (anti-affinity satisfied) |
| `pool_mode` | `transaction` ✅ |
| `max_prepared_statements` | `200` ✅ |
| `cnpg_pooler_pgbouncer` role | created by the operator |
| End-to-end probe as `pocketid` | `auth=ok db=pocketid user=pocketid in_recovery=false backend=10.42.1.186` — i.e. routed to the current primary (postgres-2) |
| pocket-id disturbed by phase 1? | No — 0 restarts through the reconcile |

One thing that would have bitten and didn't: `user_search` exists **only in the `postgres` database**, not in `pocketid`. pgbouncer is configured with `auth_dbname = postgres`, so the auth query runs where the function actually is. Had it run against the target database, auth would have failed outright.

(Paperless has `user_search` in both databases. That difference is cosmetic given `auth_dbname`, and it is *not* the reason its pooler was pointed away in `ba8e33cf` — that reason remains unrecorded.)

## This change does not take effect by itself

The chart threads `connectionString` through `valuesFrom` into the `pocket-id` Secret, and the pod reads it with `envFrom`. **A running pod keeps using `postgres-rw` until it is restarted.** So merging this is safe and inert; the cutover is a deliberate, separate step:

```bash
kubectl -n pocket-id rollout restart statefulset pocket-id
```

That is ~15–30s of full SSO downtime, now including kube-apiserver OIDC, so it wants a chosen moment rather than a merge-time surprise.

## After the restart

Confirm the app is actually on pgbouncer rather than silently still on `postgres-rw`:

```bash
kubectl -n pocket-id exec deploy/pooler -c pgbouncer -- psql -p 5432 -U pgbouncer pgbouncer -tAc 'SHOW CLIENTS'
```

Then the controlled switchover test is what tells us whether this was worth doing — promote a replica and watch whether `pocket-id-0` survives it.

## Still true

- This narrows one trigger; it does not fix exit-on-first-error, which is upstream's (`pocket-id#1274`, `#1549`).
- It adds a failure domain: a pgbouncer pod restart breaks the connections it holds, and pocket-id will exit on that too.
- The 112-restart baseline is **gone** — `pocket-id-0` was recreated at 08:17 UTC on 2026-09-09 and now reads 0 restarts. Measure from here, not against 112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)