### PR TITLE
namespaces: protect app Namespaces from garbage collection

### DIFF
--- a/k8s/apps/ai-gateway/namespace.yaml
+++ b/k8s/apps/ai-gateway/namespace.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: ai-gateway
+  annotations:
+    # Never garbage-collect this Namespace. Pruning is inventory-based, so
+    # dropping it from a Kustomization's inventory would delete the namespace
+    # and everything inside it.
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/k8s/apps/atuin/namespace.yaml
+++ b/k8s/apps/atuin/namespace.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: atuin
+  annotations:
+    # Never garbage-collect this Namespace. Pruning is inventory-based, so
+    # dropping it from a Kustomization's inventory would delete the namespace
+    # and everything inside it.
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/k8s/apps/changedetection/namespace.yaml
+++ b/k8s/apps/changedetection/namespace.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: changedetection
+  annotations:
+    # Never garbage-collect this Namespace. Pruning is inventory-based, so
+    # dropping it from a Kustomization's inventory would delete the namespace
+    # and everything inside it.
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/k8s/apps/datalake-alerts/namespace.yaml
+++ b/k8s/apps/datalake-alerts/namespace.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: datalake-alerts
+  annotations:
+    # Never garbage-collect this Namespace. Pruning is inventory-based, so
+    # dropping it from a Kustomization's inventory would delete the namespace
+    # and everything inside it.
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/k8s/apps/datalake-logs/namespace.yaml
+++ b/k8s/apps/datalake-logs/namespace.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: datalake-logs
+  annotations:
+    # Never garbage-collect this Namespace. Pruning is inventory-based, so
+    # dropping it from a Kustomization's inventory would delete the namespace
+    # and everything inside it.
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/k8s/apps/datalake-metrics/namespace.yaml
+++ b/k8s/apps/datalake-metrics/namespace.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: datalake-metrics
+  annotations:
+    # Never garbage-collect this Namespace. Pruning is inventory-based, so
+    # dropping it from a Kustomization's inventory would delete the namespace
+    # and everything inside it.
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/k8s/apps/dlna-local/namespace.yaml
+++ b/k8s/apps/dlna-local/namespace.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: dlna-local
+  annotations:
+    # Never garbage-collect this Namespace. Pruning is inventory-based, so
+    # dropping it from a Kustomization's inventory would delete the namespace
+    # and everything inside it.
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/k8s/apps/grafana/namespace.yaml
+++ b/k8s/apps/grafana/namespace.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: grafana
+  annotations:
+    # Never garbage-collect this Namespace. Pruning is inventory-based, so
+    # dropping it from a Kustomization's inventory would delete the namespace
+    # and everything inside it.
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/k8s/apps/karakeep/namespace.yaml
+++ b/k8s/apps/karakeep/namespace.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: karakeep
+  annotations:
+    # Never garbage-collect this Namespace. Pruning is inventory-based, so
+    # dropping it from a Kustomization's inventory would delete the namespace
+    # and everything inside it.
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/k8s/apps/mealie/namespace.yaml
+++ b/k8s/apps/mealie/namespace.yaml
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: mealie
+  annotations:
+    # Never garbage-collect this Namespace. Pruning is inventory-based, so
+    # dropping it from a Kustomization's inventory would delete the namespace
+    # and everything inside it.
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     # Generates a RoleBinding giving oidc:k8s:group:appadmin the `edit`
     # ClusterRole here, via the generate-group-rolebindings GeneratingPolicy.

--- a/k8s/apps/mended-drum/namespace.yaml
+++ b/k8s/apps/mended-drum/namespace.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: mended-drum
+  annotations:
+    # Never garbage-collect this Namespace. Pruning is inventory-based, so
+    # dropping it from a Kustomization's inventory would delete the namespace
+    # and everything inside it.
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/k8s/apps/photos/namespace.yaml
+++ b/k8s/apps/photos/namespace.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: photos
+  annotations:
+    # Never garbage-collect this Namespace. Pruning is inventory-based, so
+    # dropping it from a Kustomization's inventory would delete the namespace
+    # and everything inside it.
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/k8s/apps/plex/namespace.yaml
+++ b/k8s/apps/plex/namespace.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: plex
+  annotations:
+    # Never garbage-collect this Namespace. Pruning is inventory-based, so
+    # dropping it from a Kustomization's inventory would delete the namespace
+    # and everything inside it.
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/k8s/apps/pocket-id/namespace.yaml
+++ b/k8s/apps/pocket-id/namespace.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: pocket-id
+  annotations:
+    # Never garbage-collect this Namespace. Pruning is inventory-based, so
+    # dropping it from a Kustomization's inventory would delete the namespace
+    # and everything inside it.
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/k8s/apps/stirling-pdf/namespace.yaml
+++ b/k8s/apps/stirling-pdf/namespace.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: stirling-pdf
+  annotations:
+    # Never garbage-collect this Namespace. Pruning is inventory-based, so
+    # dropping it from a Kustomization's inventory would delete the namespace
+    # and everything inside it.
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/k8s/apps/unifi/namespace.yaml
+++ b/k8s/apps/unifi/namespace.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: unifi
+  annotations:
+    # Never garbage-collect this Namespace. Pruning is inventory-based, so
+    # dropping it from a Kustomization's inventory would delete the namespace
+    # and everything inside it.
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/k8s/apps/ups/namespace.yaml
+++ b/k8s/apps/ups/namespace.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: ups
+  annotations:
+    # Never garbage-collect this Namespace. Pruning is inventory-based, so
+    # dropping it from a Kustomization's inventory would delete the namespace
+    # and everything inside it.
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/k8s/apps/valheim/namespace.yaml
+++ b/k8s/apps/valheim/namespace.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: valheim
+  annotations:
+    # Never garbage-collect this Namespace. Pruning is inventory-based, so
+    # dropping it from a Kustomization's inventory would delete the namespace
+    # and everything inside it.
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/k8s/apps/vod-arr/namespace.yaml
+++ b/k8s/apps/vod-arr/namespace.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: vod-arr
+  annotations:
+    # Never garbage-collect this Namespace. Pruning is inventory-based, so
+    # dropping it from a Kustomization's inventory would delete the namespace
+    # and everything inside it.
+    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
Prerequisite for #1450 (the hoist), split out because it must land in its own merge.

Adds `kustomize.toolkit.fluxcd.io/prune: disabled` to 19 app Namespace manifests. No structural change, no behaviour change.

**Why separate.** Flux pruning is inventory-based. The moment a Namespace leaves its Kustomization inventory, `prune: true` deletes it — and deleting a Namespace cascades to everything inside it. The annotation must be live on the object *before* the manifest moves, so the move meets a guard that is already there rather than one arriving in the same reconcile.

It then travels with the file into `k8s/namespaces/`; dropping it during the move would race the prune against its own removal.

Same shape as the `helm.sh/resource-policy: keep` recipe in the app-deployment skill, with the same corollary: `kubectl annotate` would not do, because kustomize-controller force-owns `metadata.annotations` and strips anything not in git on the next reconcile.

- [x] `make validate` — 130 targets clean
- [x] annotation renders on all 19

Refs #1436

🤖 Generated with [Claude Code](https://claude.com/claude-code)