### PR TITLE
alerts: stop paging overnight, and write down how to silence for maintenance

### DIFF
--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -29,6 +29,8 @@ section once migrated.
 - [Choose a storage class](choose-a-storage-class.md) — which class a workload
   belongs on, in the order the questions actually matter
 - [Roll a workload when its ConfigMap changes](reload-on-configmap-change.md)
+- [Silence alerts for maintenance](silence-alerts-for-maintenance.md) — and the
+  one matcher that must never match
 
 ## Not written yet
 

--- a/docs/how-to/silence-alerts-for-maintenance.md
+++ b/docs/how-to/silence-alerts-for-maintenance.md
@@ -44,8 +44,7 @@ If you would rather script it, `amtool` does the same thing against the same
 API and takes matchers in the syntax above:
 
 ```bash
-amtool --alertmanager.url=https://alertmanager.ankhmorpork.thaum.xyz \
-  silence add namespace=<namespace> --duration=2h --comment="<what you are doing>"
+amtool silence add namespace=<namespace> --duration=2h --comment="<what you are doing>"
 ```
 
 !!! danger "Never let a silence match `Watchdog`"

--- a/docs/how-to/silence-alerts-for-maintenance.md
+++ b/docs/how-to/silence-alerts-for-maintenance.md
@@ -1,0 +1,79 @@
+# Silence alerts for maintenance { .quad-howto }
+
+Maintenance that takes a node or a service down fires the same alerts as an
+outage. Create an Alertmanager silence before you start, so the work does not
+page you and does not file issues you will only close again.
+
+Silences are for **attended** work — you are at the keyboard, you know when you
+started and when you are done. Recurring unattended work is handled by a time
+interval in the route tree instead and needs nothing from you.
+
+A silence stops the *notification*, not the alert: it still fires and still
+burns SLO error budget, which is what keeps the budget able to tell you that
+maintenance has grown too disruptive.
+
+## Steps
+
+Silences are created in the Alertmanager UI at
+[alertmanager.ankhmorpork.thaum.xyz](https://alertmanager.ankhmorpork.thaum.xyz)
+— **Silences → New Silence**, or the *Silence* button on a firing alert, which
+prefills its labels and is usually the fastest correct start.
+
+1. **Work out the narrowest matcher set that covers the work.** Prefer the
+   labels that describe *what you are touching* over the ones that describe
+   severity:
+
+    | Work | Matchers |
+    | --- | --- |
+    | one app | `namespace=<namespace>` |
+    | one node | `node=<node>`, and `instance=<ip>:<port>` for node-exporter alerts |
+    | one storage backend | `namespace=<namespace>`, `alertname=~"drbd.*\|linstor.*"` |
+
+2. **Set an expiry you will actually outlast, not a generous one.** A silence
+   that expires while you are still working is a nuisance; one that outlives the
+   work by hours is how a real outage goes unnoticed. Extend it rather than
+   starting long.
+
+3. **Read the preview before confirming.** Alertmanager lists the alerts the
+   silence would match. That list is the check that matters — see the trap
+   below.
+
+4. **Expire it when you finish.** Do not wait for the timer.
+
+If you would rather script it, `amtool` does the same thing against the same
+API and takes matchers in the syntax above:
+
+```bash
+amtool --alertmanager.url=https://alertmanager.ankhmorpork.thaum.xyz \
+  silence add namespace=<namespace> --duration=2h --comment="<what you are doing>"
+```
+
+!!! danger "Never let a silence match `Watchdog`"
+
+    `Watchdog` fires permanently and is delivered to
+    [healthchecks.io](https://healthchecks.io) every two minutes. It is a
+    dead-man's switch: silence it and the missing heartbeat raises an alert
+    *outside* this cluster, which is the one thing you cannot silence from
+    inside it.
+
+    It carries `severity=none` and is matched by `alertname`, so no
+    severity-based silence can reach it. What reaches it is a silence whose
+    matchers are too loose — a bare cluster-wide match, or an `alertname=~".*"`.
+    Give every silence at least one matcher `Watchdog` cannot satisfy, and
+    confirm it is absent from the preview in step 3.
+
+## Overnight work
+
+Between 20:00 and 09:00 local, criticals do not page — they are still filed as
+GitHub issues and page at 09:00 if they are still firing. You do not need a
+silence to avoid being woken at night. You do need one to avoid the issues.
+
+## Where the boundaries are set
+
+The route tree, the receivers and the `waking-hours` interval live in
+[`configmap-template.yaml`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/apps/datalake-alerts/alertmanager/configmap-template.yaml).
+The reboot window that makes node reboots unattended is `rebootDays` and
+`startTime`/`endTime` in
+[kured's values](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/platform/cluster/system-kured/values.yaml);
+what those reboots do to a running cluster is
+[Node reboots](../explanation/node-reboots.md).

--- a/k8s/apps/datalake-alerts/alertmanager/configmap-template.yaml
+++ b/k8s/apps/datalake-alerts/alertmanager/configmap-template.yaml
@@ -55,6 +55,25 @@ data:
         - send_resolved: true
           url: "http://github-receiver:8080/v1/webhook?owner=thaum-xyz&repo=ankhmorpork"
     - name: "null"
+    # Waking hours, local. Referenced by the opsgenie route below.
+    #
+    # Expressed as the hours that DO page rather than the hours that do not:
+    # an Alertmanager time range cannot cross midnight, so muting 20:00-09:00
+    # would need two ranges and a reader would have to intersect them in their
+    # head. active_time_intervals inverts it into one range that says what it
+    # means.
+    #
+    # location is not optional. Without it Alertmanager reads the times as UTC,
+    # which is right for two-thirds of the year and an hour out for the rest.
+    # The binary has embedded tzdata, so the name resolves without tzdata in
+    # the image.
+    time_intervals:
+    - name: waking-hours
+      time_intervals:
+      - times:
+        - start_time: "09:00"
+          end_time: "20:00"
+        location: Europe/Warsaw
     route:
       group_by: ['alertname', 'namespace', 'job']
       group_wait: 30s
@@ -76,10 +95,23 @@ data:
         # below, so every alert that is worth waking someone for also leaves a
         # written record. Without it a critical is paged and never written down —
         # the reason the 2026-09-09 kured reboots left no issue to read back.
+        #
+        # active_time_intervals sits on this route alone, so outside 09:00-20:00
+        # the page is withheld while the fall-through still files the issue.
+        # Nothing is lost overnight, it is only read in the morning -- and an
+        # alert still firing when the window opens pages then.
+        #
+        # This applies to every critical, with no carve-out for the ones whose
+        # damage compounds overnight -- UPS runtime, a filesystem gone read-only,
+        # a pool filling up. That is a deliberate trade by the one person who
+        # receives these: sleep is worth more than the hours between the alert
+        # and the morning. Revisit it if anyone else ever goes on the rota.
         - matchers:
           - "severity = critical"
           receiver: 'opsgenie'
           continue: true
+          active_time_intervals:
+          - waking-hours
         # Every NFS-backed PVC reports the whole export's fill level, so a single
         # NAS filling up fires this once per PVC across unrelated namespaces.
         # Grouping on alertname alone turns that into one issue listing them all.

--- a/zensical.toml
+++ b/zensical.toml
@@ -47,6 +47,7 @@ nav = [
     { "Log in with kubectl" = "how-to/log-in-with-kubectl.md" },
     { "Choose a storage class" = "how-to/choose-a-storage-class.md" },
     { "Roll a workload on ConfigMap change" = "how-to/reload-on-configmap-change.md" },
+    { "Silence alerts for maintenance" = "how-to/silence-alerts-for-maintenance.md" },
   ] },
   { "Reference" = [
     "reference/index.md",


### PR DESCRIPTION
Two changes covering unattended and attended disruption, without touching what the SLOs measure. Both came out of the #1379 target-setting work, where every failure in the reading week turned out to be a node reboot, a migration, or a night-time network upgrade.

## Overnight: `active_time_intervals` on the opsgenie route

The critical → opsgenie route gains `active_time_intervals: [waking-hours]` — **09:00–20:00 `Europe/Warsaw`**. Outside those hours a critical is not paged.

It is still *filed*. That route already carries `continue: true`, so every critical falls through to the github receiver at all hours, and anything still firing when the window opens pages at 09:00. Nothing is lost overnight, it is only read in the morning.

Written as the hours that page rather than the hours that don't, because an Alertmanager time range cannot cross midnight — muting `20:00–09:00` needs two ranges and a reader has to intersect them in their head. `location` is set explicitly; without it Alertmanager reads the times as UTC, which is right for two-thirds of the year and an hour out for the rest. Alertmanager v0.34.0 has embedded tzdata, so the name resolves without tzdata in the image.

**No carve-out** for the criticals whose damage compounds overnight — `UPSRuntimeLow`, `FilesystemReadOnly`, `TopoLVMThinPoolAlmostOutOfSpace` and friends. That is a deliberate trade by the only person on the receiving end. The manifest records both the trade and the condition to revisit it (anyone else joining the rota).

## Maintenance: a how-to for silences

[`docs/how-to/silence-alerts-for-maintenance.md`](https://github.com/thaum-xyz/ankhmorpork/blob/alert-night-mute/docs/how-to/silence-alerts-for-maintenance.md) covers the attended case — you are at the keyboard, so a silence is the right tool and a time interval is not.

The trap worth writing down: a silence with matchers loose enough to catch `Watchdog` stops the two-minute heartbeat to healthchecks.io, which then alerts from *outside* the cluster — the one alert that cannot be silenced from inside it. `Watchdog` carries `severity=none` and is matched by `alertname`, so no severity-based silence can reach it; what reaches it is a bare cluster-wide match or an `alertname=~".*"`. The page says to give every silence at least one matcher `Watchdog` cannot satisfy, and to confirm against the preview.

It is also explicit that a silence stops the notification and not the alert, so error budgets keep counting planned work — the property that lets a budget say maintenance has grown too disruptive.

## Not in this PR

A time interval for the kured reboot window. kured runs `Mo/We/Th 07:00–12:00` node-local, chosen so reboots land when the house is empty — it protects users, where `waking-hours` protects the operator, and the two windows do not overlap. Whether to move it is still open.

## Verification

- `make validate` — 128 targets render and validate cleanly
- `make validate-configmaps` — no ConfigMap produced by two Kustomizations
- `make docs-lint` — 0 errors; the new page contributes no warnings
- `make docs-build` — no issues
- Rendered `alertmanager.yaml` parsed with the Go-template placeholders stripped: the interval is defined, referenced only by the opsgenie route, and `severity =~ warning|critical` still reaches github.

🤖 Generated with [Claude Code](https://claude.com/claude-code)