### PR TITLE
alerts: bound a single webhook POST, and stop throttling github-receiver

### DIFF
--- a/k8s/apps/datalake-alerts/alertmanager/configmap-template.yaml
+++ b/k8s/apps/datalake-alerts/alertmanager/configmap-template.yaml
@@ -46,13 +46,31 @@ data:
           responders:
           - name: 'Main'
             type: team
+    # timeout bounds a single POST. Without it the only deadline is the
+    # notification pipeline's, which is max(group_interval, 10s) + 15s per peer
+    # position -- 2m to 2m30s on the Watchdog route below. One socket that hangs
+    # therefore eats the entire budget and RetryStage never gets a second
+    # attempt, which is how #1445 lost Watchdog pings: on the night of
+    # 2026-09-11 about one POST in five to hc-ping.com hung for the full ~110s
+    # while the ones between them completed in under a second.
+    #
+    # 10s leaves room for roughly six further attempts inside the same budget.
+    # Failure counters are not the cost of that: notifications_total and
+    # notifications_failed_total count *pipelines*, once each, and only
+    # notification_requests_total counts attempts -- so a retry that succeeds
+    # leaves AlertmanagerFailedToSendAlerts untouched.
     - name: 'healthchecks.io'
       webhook_configs:
         - send_resolved: false
+          timeout: 10s
           url: {{ .healthchecks_url }}  {{/* This is a reference to a secret stored in doppler */}}
+    # Same reasoning, with a larger value: this one waits on the GitHub API
+    # through github-receiver, which takes 1.5-4s in normal operation. Its route
+    # has the default 5m group_interval, so 30s still leaves ~10 attempts.
     - name: 'github'
       webhook_configs:
         - send_resolved: true
+          timeout: 30s
           url: "http://github-receiver:8080/v1/webhook?owner=thaum-xyz&repo=ankhmorpork"
     - name: "null"
     # Waking hours, local. Referenced by the opsgenie route below.

--- a/k8s/apps/datalake-alerts/github-receiver/deployment.yaml
+++ b/k8s/apps/datalake-alerts/github-receiver/deployment.yaml
@@ -57,8 +57,13 @@ spec:
             - containerPort: 8080
               name: http
           resources:
+            # No CPU limit. A limit is a CFS quota, so 10m meant 1ms of CPU per
+            # 100ms period and every burst -- a /metrics scrape, a webhook POST --
+            # ran out of it: 57% of periods were throttled while the container
+            # averaged 0.7m, a fourteenth of the limit it never got near. The
+            # request is what reserves capacity; the limit only chopped the
+            # bursts that matter and left a permanently firing CPUThrottlingHigh.
             limits:
-              cpu: 10m
               memory: 50Mi
             requests:
               cpu: 2m


### PR DESCRIPTION
Fixes #1445.

## What #1445 actually was

Not an alert-delivery failure. The webhook that timed out was the **healthchecks.io dead-man's-switch ping**, not the GitHub issue path — the alertmanager log names it, because the metric cannot:

```
err="healthchecks.io/webhook[0]: notify retry canceled after 1 attempts: context deadline exceeded"
```

`alertmanager_notifications_failed_total` is labelled `{integration, reason}` only, so both webhook receivers report as `integration="webhook"` and the filed issue can never say which one broke.

| | |
|---|---|
| Window | 22:06 → 01:09 UTC, 11→12 Sep, all three peers |
| Lost notifications | 10 pipelines, 18 failed attempts |
| Hang length | ~15 POSTs at ~110s each (latency `_sum` over the window: 693s across 38 attempts on main-0, against a 1.2s lifetime mean) |
| Interleaved pings | under 1s throughout |
| DMS gap | 7.5 min at worst, against a normal ~4 min — this did page |
| GitHub path | unaffected; #1445 itself was filed in 1.47s |

Cause is external: `hc-ping.com` resolves to four Hetzner A records and roughly one attempt in five hung, while DNS p99 sat flat at 40ms, WAN egress ran at 1–3 MB/s, no probe or node failure registered, and healthchecks.io reported no incident. Nothing in the cluster probes external egress, so this class of event is only ever visible second-hand.

## The change

The fixable half is that one hung socket could take the whole notification with it. The pipeline deadline is `max(group_interval, 10s) + peer_position × 15s` ([app.go](https://github.com/prometheus/alertmanager/blob/v0.34.0/app/app.go#L445)) — 2m–2m30s on the Watchdog route — and `webhook_configs` carries no per-attempt timeout by default, so `RetryStage` never got a second attempt.

- `timeout: 10s` on healthchecks.io — room for ~6 further attempts in the same budget.
- `timeout: 30s` on github — its route has the default 5m `group_interval` and its POSTs take 1.5–4s through the GitHub API, so ~10 attempts.

This makes the alert quieter, not noisier: `notifications_total` / `_failed_total` count **pipelines**, once each, and only `notification_requests_total` counts attempts ([retry_stage.go](https://github.com/prometheus/alertmanager/blob/v0.34.0/notify/retry_stage.go#L81)) — a retry that succeeds never touches the ratio.

Second, unrelated commit content: **github-receiver's `cpu: 10m` limit is gone.** A CPU limit is a CFS quota, so 10m meant 1ms per 100ms period and every burst — a `/metrics` scrape, a webhook POST — overran it. 57% of periods throttled against a 0.7m average. That is the `CPUThrottlingHigh` that has been firing continuously in `datalake-alerts`.

## Validation

```
make validate-alertmanager   # esoctl render + amtool check-config: SUCCESS, 4 receivers
./hack/validate-manifests.sh k8s/apps/datalake-alerts
```

`amtool` accepting the rendered config is the proof that `timeout` is a real field on v0.34.0 — the config parser rejects unknown keys.

## Rollout

`configmap-template.yaml` feeds the `alertmanager-main` Secret through ESO, so the Kustomization must reconcile before the Secret re-renders and alertmanager reloads. The Deployment change restarts github-receiver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)