### PR TITLE
kyverno: let the background controller read rolebindings

### DIFF
--- a/k8s/platform/security/kyverno/controllers/clusterrole-background-controller.yaml
+++ b/k8s/platform/security/kyverno/controllers/clusterrole-background-controller.yaml
@@ -31,3 +31,21 @@ rules:
     resourceNames:
       - edit
       - view
+  # The chart's core role grants create/update/patch/delete on rolebindings but
+  # no read verbs, and generation reads before it writes -- it looks for an
+  # existing object to decide between create and update, and synchronize needs
+  # to see drift. Without these, every generate fails with
+  #   permission denied: rolebindings ... is forbidden: ... cannot get resource
+  #   "rolebindings" ... in the namespace "<ns>"
+  # inside a background UpdateRequest, where nothing surfaces it at admission.
+  #
+  # This widens no ceiling: the controller can already write RoleBindings, and
+  # `bind` above still caps which ClusterRole any of them may reference.
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
`generate-group-rolebindings` from #1439 never produced anything. Found while
testing the first grant (#1437).

The chart's `kyverno:background-controller:core` role grants
create/update/patch/delete on rolebindings but **no read verbs**, and generation
reads before it writes — it looks for an existing object to decide between
create and update, and `synchronize` needs to see drift. Every attempt failed
with:

```
permission denied: rolebindings.rbac.authorization.k8s.io "oidc-k8s-group-appadmin-edit"
is forbidden: User "system:serviceaccount:platform-security:kyverno-background-controller"
cannot get resource "rolebindings" in API group "rbac.authorization.k8s.io"
in the namespace "zz-rbac-probe"
```

## Why this was invisible

The failure lands inside a background `UpdateRequest`. The namespace is admitted
normally, no binding appears, and nothing is logged at admission — so the only
symptom is a tenant who authenticates and then gets `Forbidden`, which reads like
a broken authenticator. `kubectl apply --dry-run=server` cannot catch it either:
it compiles the policy, it does not execute the generation.

## Widens no ceiling

The controller could already write RoleBindings — read access adds nothing it
could not do. The `bind` rule still caps which ClusterRole any generated binding
may reference to `edit` and `view`.

## Verified end to end

On a throwaway namespace carrying two labels at different tiers:

```
NAME                           ROLE   SUBJECT
oidc-k8s-group-appadmin-edit   edit   oidc:k8s:group:appadmin
oidc-k8s-group-guests-view     view   oidc:k8s:group:guests
```

Both generated; dropping the `guests` label removed its binding and left the
other. The probe namespace and the temporary ClusterRole used to test the fix
are both deleted — the cluster carries no leftovers, and none of it was applied
to the real ClusterRole (Flux force-owns that object and reverted an attempt, as
expected).

Also confirmed on the way: `validate-group-labels` denies a tier outside
edit/view at admission, with its message.

`make validate` — 129 targets render and validate cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
