### PR TITLE
rbac: aggregate the app CRDs into view/edit/admin

### DIFF
--- a/k8s/apps/datalake-metrics/pyrra/clusterrole-aggregate-edit.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/clusterrole-aggregate-edit.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pyrra-crd-edit
+  labels:
+    # edit, and through the label edit itself carries, admin.
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  annotations:
+    kubernetes.io/description: >-
+      Write access to ServiceLevelObjectives for the built-in edit and admin
+      roles. The most-authored CRD in this repository, and the one a tenant most
+      needs to own: an SLO is a statement about their own application's
+      behaviour, and the PrometheusRules it generates are what page someone.
+rules:
+  - apiGroups:
+      - pyrra.dev
+    resources:
+      - servicelevelobjectives
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update

--- a/k8s/apps/datalake-metrics/pyrra/clusterrole-aggregate-view.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/clusterrole-aggregate-view.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pyrra-crd-view
+  labels:
+    # The built-in roles chain through labels on each other -- `view` carries
+    # aggregate-to-edit and `edit` carries aggregate-to-admin -- so a role
+    # labelled for view alone still reaches all three tiers.
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  annotations:
+    kubernetes.io/description: >-
+      Read access to ServiceLevelObjectives for the built-in view/edit/admin
+      roles, so a namespace grant can see the app's own SLO. The pyrra chart
+      ships no aggregation roles of its own -- unlike cloudnative-pg and
+      kube-prometheus-stack, which do it behind a values flag -- so this is
+      written by hand and lives with the controller whose CRD it covers.
+rules:
+  - apiGroups:
+      - pyrra.dev
+    resources:
+      - servicelevelobjectives
+    verbs:
+      - get
+      - list
+      - watch

--- a/k8s/apps/datalake-metrics/pyrra/kustomization.yaml
+++ b/k8s/apps/datalake-metrics/pyrra/kustomization.yaml
@@ -5,6 +5,8 @@ namespace: datalake-metrics
 resources:
   - repository.yaml
   - release.yaml
+  - clusterrole-aggregate-view.yaml
+  - clusterrole-aggregate-edit.yaml
 # Qualified so a future values generator in the parent cannot collide.
 configMapGenerator:
   - name: values-pyrra

--- a/k8s/platform/network/traefik/clusterrole-aggregate-edit.yaml
+++ b/k8s/platform/network/traefik/clusterrole-aggregate-edit.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: traefik-crd-edit
+  labels:
+    # edit, and through the label edit itself carries, admin.
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  annotations:
+    kubernetes.io/description: >-
+      Write access to Traefik Middlewares for the built-in edit and admin roles.
+
+      Middlewares only. Routing in this cluster is plain Ingress objects with
+      annotations -- already covered by `edit` -- and the one Traefik CRD any
+      application authors is a Middleware, in k8s/apps/paperless. IngressRoute
+      and the transport objects stay read-only: nothing here authors one, and a
+      tenant who needs one is doing something worth reviewing.
+rules:
+  - apiGroups:
+      - traefik.io
+    resources:
+      - middlewares
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update

--- a/k8s/platform/network/traefik/clusterrole-aggregate-view.yaml
+++ b/k8s/platform/network/traefik/clusterrole-aggregate-view.yaml
@@ -1,0 +1,41 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: traefik-crd-view
+  labels:
+    # The built-in roles chain through labels on each other -- `view` carries
+    # aggregate-to-edit and `edit` carries aggregate-to-admin -- so a role
+    # labelled for view alone still reaches all three tiers.
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  annotations:
+    kubernetes.io/description: >-
+      Read access to the Traefik CRDs for the built-in view/edit/admin roles.
+
+      Written by hand rather than with the chart's `rbac.aggregateTo`, which
+      does something different and much wider than its name suggests: it
+      aggregates Traefik's *own controller* ClusterRole into the user-facing
+      roles, which drags cluster-wide read on secrets, nodes, namespaces,
+      services and configmaps along with it. `view` deliberately excludes
+      secrets, and this cluster has a cluster-wide `view` binding, so that flag
+      would hand every viewer read access to every Secret in the cluster.
+
+      One ClusterRole shared by both Traefik instances, which is why it sits
+      here rather than under public/ or private/.
+rules:
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+      - ingressroutetcps
+      - ingressrouteudps
+      - middlewares
+      - middlewaretcps
+      - serverstransports
+      - serverstransporttcps
+      - tlsoptions
+      - tlsstores
+      - traefikservices
+    verbs:
+      - get
+      - list
+      - watch

--- a/k8s/platform/network/traefik/kustomization.yaml
+++ b/k8s/platform/network/traefik/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
   - public/release.yaml
   - private/release.yaml
   - repository.yaml
+  - clusterrole-aggregate-view.yaml
+  - clusterrole-aggregate-edit.yaml
 generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:

--- a/k8s/platform/observability/kube-prometheus-stack/values.yaml
+++ b/k8s/platform/observability/kube-prometheus-stack/values.yaml
@@ -3,6 +3,22 @@
 crds:
   enabled: false
 
+global:
+  rbac:
+    # Ships two ClusterRoles labelled for aggregation into the built-in
+    # view/edit/admin, covering monitoring.coreos.com. Without it a namespace
+    # grant cannot touch the app's own ServiceMonitor or PrometheusRule -- which
+    # is most of what an app in this repo is made of, 19 PrometheusRules and 12
+    # ServiceMonitors across k8s/.
+    #
+    # The edit role covers the whole API group, so it also lets a tenant author
+    # a Prometheus or an Alertmanager in their own namespace. Accepted: that is
+    # upstream's own definition of user-facing, and the blast radius is one
+    # namespace's resource budget. AlertmanagerConfig writes are inert today
+    # because datalake-alerts/main sets no alertmanagerConfigSelector -- if one
+    # is ever added, tenant-authored routing becomes live, so revisit this then.
+    createAggregateClusterRoles: true
+
 # The Prometheus and Alertmanager CRs are hand-written so their specs stay under
 # our control: k8s/apps/datalake-metrics and k8s/apps/datalake-alerts.
 prometheus:

--- a/k8s/platform/storage/cnpg-system/operator/values.yaml
+++ b/k8s/platform/storage/cnpg-system/operator/values.yaml
@@ -1,5 +1,19 @@
 # Config reference: https://github.com/cloudnative-pg/charts/tree/main
 
+rbac:
+  # Ships two ClusterRoles labelled for aggregation into the built-in view/edit/
+  # admin, so a namespace grant reaches the app's own database rather than
+  # stopping at the workloads in front of it. Without it, `edit` in a namespace
+  # cannot even read the Cluster the app runs on.
+  #
+  # The chart's edit role covers every kind in the group, `delete clusters`
+  # included -- which takes the PVCs with it through ownerReferences. That is
+  # not a new capability: `edit` already grants delete on
+  # persistentvolumeclaims in the namespace, so the same data is already one
+  # command away. Preferred over a hand-written narrower role because it tracks
+  # the CRD set across chart upgrades.
+  aggregateClusterRoles: true
+
 additionalArgs:
 - "--metrics-bind-address=0.0.0.0:8080"
 


### PR DESCRIPTION
`admin`, `edit` and `view` only carry rules that something aggregates into them.
The GitOps controllers, external-secrets, k8up, cert-manager and kyverno all
ship such roles; prometheus-operator, Pyrra, CNPG and Traefik do not — so a
namespace grant did not span the application it was for. A tenant with `edit`
could not read their own database, its SLO, or the alert rules generated from it.

Split per controller and shipped next to each one, rather than as a central pair
of roles.

## Two of the four charts already do this

| Controller | How |
| --- | --- |
| cloudnative-pg | `rbac.aggregateClusterRoles: true` |
| kube-prometheus-stack | `global.rbac.createAggregateClusterRoles: true` |
| Pyrra | no such flag — hand-written, in the pyrra component |
| Traefik | flag exists and is **deliberately not used** — see below |

The two flags are wider than a curated split would be. CNPG's edit role covers
`delete clusters`, which takes the PVCs with it through `ownerReferences`;
prometheus-operator's lets a tenant author a Prometheus or Alertmanager in their
own namespace. Both accepted, for concrete reasons rather than convenience:

- `edit` **already** grants `delete` on `persistentvolumeclaims` in the
  namespace (verified), so the CNPG data is one command away either way. The
  aggregation adds no new data-loss path.
- Standing up a Prometheus is bounded by one namespace's resource budget, and is
  upstream's own definition of user-facing. AlertmanagerConfig writes are inert
  today because `datalake-alerts/main` sets no `alertmanagerConfigSelector` — if
  one is ever added, tenant-authored routing becomes live, and the values comment
  says so.

In exchange they track the CRD set across chart upgrades instead of drifting
from a hand-maintained list.

## Traefik's `rbac.aggregateTo` is a trap

Despite the name, it does not expose Traefik's CRDs to the user-facing roles. It
aggregates Traefik's **own controller ClusterRole** into them, which drags along:

```
['']                              ['configmaps','nodes','services']  get,list,watch
['']                              ['secrets']                        get,list,watch
['']                              ['namespaces']                     list,watch
['extensions','networking.k8s.io']['ingressclasses','ingresses']     get,list,watch
```

`view` deliberately excludes Secrets, and this cluster has a cluster-wide `view`
binding — so that one line would hand every viewer read access to every Secret
in the cluster. `traefik-crd-view` / `traefik-crd-edit` cover the CRDs only,
with write on `middlewares` alone: the one Traefik CRD anything here authors, in
`k8s/apps/paperless`.

## Left out

homer-operator. Its single Dashboard lives in homer's own namespace, so no
namespace-scoped grant can reach one, and granting it would be a permission
nothing uses.

## Verified, then reverted

Applied all six roles and checked with impersonation, so the change is measured
rather than argued:

| Check | Before | After |
| --- | --- | --- |
| tenant `edit`: patch servicemonitors / prometheusrules / SLOs / cnpg backups / middlewares in its namespace | no | **yes** |
| tenant `edit`: patch `ingressroutes` | no | no — read-only by design, `get` is yes |
| cluster-wide `view`: get SLOs / cnpg clusters / middlewares | no | **yes** |
| cluster-wide `view`: patch any of them | no | no |
| cluster-wide `view`: `get secrets -A` | no | **no** — the Traefik trap, avoided |
| tenant `edit`: patch SLO in an unbound namespace | no | no |

Then removed: the six roles deleted, and the two pre-existing CNPG roles
un-labelled back to their prior state — the CNPG chart ships those objects
either way and the flag only adds the labels. Baseline confirmed restored, so
nothing is granted until this merges.

`make validate` — 129 targets render and validate cleanly. Both chart flags were
confirmed to produce their roles by rendering each chart against this repo's own
values file.

## One note for review

Aggregation is cluster-wide, so this also widens the existing
`oidc:k8s:cluster:view` binding, not only future namespace grants. Intended, and
the table above is what that widening amounts to. Aggregation only ever adds —
narrowing any of it later means a bespoke ClusterRole and giving up upstream's.

Fixes #1438

🤖 Generated with [Claude Code](https://claude.com/claude-code)
