### PR TITLE
flux: adopt the multi-tenancy lockdown flags

### DIFF
--- a/k8s/platform/cluster/flux-system/controllers/values.yaml
+++ b/k8s/platform/cluster/flux-system/controllers/values.yaml
@@ -1,6 +1,16 @@
 # Reference documentation: https://github.com/fluxcd-community/helm-charts/tree/main/charts/flux2
 
 helmController:
+  # Confine a HelmRelease to chart sources and dependsOn targets in its own
+  # namespace. Verified inert: no HelmRelease references either across one.
+  #
+  # --default-service-account is deliberately absent. Unlike kustomize-
+  # controller, where every Kustomization lives in flux-system, the SA would be
+  # resolved in each HelmRelease's own namespace -- 31 of them, none holding a
+  # flux-reconciler yet. It goes on once they do.
+  container:
+    additionalArgs:
+      - --no-cross-namespace-refs=true
   priorityClassName: system-cluster-critical
   tolerations:
     - key: node-role.kubernetes.io/control-plane
@@ -16,25 +26,46 @@ helmController:
             operator: Exists
 
 kustomizeController:
-  # Impersonate flux-system's flux-reconciler ServiceAccount for every
-  # Kustomization that does not set spec.serviceAccountName, rather than
-  # applying as the controller's own cluster-admin identity.
+  # Flux's multi-tenancy lockdown, minus the one flag that does not apply here.
+  # https://fluxcd.io/flux/installation/configuration/multitenancy/
   #
-  # Passed here rather than through `multitenancy.enabled`, which is the
-  # chart's switch for this flag but emits `--no-cross-namespace-refs=true`
-  # alongside it. That one forbids `sourceRef.namespace: flux-system`, which is
-  # how a Kustomization in an app namespace shares the single GitRepository --
-  # turning it on would mean a GitRepository per namespace. Impersonation
-  # already denies a tenant pointing spec.path at another component, so the
-  # cross-namespace flag buys nothing here.
+  # --default-service-account: impersonate flux-system's flux-reconciler for
+  #   every Kustomization that does not set spec.serviceAccountName, rather
+  #   than applying as the controller's own cluster-admin identity. The SA is
+  #   resolved in each Kustomization's OWN namespace, so this is inert while
+  #   all of them live in flux-system -- the name resolves to the SA in
+  #   reconciler/, which is cluster-admin. It stops being inert the moment a
+  #   Kustomization moves into an app namespace, which is the intended order.
   #
-  # The SA is resolved in each Kustomization's OWN namespace, so this is inert
-  # while all of them live in flux-system: the name resolves to the SA in
-  # reconciler/, which is cluster-admin. It stops being inert the moment a
-  # Kustomization moves into an app namespace, which is the intended order.
+  #   Upstream uses `default` here. A named SA instead, because `default` is
+  #   what a Pod gets when it names none: granting it reconcile rights would
+  #   hand namespace-admin, token already mounted, to every such Pod -- 30 of
+  #   them across 15 namespaces when this was measured. See reconciler/.
+  #
+  # --no-cross-namespace-refs: a Flux object may only reference sources,
+  #   dependsOn targets and notification providers in its own namespace. Each
+  #   namespace that gains a Kustomization therefore gains its own
+  #   GitRepository -- which is already how every HelmRelease here works, and
+  #   costs nothing extra since the repo is public and needs no credential.
+  #
+  # --no-remote-bases: a kustomization.yaml may not pull a base from a URL, so
+  #   only what the Flux source carries can reach the cluster.
+  #
+  # Both of the latter were verified to break nothing before being set: zero
+  # cross-namespace sourceRefs, zero cross-namespace dependsOn, and no remote
+  # bases anywhere in k8s/.
+  #
+  # Set through additionalArgs rather than the chart's `multitenancy.enabled`,
+  # which would be the natural switch for all three. It also puts
+  # --default-service-account on helm-controller, where it is NOT inert: that
+  # SA is resolved in each HelmRelease's own namespace, and the 48 HelmReleases
+  # are spread over 31 namespaces, none of which has the SA yet. Switch to it
+  # once they do.
   container:
     additionalArgs:
       - --default-service-account=flux-reconciler
+      - --no-cross-namespace-refs=true
+      - --no-remote-bases=true
   priorityClassName: system-cluster-critical
   tolerations:
     - key: "node-role.kubernetes.io/control-plane"
@@ -65,6 +96,13 @@ sourceController:
             operator: Exists
 
 notificationController:
+  # An Alert may only reference a Provider in its own namespace, and a Receiver
+  # only resources in its own. One notification object exists today, in
+  # flux-system, so this changes nothing now and stops a tenant subscribing to
+  # another namespace's events later.
+  container:
+    additionalArgs:
+      - --no-cross-namespace-refs=true
   webhookReceiver:
     ingress:
       ingressClassName: cloudflare


### PR DESCRIPTION
Stacked on #1444 (base is `pkrupa/flux-impersonate-kustomize-controller`), since it extends the same `additionalArgs` block. Independent of #1446.

Two more flags from [Flux's multi-tenancy lockdown](https://fluxcd.io/flux/installation/configuration/multitenancy/):

| Flag | Controllers |
| --- | --- |
| `--no-cross-namespace-refs=true` | kustomize, helm, notification |
| `--no-remote-bases=true` | kustomize |

The first confines a Flux object's `sourceRef`, `dependsOn` and notification references to its own namespace. The second stops a `kustomization.yaml` pulling a base from a URL, so only what a Flux source carries can reach the cluster.

## Verified inert before setting

| | |
| --- | --- |
| cross-namespace `sourceRef` | **0** Kustomizations, **0** HelmReleases |
| cross-namespace `dependsOn` | **0** Kustomizations, **0** HelmReleases |
| notification objects | **1**, in `flux-system` |
| remote kustomize bases in `k8s/` | **0** |

The full chart render gains exactly four lines and nothing else moves:

```
5728a5729
>         - --no-cross-namespace-refs=true      # helm-controller
5823a5825,5826
>         - --no-cross-namespace-refs=true      # kustomize-controller
>         - --no-remote-bases=true
5918a5922
>         - --no-cross-namespace-refs=true      # notification-controller
```

Setting them now makes them a ratchet that holds while Kustomizations move into app namespaces, rather than something to retrofit once there is something to break.

## Revisiting #1436's "deliberately out of scope"

The issue rules `--no-cross-namespace-refs` out because it forbids the `sourceRef.namespace: flux-system` that lets a tenant namespace share the single GitRepository — "so it would mean a GitRepository per namespace." That premise doesn't survive measurement:

- **The repo is public.** The GitRepository carries no `secretRef`, so a source per namespace distributes no credential. That was the real objection, and it doesn't apply.
- **It's already the house pattern.** 32 namespaces hold their own HelmRepository or OCIRepository — "the source lives with its consumer" is how every Helm chart here already works.
- **It's cheap.** 16 MiB pack; source-controller's artifact volume has 48 GiB free. ~20 namespaces ≈ 320 MiB. The only real cost is fetch rate at the current 60s interval, which a longer interval on tenant sources handles — there's already a Receiver for webhook-driven immediacy.

## Still not the chart's `multitenancy.enabled`

That switch would emit all three flags, which is now most of what we want — but it also puts `--default-service-account` on **helm-controller**, where the SA is resolved in each HelmRelease's own namespace. 31 namespaces hold HelmReleases and none has a `flux-reconciler` yet. Switch to it once they do; the comment in `values.yaml` says so.

## Also recorded in the values comment

Why the SA is named rather than upstream's `default`: `default` is what a Pod gets when it names none, so granting it reconcile rights would hand namespace-admin — token already mounted — to every such Pod. **30 of 228 pods across 15 namespaces**, `mealie` included.

## Verification

- [x] all three flags confirmed present on the running v1.9.2 binaries (`--help` on each controller)
- [x] chart render diff is exactly the four expected lines
- [x] `make validate` — 130 targets clean
- [x] `make validate-flux` — 51 paths clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
