### PR TITLE
flux: impersonate flux-reconciler for every Kustomization

### DIFF
--- a/docs/reference/admission-policies.md
+++ b/docs/reference/admission-policies.md
@@ -21,6 +21,7 @@ schedule against objects that already exist.
 | [`validate-ingress-contract`](#validate-ingress-contract) | `ingresses` | **Deny** | `kyverno-policies` |
 | [`validate-nfs-k8up-annotations`](#validate-nfs-k8up-annotations) | `persistentvolumeclaims`, `persistentvolumes` | **Warn** | `csi-nfs` |
 | [`validate-pdb-drain-safety`](#validate-pdb-drain-safety) | `poddisruptionbudgets` | **Warn** | `kyverno-policies` |
+| [`validate-reconciler-sa-usage`](#validate-reconciler-sa-usage) | `pods` | **Deny** | `kyverno-policies` |
 | [`validate-roaming-volume-size`](#validate-roaming-volume-size) | `persistentvolumeclaims` | **Deny** | `piraeus-datastore` |
 
 ## `cleanup-cnpg-backups`
@@ -182,6 +183,22 @@ Rules enforced:
 - maxUnavailable must permit at least one voluntary disruption.
 - unhealthyPodEvictionPolicy must be AlwaysAllow so an unhealthy Pod does not indefinitely block a node drain.
 - PodDisruptionBudget selectors must not be empty because policy/v1 empty selectors match every Pod in the namespace.
+
+## `validate-reconciler-sa-usage`
+
+| | |
+| --- | --- |
+| **Kind** | `ValidatingPolicy` |
+| **Applies to** | `pods` |
+| **On** | `CREATE` |
+| **Effect** | **Deny** |
+| **failurePolicy** | `Fail` |
+| **Shipped by** | `kyverno-policies` |
+| **Source** | [`k8s/platform/security/kyverno/policies/validate-reconciler-sa-usage.yaml`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/platform/security/kyverno/policies/validate-reconciler-sa-usage.yaml) |
+
+Rules enforced:
+
+- The flux-reconciler ServiceAccount is the identity Flux impersonates to reconcile this namespace, not one a workload may run as; it is privileged by construction. Give the Pod its own ServiceAccount and grant that what it needs.
 
 ## `validate-roaming-volume-size`
 

--- a/k8s/platform/cluster/flux-system/controllers/values.yaml
+++ b/k8s/platform/cluster/flux-system/controllers/values.yaml
@@ -1,6 +1,16 @@
 # Reference documentation: https://github.com/fluxcd-community/helm-charts/tree/main/charts/flux2
 
 helmController:
+  # Confine a HelmRelease to chart sources and dependsOn targets in its own
+  # namespace. Verified inert: no HelmRelease references either across one.
+  #
+  # --default-service-account is deliberately absent. Unlike kustomize-
+  # controller, where every Kustomization lives in flux-system, the SA would be
+  # resolved in each HelmRelease's own namespace -- 31 of them, none holding a
+  # flux-reconciler yet. It goes on once they do.
+  container:
+    additionalArgs:
+      - --no-cross-namespace-refs=true
   priorityClassName: system-cluster-critical
   tolerations:
     - key: node-role.kubernetes.io/control-plane
@@ -16,25 +26,46 @@ helmController:
             operator: Exists
 
 kustomizeController:
-  # Impersonate flux-system's flux-reconciler ServiceAccount for every
-  # Kustomization that does not set spec.serviceAccountName, rather than
-  # applying as the controller's own cluster-admin identity.
+  # Flux's multi-tenancy lockdown, minus the one flag that does not apply here.
+  # https://fluxcd.io/flux/installation/configuration/multitenancy/
   #
-  # Passed here rather than through `multitenancy.enabled`, which is the
-  # chart's switch for this flag but emits `--no-cross-namespace-refs=true`
-  # alongside it. That one forbids `sourceRef.namespace: flux-system`, which is
-  # how a Kustomization in an app namespace shares the single GitRepository --
-  # turning it on would mean a GitRepository per namespace. Impersonation
-  # already denies a tenant pointing spec.path at another component, so the
-  # cross-namespace flag buys nothing here.
+  # --default-service-account: impersonate flux-system's flux-reconciler for
+  #   every Kustomization that does not set spec.serviceAccountName, rather
+  #   than applying as the controller's own cluster-admin identity. The SA is
+  #   resolved in each Kustomization's OWN namespace, so this is inert while
+  #   all of them live in flux-system -- the name resolves to the SA in
+  #   reconciler/, which is cluster-admin. It stops being inert the moment a
+  #   Kustomization moves into an app namespace, which is the intended order.
   #
-  # The SA is resolved in each Kustomization's OWN namespace, so this is inert
-  # while all of them live in flux-system: the name resolves to the SA in
-  # reconciler/, which is cluster-admin. It stops being inert the moment a
-  # Kustomization moves into an app namespace, which is the intended order.
+  #   Upstream uses `default` here. A named SA instead, because `default` is
+  #   what a Pod gets when it names none: granting it reconcile rights would
+  #   hand namespace-admin, token already mounted, to every such Pod -- 30 of
+  #   them across 15 namespaces when this was measured. See reconciler/.
+  #
+  # --no-cross-namespace-refs: a Flux object may only reference sources,
+  #   dependsOn targets and notification providers in its own namespace. Each
+  #   namespace that gains a Kustomization therefore gains its own
+  #   GitRepository -- which is already how every HelmRelease here works, and
+  #   costs nothing extra since the repo is public and needs no credential.
+  #
+  # --no-remote-bases: a kustomization.yaml may not pull a base from a URL, so
+  #   only what the Flux source carries can reach the cluster.
+  #
+  # Both of the latter were verified to break nothing before being set: zero
+  # cross-namespace sourceRefs, zero cross-namespace dependsOn, and no remote
+  # bases anywhere in k8s/.
+  #
+  # Set through additionalArgs rather than the chart's `multitenancy.enabled`,
+  # which would be the natural switch for all three. It also puts
+  # --default-service-account on helm-controller, where it is NOT inert: that
+  # SA is resolved in each HelmRelease's own namespace, and the 48 HelmReleases
+  # are spread over 31 namespaces, none of which has the SA yet. Switch to it
+  # once they do.
   container:
     additionalArgs:
       - --default-service-account=flux-reconciler
+      - --no-cross-namespace-refs=true
+      - --no-remote-bases=true
   priorityClassName: system-cluster-critical
   tolerations:
     - key: "node-role.kubernetes.io/control-plane"
@@ -65,6 +96,13 @@ sourceController:
             operator: Exists
 
 notificationController:
+  # An Alert may only reference a Provider in its own namespace, and a Receiver
+  # only resources in its own. One notification object exists today, in
+  # flux-system, so this changes nothing now and stops a tenant subscribing to
+  # another namespace's events later.
+  container:
+    additionalArgs:
+      - --no-cross-namespace-refs=true
   webhookReceiver:
     ingress:
       ingressClassName: cloudflare

--- a/k8s/platform/cluster/flux-system/controllers/values.yaml
+++ b/k8s/platform/cluster/flux-system/controllers/values.yaml
@@ -16,6 +16,25 @@ helmController:
             operator: Exists
 
 kustomizeController:
+  # Impersonate flux-system's flux-reconciler ServiceAccount for every
+  # Kustomization that does not set spec.serviceAccountName, rather than
+  # applying as the controller's own cluster-admin identity.
+  #
+  # Passed here rather than through `multitenancy.enabled`, which is the
+  # chart's switch for this flag but emits `--no-cross-namespace-refs=true`
+  # alongside it. That one forbids `sourceRef.namespace: flux-system`, which is
+  # how a Kustomization in an app namespace shares the single GitRepository --
+  # turning it on would mean a GitRepository per namespace. Impersonation
+  # already denies a tenant pointing spec.path at another component, so the
+  # cross-namespace flag buys nothing here.
+  #
+  # The SA is resolved in each Kustomization's OWN namespace, so this is inert
+  # while all of them live in flux-system: the name resolves to the SA in
+  # reconciler/, which is cluster-admin. It stops being inert the moment a
+  # Kustomization moves into an app namespace, which is the intended order.
+  container:
+    additionalArgs:
+      - --default-service-account=flux-reconciler
   priorityClassName: system-cluster-critical
   tolerations:
     - key: "node-role.kubernetes.io/control-plane"

--- a/k8s/platform/cluster/flux-system/reconciler/clusterrolebinding.yaml
+++ b/k8s/platform/cluster/flux-system/reconciler/clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flux-reconciler
+  annotations:
+    kubernetes.io/description: >-
+      cluster-admin, deliberately: this SA reconciles flux-system, which owns
+      every component Kustomization, the CRDs and the cluster-scoped RBAC.
+      Narrowing it would not bound anything -- flux-system is the control
+      plane, not a tenant. The boundary this change buys appears one namespace
+      at a time, as each app's Kustomization moves into its own namespace with
+      an SA scoped to that app.
+subjects:
+  - kind: ServiceAccount
+    name: flux-reconciler
+    namespace: flux-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin

--- a/k8s/platform/cluster/flux-system/reconciler/kustomization.yaml
+++ b/k8s/platform/cluster/flux-system/reconciler/kustomization.yaml
@@ -2,7 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: flux-system
 resources:
-  - namespace.yaml
-  - controllers/
-  - additional/
-  - reconciler/
+  - serviceaccount.yaml
+  - clusterrolebinding.yaml

--- a/k8s/platform/cluster/flux-system/reconciler/serviceaccount.yaml
+++ b/k8s/platform/cluster/flux-system/reconciler/serviceaccount.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flux-reconciler
+  namespace: flux-system
+  annotations:
+    kubernetes.io/description: >-
+      The identity kustomize-controller impersonates when a Kustomization does
+      not set spec.serviceAccountName, via --default-service-account. The SA is
+      looked up in the Kustomization's OWN namespace, so this one covers only
+      the objects in flux-system. A Kustomization that moves into an app
+      namespace needs a flux-reconciler there, scoped to that app -- which is
+      the point of the whole exercise.
+# No token is mounted anywhere: impersonation goes through the API server, not
+# through a mounted credential. automountServiceAccountToken is off so a Pod
+# that names this SA cannot borrow its rights.
+automountServiceAccountToken: false

--- a/k8s/platform/security/kyverno/policies/kustomization.yaml
+++ b/k8s/platform/security/kyverno/policies/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - mutate-configmap-autoreload.yaml
   - validate-group-labels.yaml
   - generate-group-rolebindings.yaml
+  - validate-reconciler-sa-usage.yaml

--- a/k8s/platform/security/kyverno/policies/validate-reconciler-sa-usage.yaml
+++ b/k8s/platform/security/kyverno/policies/validate-reconciler-sa-usage.yaml
@@ -1,0 +1,96 @@
+apiVersion: policies.kyverno.io/v1
+kind: ValidatingPolicy
+metadata:
+  # Cluster-scoped. kustomize cannot know that for a CRD kind and stamps the
+  # component's namespace on it in the rendered output; the API server ignores
+  # the field for cluster-scoped resources.
+  name: validate-reconciler-sa-usage
+spec:
+  # `flux-reconciler` is the name kustomize-controller impersonates for any
+  # Kustomization that does not set spec.serviceAccountName
+  # (--default-service-account). It is a reconciliation identity, never a
+  # workload identity, and it is privileged by construction -- in flux-system
+  # it is cluster-admin. A Pod that names it gets a token for it.
+  #
+  # Nothing legitimately runs as this SA. Impersonation is an API-server
+  # mechanism: the controller asks to act AS the SA, it never mounts a token,
+  # and the controller's own Pods run as `kustomize-controller`. So denying the
+  # name outright costs nothing and removes the most likely way it leaks --
+  # `serviceAccountName: flux-reconciler` copy-pasted into a Deployment,
+  # handing that workload cluster-admin with no error and no symptom.
+  #
+  # THIS GUARDS WORKLOADS, NOT TENANTS -- a distinction worth keeping straight,
+  # because the two have different reachability.
+  #
+  # It cannot bound a human who holds `edit` on the namespace. `ClusterRole/edit`
+  # carries `impersonate` on serviceaccounts (upstream editRules(), and `admin`
+  # aggregates it), so `kubectl --as=system:serviceaccount:<ns>:flux-reconciler`
+  # reaches the SA while creating nothing. No admission controller can intercept
+  # that, and the request that arrives is indistinguishable from Flux's own --
+  # being that identity is exactly what Flux does. The same goes for the other
+  # admission-visible token routes, a `kubernetes.io/service-account-token`
+  # Secret and a `serviceaccounts/token` TokenRequest: denying them here would
+  # add rules that bound nobody.
+  #
+  # Nor is any of that worth chasing. A tenant who controls the git path Flux
+  # reconciles can commit a Pod that reads the token and ships it out, so the
+  # reconciler's rights in a namespace ARE the tenant's rights there -- true of
+  # Flux's own tenancy model too, which assumes tenants have no API access at
+  # all. What bounds a tenant is the namespace edge: a RoleBinding rather than a
+  # ClusterRoleBinding, --no-cross-namespace-refs, and Pod Security Admission.
+  #
+  # A workload is the other case. A container runs as this SA only because a
+  # manifest said so, which makes the realistic cause a mistake rather than an
+  # attack -- and in flux-system that mistake is a cluster-admin workload with
+  # no error and no symptom. That is what the rule below is for.
+  # See thaum-xyz/ankhmorpork#1436.
+  #
+  # WHY THIS LIVES HERE rather than with flux-system, where csi-nfs,
+  # piraeus-datastore and cnpg-system each keep their own policy:
+  #
+  # `flux-reconciler` is a reserved name in EVERY namespace, not an object the
+  # flux-system component owns -- a cluster-wide convention like
+  # validate-group-labels, rather than validate-roaming-volume-size guarding the
+  # one StorageClass piraeus ships. Its other half belongs here too: the
+  # GeneratingPolicy that mints the per-namespace SA and RoleBinding sits beside
+  # generate-group-rolebindings. One mechanism mints the identity, the other
+  # keeps workloads off it.
+  #
+  # Moving it would also cost more than it looks. The SA and its
+  # ClusterRoleBinding cannot leave the flux-system component: they must be
+  # created by the same Kustomization that sets --default-service-account, or a
+  # cold bootstrap deadlocks -- the controllers restart wanting an identity that
+  # only a reconcile could create. So the policy would arrive there needing
+  # `dependsOn: kyverno` on flux-system, coupling the GitOps engine to the
+  # policy engine on the one Kustomization deliberately marked prune: false.
+  evaluation:
+    background:
+      enabled: false
+  failurePolicy: Fail
+  validationActions:
+    - Deny
+  matchConstraints:
+    resourceRules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          # spec.serviceAccountName is immutable on a Pod, so CREATE is the
+          # only way in.
+          - CREATE
+        resources:
+          - pods
+  validations:
+    # Both spellings: `serviceAccount` is the deprecated alias for
+    # `serviceAccountName`. The API server defaults one from the other before
+    # admission runs, so checking either would do -- checking both means the
+    # rule does not rest on that defaulting staying where it is.
+    - expression: >-
+        object.spec.?serviceAccountName.orValue("") != "flux-reconciler" &&
+        object.spec.?serviceAccount.orValue("") != "flux-reconciler"
+      message: >-
+        The flux-reconciler ServiceAccount is the identity Flux impersonates to
+        reconcile this namespace, not one a workload may run as; it is
+        privileged by construction. Give the Pod its own ServiceAccount and
+        grant that what it needs.


### PR DESCRIPTION
First step of #1436 — the one that creates the security boundary; the rest is ergonomics.

## What this does

kustomize-controller applies as its own identity, bound to `cluster-admin`. `--default-service-account=flux-reconciler` makes it impersonate that ServiceAccount instead, resolved **in each Kustomization's own namespace**.

All 51 Kustomizations live in `flux-system`, so it resolves to the one SA added here, itself bound to `cluster-admin`. Inert today, by design — the boundary appears one namespace at a time as each app's Kustomization moves into its own namespace with an SA scoped to that app.

## Why it is inert, shown rather than asserted

The full `helm template` of the flux2 chart, before vs. after:

```
5822a5823
>         - --default-service-account=flux-reconciler
```

One added line. helm-controller, source-controller and notification-controller are untouched.

## Two findings worth recording

**The chart couples the two flags.** `multitenancy.enabled: true` is the chart's switch for `--default-service-account`, but it emits `--no-cross-namespace-refs=true` alongside it (`templates/kustomize-controller.yaml:42-44`). That one forbids the `sourceRef.namespace: flux-system` that lets a tenant namespace share the single GitRepository — it would mean a GitRepository per namespace, which #1436 rules out. So the flag goes through `kustomizeController.container.additionalArgs` and `multitenancy` stays off. Verified `--no-cross-namespace-refs` appears zero times in the render.

**helm-controller is deliberately left alone.** #1436 says flipping the flag is "behaviourally inert" while everything lives in `flux-system`. That holds for Kustomizations, not HelmReleases:

| | |
| --- | --- |
| Kustomizations | 51, all in `flux-system` → one SA covers them |
| HelmReleases | **48, across 31 namespaces** → the SA is resolved in each release's own namespace |

Flipping helm-controller breaks 48 releases unless all 31 namespaces have the SA first. That is its own change.

A third one for whoever picks up the seeding: a `cluster-admin`-bound `flux-reconciler` in a *tenant* namespace is a new escalation path — `mealie` already carries `group.rbac.thaum.xyz/appadmin: edit`, and anyone with `edit` can run a Pod as that SA. "Bind to cluster-admin first, narrow later" is safe in platform namespaces, which have no human grants, and not in app namespaces. The SA here sets `automountServiceAccountToken: false` for the same reason.

## Verification

- [x] `make validate` — 130 targets render and validate cleanly
- [x] `make validate-flux` — all 51 live paths exist
- [x] chart render diff is the single expected line
- [ ] after merge: reconcile the Kustomization (creates the SA) **before** the HelmRelease (flips the flag), then confirm all 51 Kustomizations still reconcile

🤖 Generated with [Claude Code](https://claude.com/claude-code)
