### PR TITLE
oidc-rbac: name the cluster-wide groups k8s:cluster:<tier>

### DIFF
--- a/k8s/platform/security/oidc-rbac/clusterrolebinding-cluster-admins.yaml
+++ b/k8s/platform/security/oidc-rbac/clusterrolebinding-cluster-admins.yaml
@@ -7,14 +7,19 @@ metadata:
     # Applied the other way round, tokens authenticate and then map to a group
     # with no permissions, which reads exactly like a broken authenticator.
     kubernetes.io/description: >-
-      cluster-admin for the pocket-id `k8s-admins` group. The `oidc:` prefix is
-      applied by claimMappings.groups.prefix in
+      cluster-admin for the pocket-id `k8s:cluster:admin` group. The `oidc:`
+      prefix is applied by claimMappings.groups.prefix in
       metal/roles/k3s-master/templates/authentication-config.yaml.j2 -- the two
       must be changed together.
+
+      Colon-separated to match the per-namespace tenant groups that
+      generate-tenant-rolebinding derives, and the shape Kubernetes uses for
+      its own `system:` groups. `scope:tier`, so the cluster-wide pair reads the
+      same way as `k8s:mealie:edit`.
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
-    name: oidc:k8s-admins
+    name: oidc:k8s:cluster:admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/k8s/platform/security/oidc-rbac/clusterrolebinding-viewers.yaml
+++ b/k8s/platform/security/oidc-rbac/clusterrolebinding-viewers.yaml
@@ -4,15 +4,19 @@ metadata:
   name: oidc-cluster-viewers
   annotations:
     kubernetes.io/description: >-
-      Cluster-wide read-only for the pocket-id `k8s-viewers` group. `view`
+      Cluster-wide read-only for the pocket-id `k8s:cluster:view` group. `view`
       excludes Secrets but does read every ConfigMap in the cluster, so this is
       not a nothing-to-see-here role. Membership also has to be granted on the
       kubectl client's Allowed User Groups in pocket-id, or the login fails
       before RBAC is consulted.
+
+      Colon-separated to match the per-namespace tenant groups that
+      generate-tenant-rolebinding derives, and the shape Kubernetes uses for
+      its own `system:` groups.
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
-    name: oidc:k8s-viewers
+    name: oidc:k8s:cluster:view
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/metal/group_vars/k3s.yml
+++ b/metal/group_vars/k3s.yml
@@ -13,7 +13,7 @@ k3s_token: "{{ hostvars[groups['k3s_control_plane'][0]]['token'] }}"
 # k3s_oidc_client_id makes the whole feature inert again: no config file, no
 # apiserver arg, no restart. That is the way to back it out.
 #
-# The `oidc:k8s-admins` ClusterRoleBinding in
+# The `oidc:k8s:cluster:admin` ClusterRoleBinding in
 # k8s/platform/security/oidc-rbac/ must be live before this reaches an
 # apiserver, or logins authenticate into a group holding no permissions.
 k3s_oidc_issuer_url: "https://login.krupa.net.pl"


### PR DESCRIPTION
Renames the pocket-id groups behind the two cluster-wide bindings:

| Was | Now | Kubernetes group |
| --- | --- | --- |
| `k8s-admins` | `k8s:cluster:admin` | `oidc:k8s:cluster:admin` |
| `k8s-viewers` | `k8s:cluster:view` | `oidc:k8s:cluster:view` |

Colon-separated to match the shape Kubernetes uses for its own `system:` groups,
and so the cluster-wide pair reads the same way as the per-namespace tenant
groups in #1439 — `scope:tier` throughout.

The binding object names are left alone. Renaming a ClusterRoleBinding is a
delete-and-create of the object granting cluster-admin, and there is nothing to
gain from it: `oidc-cluster-admins` already says what it is.

## Ordering — this one bites

Replaced outright rather than added alongside, as requested, so there is a window
where OIDC grants nothing: between this reconciling and the pocket-id groups
being renamed, `oidc:k8s-admins` matches no binding. Shortest path:

1. merge, then `flux -n flux-system reconcile kustomization oidc-rbac`
2. rename both groups in pocket-id (rename, don't recreate — the group keeps its
   id, so the kubectl client's `Allowed User Groups` selection survives)
3. `rm -rf ~/.kube/cache/oidc-login` — a cached token still carries the old
   group, so without this the identity looks unchanged
4. `KUBECONFIG=~/.kube/clusters/ankhmorpork-oidc kubectl auth whoami`

Expect `oidc:k8s:cluster:admin` in the groups list. The client-certificate
kubeconfig is untouched by any of this and is the way back in if the window goes
wrong.

## Verification

- `make validate` — 129 targets render and validate cleanly
- `make docs-lint` — 0 errors
- the rendered bindings carry exactly `oidc:k8s:cluster:admin` and
  `oidc:k8s:cluster:view`
- `grep` for the old names across `k8s/`, `docs/` and `metal/` comes back empty;
  the stale reference in `metal/group_vars/k3s.yml` is updated here too

## Note

#1439 also edits the group table in `docs/how-to/log-in-with-kubectl.md`, so
whichever merges second needs a one-line conflict resolution there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
