### PR TITLE
kyverno: deny Pods that run as flux-reconciler

### DIFF
--- a/docs/reference/admission-policies.md
+++ b/docs/reference/admission-policies.md
@@ -21,6 +21,7 @@ schedule against objects that already exist.
 | [`validate-ingress-contract`](#validate-ingress-contract) | `ingresses` | **Deny** | `kyverno-policies` |
 | [`validate-nfs-k8up-annotations`](#validate-nfs-k8up-annotations) | `persistentvolumeclaims`, `persistentvolumes` | **Warn** | `csi-nfs` |
 | [`validate-pdb-drain-safety`](#validate-pdb-drain-safety) | `poddisruptionbudgets` | **Warn** | `kyverno-policies` |
+| [`validate-reconciler-sa-usage`](#validate-reconciler-sa-usage) | `pods` | **Deny** | `kyverno-policies` |
 | [`validate-roaming-volume-size`](#validate-roaming-volume-size) | `persistentvolumeclaims` | **Deny** | `piraeus-datastore` |
 
 ## `cleanup-cnpg-backups`
@@ -182,6 +183,22 @@ Rules enforced:
 - maxUnavailable must permit at least one voluntary disruption.
 - unhealthyPodEvictionPolicy must be AlwaysAllow so an unhealthy Pod does not indefinitely block a node drain.
 - PodDisruptionBudget selectors must not be empty because policy/v1 empty selectors match every Pod in the namespace.
+
+## `validate-reconciler-sa-usage`
+
+| | |
+| --- | --- |
+| **Kind** | `ValidatingPolicy` |
+| **Applies to** | `pods` |
+| **On** | `CREATE` |
+| **Effect** | **Deny** |
+| **failurePolicy** | `Fail` |
+| **Shipped by** | `kyverno-policies` |
+| **Source** | [`k8s/platform/security/kyverno/policies/validate-reconciler-sa-usage.yaml`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/platform/security/kyverno/policies/validate-reconciler-sa-usage.yaml) |
+
+Rules enforced:
+
+- The flux-reconciler ServiceAccount is the identity Flux impersonates to reconcile this namespace, not one a workload may run as; it is privileged by construction. Give the Pod its own ServiceAccount and grant that what it needs.
 
 ## `validate-roaming-volume-size`
 

--- a/k8s/platform/security/kyverno/policies/kustomization.yaml
+++ b/k8s/platform/security/kyverno/policies/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - mutate-configmap-autoreload.yaml
   - validate-group-labels.yaml
   - generate-group-rolebindings.yaml
+  - validate-reconciler-sa-usage.yaml

--- a/k8s/platform/security/kyverno/policies/validate-reconciler-sa-usage.yaml
+++ b/k8s/platform/security/kyverno/policies/validate-reconciler-sa-usage.yaml
@@ -1,0 +1,96 @@
+apiVersion: policies.kyverno.io/v1
+kind: ValidatingPolicy
+metadata:
+  # Cluster-scoped. kustomize cannot know that for a CRD kind and stamps the
+  # component's namespace on it in the rendered output; the API server ignores
+  # the field for cluster-scoped resources.
+  name: validate-reconciler-sa-usage
+spec:
+  # `flux-reconciler` is the name kustomize-controller impersonates for any
+  # Kustomization that does not set spec.serviceAccountName
+  # (--default-service-account). It is a reconciliation identity, never a
+  # workload identity, and it is privileged by construction -- in flux-system
+  # it is cluster-admin. A Pod that names it gets a token for it.
+  #
+  # Nothing legitimately runs as this SA. Impersonation is an API-server
+  # mechanism: the controller asks to act AS the SA, it never mounts a token,
+  # and the controller's own Pods run as `kustomize-controller`. So denying the
+  # name outright costs nothing and removes the most likely way it leaks --
+  # `serviceAccountName: flux-reconciler` copy-pasted into a Deployment,
+  # handing that workload cluster-admin with no error and no symptom.
+  #
+  # THIS GUARDS WORKLOADS, NOT TENANTS -- a distinction worth keeping straight,
+  # because the two have different reachability.
+  #
+  # It cannot bound a human who holds `edit` on the namespace. `ClusterRole/edit`
+  # carries `impersonate` on serviceaccounts (upstream editRules(), and `admin`
+  # aggregates it), so `kubectl --as=system:serviceaccount:<ns>:flux-reconciler`
+  # reaches the SA while creating nothing. No admission controller can intercept
+  # that, and the request that arrives is indistinguishable from Flux's own --
+  # being that identity is exactly what Flux does. The same goes for the other
+  # admission-visible token routes, a `kubernetes.io/service-account-token`
+  # Secret and a `serviceaccounts/token` TokenRequest: denying them here would
+  # add rules that bound nobody.
+  #
+  # Nor is any of that worth chasing. A tenant who controls the git path Flux
+  # reconciles can commit a Pod that reads the token and ships it out, so the
+  # reconciler's rights in a namespace ARE the tenant's rights there -- true of
+  # Flux's own tenancy model too, which assumes tenants have no API access at
+  # all. What bounds a tenant is the namespace edge: a RoleBinding rather than a
+  # ClusterRoleBinding, --no-cross-namespace-refs, and Pod Security Admission.
+  #
+  # A workload is the other case. A container runs as this SA only because a
+  # manifest said so, which makes the realistic cause a mistake rather than an
+  # attack -- and in flux-system that mistake is a cluster-admin workload with
+  # no error and no symptom. That is what the rule below is for.
+  # See thaum-xyz/ankhmorpork#1436.
+  #
+  # WHY THIS LIVES HERE rather than with flux-system, where csi-nfs,
+  # piraeus-datastore and cnpg-system each keep their own policy:
+  #
+  # `flux-reconciler` is a reserved name in EVERY namespace, not an object the
+  # flux-system component owns -- a cluster-wide convention like
+  # validate-group-labels, rather than validate-roaming-volume-size guarding the
+  # one StorageClass piraeus ships. Its other half belongs here too: the
+  # GeneratingPolicy that mints the per-namespace SA and RoleBinding sits beside
+  # generate-group-rolebindings. One mechanism mints the identity, the other
+  # keeps workloads off it.
+  #
+  # Moving it would also cost more than it looks. The SA and its
+  # ClusterRoleBinding cannot leave the flux-system component: they must be
+  # created by the same Kustomization that sets --default-service-account, or a
+  # cold bootstrap deadlocks -- the controllers restart wanting an identity that
+  # only a reconcile could create. So the policy would arrive there needing
+  # `dependsOn: kyverno` on flux-system, coupling the GitOps engine to the
+  # policy engine on the one Kustomization deliberately marked prune: false.
+  evaluation:
+    background:
+      enabled: false
+  failurePolicy: Fail
+  validationActions:
+    - Deny
+  matchConstraints:
+    resourceRules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          # spec.serviceAccountName is immutable on a Pod, so CREATE is the
+          # only way in.
+          - CREATE
+        resources:
+          - pods
+  validations:
+    # Both spellings: `serviceAccount` is the deprecated alias for
+    # `serviceAccountName`. The API server defaults one from the other before
+    # admission runs, so checking either would do -- checking both means the
+    # rule does not rest on that defaulting staying where it is.
+    - expression: >-
+        object.spec.?serviceAccountName.orValue("") != "flux-reconciler" &&
+        object.spec.?serviceAccount.orValue("") != "flux-reconciler"
+      message: >-
+        The flux-reconciler ServiceAccount is the identity Flux impersonates to
+        reconcile this namespace, not one a workload may run as; it is
+        privileged by construction. Give the Pod its own ServiceAccount and
+        grant that what it needs.


### PR DESCRIPTION
Stacked on #1444 — base is `pkrupa/flux-impersonate-kustomize-controller`, since the SA this guards does not exist until that merges. Independent of #1448.

## What it does

Denies any Pod naming `flux-reconciler` as its ServiceAccount, cluster-wide, on both the `serviceAccountName` field and the deprecated `serviceAccount` alias.

Nothing legitimately runs as that SA. Impersonation is an API-server mechanism — kustomize-controller asks to act *as* the SA, never mounts a token, and its own Pods run as `kustomize-controller`.

## This guards workloads, not tenants

The two have different reachability, and the distinction is the whole justification for the rule.

**It cannot bound a human holding `edit` on the namespace.** Measured live:

```
edit  ->  ["impersonate"]  on  ["serviceaccounts"]
edit  ->  ["create"]       on  ["serviceaccounts/token"]
```

`kubectl --as=system:serviceaccount:<ns>:flux-reconciler` reaches the SA while creating nothing for admission to intercept, and the request that arrives is indistinguishable from Flux's own. The other admission-visible token routes — a `kubernetes.io/service-account-token` Secret, and a `serviceaccounts/token` TokenRequest — are deliberately left unguarded for the same reason: they'd be rules that bound nobody.

**Nor is that worth chasing.** A tenant who controls the git path Flux reconciles can commit a Pod that reads the token and ships it out, so the reconciler's rights in a namespace *are* the tenant's rights there. That holds in Flux's own tenancy model too, which assumes tenants have [no direct API access](https://github.com/fluxcd/flux2-multi-tenancy) at all. What bounds a tenant is the namespace edge: a RoleBinding rather than a ClusterRoleBinding, `--no-cross-namespace-refs` (#1448), and Pod Security Admission.

**A workload is the other case, and the one this catches.** A container runs as this SA only because a manifest said so — which makes the realistic cause a mistake rather than an attack. `serviceAccountName: flux-reconciler` copy-pasted into a Deployment is, in `flux-system`, a cluster-admin workload with no error and no symptom. Cheap rule, catastrophic tail.

Kubernetes offers no other way to express "this identity may not be used by Pods" — RBAC can't, PSA can't, and `automountServiceAccountToken: false` (set on the SA in #1444) is only a speed bump, since a Pod can override it or project the token itself.

## Verification

- [x] `kubectl apply --dry-run=server` — the `validate-policy.kyverno.svc` webhook compiles the CEL
- [x] `kyverno apply` against five fixture Pods: **denied** for `serviceAccountName`, for the deprecated `serviceAccount` alias, and in `flux-system`; **passed** for another SA and for no SA at all (`pass: 2, fail: 3, warn: 0, error: 0, skip: 0`)
- [x] nothing in `k8s/` names the SA as a workload identity; 0 live Pods run as it
- [x] `make validate` — 130 targets clean
- [x] `make docs-reference` run and committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
