### PR TITLE
mealie: give k8s:group:appadmin edit on the namespace

### DIFF
--- a/k8s/apps/mealie/namespace.yaml
+++ b/k8s/apps/mealie/namespace.yaml
@@ -2,3 +2,13 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: mealie
+  labels:
+    # Generates a RoleBinding giving oidc:k8s:group:appadmin the `edit`
+    # ClusterRole here, via the generate-group-rolebindings GeneratingPolicy.
+    # Add another `group.rbac.thaum.xyz/<group>` label for a second group; keys
+    # are unique, so several groups can hold different levels here.
+    #
+    # The pocket-id group `k8s:group:appadmin` still has to exist with its
+    # members and be selected under the kubectl client's Allowed User Groups, or
+    # the login fails before RBAC is consulted.
+    group.rbac.thaum.xyz/appadmin: edit


### PR DESCRIPTION
The first grant through the mechanism in #1439, and the whole change:

```yaml
labels:
  group.rbac.thaum.xyz/appadmin: edit
```

`generate-group-rolebindings` turns that into a RoleBinding binding
`oidc:k8s:group:appadmin` to the `edit` ClusterRole in `mealie`, and keeps it in
sync — so removing the label removes the access.

## What changed here

This branch used to carry a hand-written RoleBinding. It had to go: the
generated binding occupies the same slot, so Flux and Kyverno would have fought
over ownership — Flux applying with server-side apply and force, Kyverno
re-synchronising. A label is also the shape the next grant will take, so there
is no reason for the first one to be special.

Add another `group.rbac.thaum.xyz/<group>` label for a second group. Keys are
unique, so several groups can hold different levels in the same namespace.

## Depends on #1441

#1439 has merged, so the policies are live. But generation is broken until
#1441 lands: the background controller cannot read rolebindings, so the label
produces nothing. Safe to merge in either order, useful only after #1441.

## Why `edit` and not `admin`

Measured against the live cluster, the only part of the `admin` delta a
RoleBinding can actually grant is `roles`/`rolebindings` writes. Bindings created
by hand sit outside Flux's inventory, so `prune` would never remove them and they
would not appear in git at all. The rest of the delta is inert or worthless here:
the Kyverno cluster-scoped kinds cannot be granted by a RoleBinding, PolicyExceptions
are ignored (`--enablePolicyException=false`), and the cluster has no
ResourceQuotas or LimitRanges.

## Known limitation: this is cluster-admin until #1436

`edit` grants create/patch on `*` across all six `*.fluxcd.io` groups, and
reconciliation runs unimpersonated as a cluster-admin ServiceAccount. So the
holder can repoint the HelmRelease at a chart of their choosing and have Flux
apply a ClusterRoleBinding for them. Acceptable while only test accounts are in
the pocket-id group; #1436 adds the `--default-service-account` impersonation
that bounds it.

## What the group cannot reach

`edit` has no rules for `slo.pyrra.dev`, `cluster.postgresql.cnpg.io` or
`prometheusrule.monitoring.coreos.com`, so it cannot see mealie's own database,
its SLO, or the alert rules Pyrra generates from it. #1438 closes that with
aggregation. `edit` does read Secrets in the namespace — for mealie that is the
OIDC client secret and the Postgres credentials.

## Before this is useful

The pocket-id group `k8s:group:appadmin` must exist with its members, **and** be
selected under `Allowed User Groups` on the kubectl client — otherwise the login
fails with `access_denied` before RBAC is ever consulted.

## Verification

`make validate` — 129 targets render and validate cleanly.

Once merged and reconciled:

```
kubectl -n mealie get rolebinding oidc-k8s-group-appadmin-edit
kubectl auth can-i patch deployments -n mealie --as=nobody@krupa.net.pl --as-group=oidc:k8s:group:appadmin
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
