### PR TITLE
probe: resolve the admin consoles' inert probe-uri annotations

### DIFF
--- a/k8s/apps/datalake-alerts/alertmanager/ingress.yaml
+++ b/k8s/apps/datalake-alerts/alertmanager/ingress.yaml
@@ -4,6 +4,9 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     ignore-check.kube-linter.io/dangling-service: Check is incompatible with prometheus-operator CRDs
+    # Alertmanager's own health handler, not /: the UI at / is a static asset
+    # bundle that returns 200 with the cluster peer gone. /-/healthy answers
+    # "OK" in 2 bytes.
     ingress.thaum.xyz/probe-uri: /-/healthy
     traefik.ingress.kubernetes.io/service.sticky.cookie: "true"
   labels:
@@ -11,6 +14,19 @@ metadata:
     app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
+    # The annotation above is inert without this label -- the Probe selects
+    # Ingresses by it and only then reads the URI off them.
+    #
+    # The strongest case among the admin consoles: Alertmanager is what reports
+    # everything else and had no check on it from outside the pod at all.
+    # AlertmanagerFailedToSendAlerts covers the delivery leg; this covers the
+    # ingress leg, which is how a console goes unreachable while the pod stays
+    # Ready.
+    #
+    # Nothing alerts on the result, by decision in #1340: no SLO, because nobody
+    # waits on this console, and SiteDown joins on an UptimeRobot monitor, which
+    # a LAN-only host cannot have. A series to look at, not a page.
+    ingress.thaum.xyz/probe: enabled
   name: alertmanager
 spec:
   ingressClassName: private

--- a/k8s/apps/datalake-metrics/prometheus/ingress.yaml
+++ b/k8s/apps/datalake-metrics/prometheus/ingress.yaml
@@ -4,6 +4,9 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     ignore-check.kube-linter.io/dangling-service: Check is incompatible with prometheus-operator CRDs
+    # Prometheus's own health handler, not /: the UI at / is a static asset
+    # bundle that returns 200 with the TSDB unreachable. /-/healthy answers
+    # "Prometheus Server is Healthy." in 30 bytes.
     ingress.thaum.xyz/probe-uri: /-/healthy
     traefik.ingress.kubernetes.io/service.sticky.cookie: "true"
   labels:
@@ -11,6 +14,16 @@ metadata:
     app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
+    # The annotation above is inert without this label -- the Probe selects
+    # Ingresses by it and only then reads the URI off them.
+    #
+    # A Prometheus that is down cannot scrape the probe that would report it,
+    # so this measures the path to the console, not Prometheus's liveness.
+    #
+    # Nothing alerts on the result, by decision in #1340: no SLO, because nobody
+    # waits on this console, and SiteDown joins on an UptimeRobot monitor, which
+    # a LAN-only host cannot have. A series to look at, not a page.
+    ingress.thaum.xyz/probe: enabled
   name: prometheus-k8s
 spec:
   ingressClassName: private

--- a/k8s/apps/datalake-metrics/pyrra/values.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/values.yaml
@@ -11,7 +11,14 @@ ingress:
   className: public
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    ingress.thaum.xyz/probe-uri: /-/healthy
+    # Deliberately not probed, and so carries no ingress.thaum.xyz/probe-uri.
+    # It used to carry /-/healthy copied from its Prometheus neighbours, which
+    # pyrra 404s -- inert anyway, since the label that selects it was never
+    # added. There is nothing honest to point a probe at: / is a 1.1KB React
+    # shell that returns 200 with the backend dead (#1308), /metrics only says
+    # the process is alive, and the real API is Connect RPC, which 405s on the
+    # GET that blackbox's single http_2xx module makes. Probing it would need a
+    # POST module built for this one console. #1340.
     item.homer.rajsingh.info/name: "Pyrra"
     item.homer.rajsingh.info/logo: "https://avatars.githubusercontent.com/u/87393422?s=200&v=4"
     item.homer.rajsingh.info/order: "30"


### PR DESCRIPTION
Fixes #1340.

All three consoles declared `ingress.thaum.xyz/probe-uri` without `ingress.thaum.xyz/probe`, so the blackbox `Probe` never selected them.

## What each path actually does

Verified live against the running services:

| host | path | result |
|---|---|---|
| prometheus | `/-/healthy` | 200, 30B |
| alertmanager | `/-/healthy` | 200, 2B |
| pyrra | `/-/healthy`, `/healthz`, `/health`, `/readyz`, `/-/ready` | all 404 |
| pyrra | `/` | 200, 1144B — static React shell |
| pyrra | `/objectives.v1alpha1.ObjectiveService/List` | **405 on GET** (200/80KB on POST) |
| pyrra | `/metrics` | 200 — the process's own connect metrics |

## prometheus + alertmanager: labelled

`private` is not an obstacle — plex is `ingressClassName: private` and probes green today (`https://vod.krupa.net.pl/identity` = 1).

## pyrra: annotation deleted

Nothing honest to point a probe at. `/` is the #1308 mistake exactly — 200 from static assets with the backend dead. `/metrics` is liveness only. The real API is Connect RPC and 405s on GET, and blackbox has a single `http_2xx` module, so probing it would mean a POST module built for one P3 console.

## Known gap: the series will not alert

Deliberate, per the decision on the issue, but worth stating plainly so it is not rediscovered later:

- No SLO, per #1340 — an error budget on a console one person opens occasionally measures nothing anyone waited for.
- `SiteDown` is `probe_success == 0 AND on (instance) uptimerobot_monitor_status == 9`. There is no UptimeRobot monitor for `prometheus.ankhmorpork.thaum.xyz` or `alertmanager.ankhmorpork.thaum.xyz` — they are LAN-only — so that join is always empty and the alert cannot fire for them.

Cert expiry is covered independently by `CertManagerCertExpirySoon` / `CertManagerCertNotReady`. The probe's unique residual signal is traefik-route/VIP/DNS breakage for the host, which shows up as a series on a dashboard and nowhere else. Both comments in tree say so.

## Validation

`make validate` (129 targets) and `make docs-reference-check` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)