### PR TITLE
pocket-id: drop the pooler, and write down why

### DIFF
--- a/docs/explanation/database-failover.md
+++ b/docs/explanation/database-failover.md
@@ -1,0 +1,115 @@
+# Why a database failover interrupts an app { .quad-explanation }
+
+Every CloudNativePG cluster here publishes a `<name>-rw` Service, and every app
+that writes connects through it. That Service selects on a **label the operator
+moves**, not on a fixed pod:
+
+```yaml
+selector:
+  cnpg.io/cluster: postgres
+  cnpg.io/instanceRole: primary
+```
+
+During a switchover the old primary's label is removed before the new primary's
+is applied. For that moment no pod carries `instanceRole: primary`, so the
+Service has **no endpoints at all**. This is deliberate: a write must not reach
+a demoted primary, and having nowhere to go is the safe failure.
+
+The cost is that clients see a hard failure rather than a pause.
+
+## The error text is misleading
+
+With no endpoints behind the Service, Cilium answers with EHOSTUNREACH, which
+Go's dialer prints as:
+
+```
+dial tcp 10.43.5.207:5432: connect: no route to host
+```
+
+That reads like a broken network, and it is not. It is a label transition
+completing normally. The same wording also appears here for genuine datapath
+problems, so the two are easy to conflate — the way to tell them apart is
+whether the timestamp lines up with `Requesting fast shutdown` and
+`I'm the target primary` in the cluster's own logs.
+
+An app that reports `no route to host` against a `-rw` Service is almost always
+reporting a failover, not a network fault.
+
+## Two ways an app can respond
+
+The window is short. What decides whether it is a blip or an outage is entirely
+the client.
+
+| The app… | Result |
+| --- | --- |
+| retries the connection | a few failed queries, no visible downtime |
+| exits the process | downtime for as long as the restart takes |
+
+Most things in this cluster do the first. They are not configured to; it is
+simply what a normal connection pool does when a socket dies.
+
+An app that does the second turns routine database maintenance into an outage,
+and there is nothing to tune on the database side that will save it — see the
+pgbouncer result below. `k8s/apps/pocket-id/postgres/values.yaml` records one
+such app and what was tried for it.
+
+The failure is worse than a single restart when the app also holds a lease or
+lock in that same database. It dies without releasing it, and the restarted
+process is then locked out by its own stale entry until the lease expires — so
+one failover costs two or more restarts.
+
+## What shortens the window
+
+`primaryUpdateMethod` decides how the operator replaces a primary when the
+cluster's image or configuration changes:
+
+| Value | What happens | Window |
+| --- | --- | --- |
+| `restart` (the operator's default) | Postgres stops and starts in place on the primary | as long as a Postgres restart |
+| `switchover` | an already-running replica is promoted | as long as a label change |
+
+`switchover` is the shorter of the two and is the better default for anything
+with a real availability target. It shortens the window; it does not close it,
+because either path passes through the same no-endpoint moment. Which clusters
+set it is in their `values.yaml`.
+
+## pgbouncer does not close it
+
+A connection pooler in front of the database looks like the obvious fix: let
+pgbouncer hold the client connection and re-establish the backend one. In
+transaction pool mode that is genuinely what it does — between transactions a
+client is not bound to any particular backend.
+
+It was tried for pocket-id and measured with a deliberate `cnpg promote` on
+2026-09-09. A 7-second switchover produced about 88 seconds of downtime and four
+restarts through the pooler, against roughly two restarts connecting directly.
+It was reverted.
+
+Two reasons, and the first is not tunable:
+
+1. **The pooler cannot prevent the first failure.** While the `-rw` Service has
+   no endpoints, pgbouncer has no backend either. Transaction pooling lets a
+   client survive a backend swap only when there is a backend to swap to.
+   Anything that would have failed talking to Postgres directly still fails.
+2. **It then slows recovery down.** pgbouncer caches a failed server login for
+   `server_login_retry` and answers *new* client connections with
+   `FATAL: server login has been failing` for that period. An app that exits and
+   restarts into that window fails during startup, so its crash loop outlives
+   the switchover that started it.
+
+Setting `server_login_retry` to zero addresses the second point and not the
+first, which leaves the pooler no better than a direct connection while adding
+two more pods and a `requiredDuringScheduling` anti-affinity to satisfy.
+
+A pooler is still worth having for what it is actually for — bounding backend
+connection counts for an app that opens many. It is not failover tolerance.
+
+## What actually fixes it
+
+The client has to retry. That is a property of the application, so for
+third-party software it is an upstream change rather than a configuration one,
+and the honest local options are to shorten the window with `switchover` and to
+schedule maintenance when an interruption is acceptable.
+
+This is also why the reboot gate waits for the CloudNativePG alerts to be quiet
+before draining a node — see [how a node reboot is gated](node-reboots.md).

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -34,3 +34,6 @@ is only in commit messages, per-app READMEs and
   was scattered, and the two traps that decided the order
 - [How a node reboot is gated](node-reboots.md) — what has to agree before a node
   goes down, and why a shorter drain timeout is the safer one
+- [Why a database failover interrupts an app](database-failover.md) — the
+  no-endpoint moment every `-rw` Service passes through, and why a pooler does
+  not cover it

--- a/k8s/apps/pocket-id/app/pg-connection.yaml
+++ b/k8s/apps/pocket-id/app/pg-connection.yaml
@@ -14,11 +14,7 @@ spec:
   target:
     template:
       data:
-        # pgbouncer, not postgres-rw. postgres-rw selects
-        # cnpg.io/instanceRole=primary, a label no pod carries for a moment
-        # during a switchover, so it goes to zero endpoints and the dial fails
-        # outright -- and pocket-id exits the process rather than reconnect.
-        # See postgres/values.yaml. The chart feeds this through valuesFrom
-        # into the pocket-id Secret, which the pod reads with envFrom, so a
-        # change here does not reach a running pod: it needs a restart.
-        connectionString: "postgresql://pocketid:{{ .password }}@pooler:5432/pocketid"
+        # postgres-rw, not a pooler: pgbouncer was measured making a failover
+        # worse here, not better.
+        # See docs/explanation/database-failover.md
+        connectionString: "postgresql://pocketid:{{ .password }}@postgres-rw:5432/pocketid"

--- a/k8s/apps/pocket-id/postgres/values.yaml
+++ b/k8s/apps/pocket-id/postgres/values.yaml
@@ -3,11 +3,9 @@ owner: pocketid
 
 cluster:
   instances: 3
-  # Default is restart, which stops Postgres in place on the primary for every
-  # image bump -- a longer window with postgres-rw at zero endpoints than
-  # promoting an already-running replica. paperless has run this way for a
-  # while. It shortens the gap the pooler below has to cover; it does not
-  # remove it.
+  # Promote a running replica rather than restarting Postgres in place, which
+  # is the shorter of the two no-endpoint windows.
+  # See docs/explanation/database-failover.md
   primaryUpdateMethod: switchover
   storage:
     size: 9Gi
@@ -26,33 +24,14 @@ backup:
     # Not the namespace name.
     pathSuffix: pocketid
 
-# pocket-id has no reconnect loop: its actor host exits the whole process on a
-# single failed database health check, and because postgres-rw selects
-# cnpg.io/instanceRole=primary -- a label no pod carries for a moment during a
-# switchover -- the Service goes to zero endpoints and the dial fails outright.
-# Every such blip is full SSO downtime, and costs two restarts rather than one,
-# since the abandoned hosts row keeps the next start out for up to its 90s
-# health-check deadline. pgbouncer keeps the client connection up across the
-# gap instead of handing pocket-id a hard error.
-pooler:
-  enabled: true
-  pgbouncer:
-    # transaction, not the chart's session default. Session pooling binds a
-    # client to one backend connection for its whole session, so a switchover
-    # breaks it anyway and the pooler buys nothing. Nothing here needs a
-    # pinned backend: francis keeps its host lock as a row in a hosts table
-    # with a timestamp deadline, and uses no advisory locks, LISTEN/NOTIFY or
-    # session state.
-    poolMode: transaction
-    parameters:
-      # pgx prepares statements by default, and pgbouncer only tracks them
-      # under transaction pooling when this is non-zero. Left at 0 the driver's
-      # prepared statements would fail once connections start being reused.
-      max_prepared_statements: "200"
-  resources:
-    requests:
-      cpu: 10m
-      memory: 64Mi
+# There is deliberately NO pooler here. pocket-id exits its process on a single
+# failed database health check, and a transaction-mode pgbouncer was measured
+# making that worse rather than better -- it cannot help while the -rw Service
+# has no endpoints, and its cached login failure outlives the switchover.
+# Numbers and reasoning: docs/explanation/database-failover.md
+#
+# The fix is upstream: a transient database error should be retried, not fatal.
+# See pocket-id#1274 and #1549.
 
 externalSecrets:
   admin:

--- a/zensical.toml
+++ b/zensical.toml
@@ -71,6 +71,7 @@ nav = [
     { "Rule linting with pint" = "explanation/pint-rule-linting.md" },
     { "The Postgres fleet upgrade" = "explanation/postgres-fleet-upgrade.md" },
     { "How a node reboot is gated" = "explanation/node-reboots.md" },
+    { "Why a database failover interrupts an app" = "explanation/database-failover.md" },
   ] },
 ]
 


### PR DESCRIPTION
Reverts the cutover in #1420 and removes the Pooler added in #1419. Keeps `primaryUpdateMethod: switchover`. Adds the explanation page the finding belongs on, and shortens both manifests by pointing at it.

## The test result

A controlled `kubectl cnpg promote postgres postgres-7` on 2026-09-09. The switchover itself took **7 seconds** (20:07:02 → 20:07:09).

| | Direct (postgres-rw) | Through the pooler |
|---|---|---|
| Restarts per switchover | ~2 | **4** |
| SSO downtime | ~15–30s | **~88s** (20:07:16 → 20:08:44) |
| Manual intervention | none | pooler pods restarted to clear it |

kube-apiserver OIDC was down for that window too. Recovery confirmed with `kubectl auth whoami`.

## Why pgbouncer cannot fix this

**1. It cannot prevent the first failure.** While the `-rw` Service has no endpoints, pgbouncer has no backend either. Transaction pooling lets a client survive a backend swap only when there is a backend to swap to. This was the flaw in the original reasoning and it is not tunable.

**2. It then slows recovery down.** pgbouncer caches a failed server login for `server_login_retry` and answers new client connections with `FATAL: server login has been failing`. pocket-id meets that during startup — a hard exit — so the crash loop outlived the switchover it was meant to absorb.

`server_login_retry: "0"` addresses (2) and not (1), leaving it no better than direct.

## Why the Pooler goes rather than staying bypassed

It buys nothing here, costs two pgbouncer pods, and its `requiredDuringScheduling` anti-affinity is what made #769 fire in paperless. Keeping a bypassed pooler is what paperless did in `ba8e33cf`, and the reason was lost — so the reason goes in docs instead of in a dead config block.

## The docs page, and why the manifests got shorter

The generalisable half of this is not pocket-id's. **Every** `-rw` Service selects on `cnpg.io/instanceRole=primary`, a label the operator moves, so all of them pass through a no-endpoint moment — and every app that does not reconnect dies there, reporting `no route to host`, which reads like a datapath fault and is not.

That now has one home: `docs/explanation/database-failover.md`, covering the mechanism, the misleading error text, the `primaryUpdateMethod` trade-off, and the pgbouncer measurement. The two manifests link to it rather than restating it, which is why `values.yaml` loses ~30 lines of comment on net.

Per `docs-authoring`, the page carries no counts, no versions in prose, and no fleet enumeration a PR to `k8s/` could invalidate — the dates are on the measurement, which the skill permits.

```
make docs-lint            # 0 errors (6 warnings, all pre-existing in other pages)
make docs-reference-check # generated pages unchanged
make docs-build           # No issues found
```

## Merge ordering — worth knowing

pocket-id is **currently running against the pooler**, and this PR both repoints it and deletes the Pooler. The two HelmReleases reconcile on independent 5m intervals, so if `postgres` reconciles first the Pooler disappears while the app still points at it.

That self-heals — the app crash-loops until the `pocket-id` HelmRelease refreshes the Secret and a restart picks it up — but worst case that is ~5 minutes of SSO downtime rather than the ~15s it needs to be. The clean sequence after merge:

```bash
flux -n flux-system reconcile kustomization pocket-id
flux -n pocket-id reconcile helmrelease pocket-id     # Secret -> postgres-rw
kubectl -n pocket-id rollout restart statefulset pocket-id
flux -n pocket-id reconcile helmrelease postgres      # Pooler removed, harmlessly
```

The restart is required — the app reads its connection string with `envFrom`, so a Secret change alone never reaches a running pod.

## Honest caveats

- I restarted the pooler pods at 20:08:20 and recovery came 24s later. With CrashLoopBackOff at 20s and `server_login_retry` at 15s, it may have recovered unaided; that run cannot separate the two. The 4 restarts and ~88s are solid.
- My 1-second sampler was written without a sleep, so 150 iterations completed in 20s and it stopped one second before the first error. Timings above come from pod state and log timestamps instead.

## Next

The remaining fix is upstream — pocket-id exits the process on one failed database health check instead of retrying (`pocket-id#1274`, `#1549`). This experiment rules out working around it locally, which is a useful thing to be able to say in that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)