### PR TITLE
resources: drop every CPU limit

### DIFF
--- a/k8s/apps/ai-gateway/db/values.yaml
+++ b/k8s/apps/ai-gateway/db/values.yaml
@@ -8,7 +8,6 @@ cluster:
     size: 2Gi
   resources:
     limits:
-      cpu: 500m
       memory: 512Mi
     requests:
       cpu: 100m

--- a/k8s/apps/atuin/postgres/values.yaml
+++ b/k8s/apps/atuin/postgres/values.yaml
@@ -14,7 +14,6 @@ cluster:
     size: 7Gi
   resources:
     limits:
-      cpu: 400m
       memory: 420Mi
     requests:
       cpu: 130m

--- a/k8s/apps/changedetection/playwright/deployment.yaml
+++ b/k8s/apps/changedetection/playwright/deployment.yaml
@@ -31,4 +31,3 @@ spec:
             memory: 64Mi
           limits:
             memory: "1000Mi"
-            cpu: "1"

--- a/k8s/apps/datalake-alerts/alertmanager/alertmanager.yaml
+++ b/k8s/apps/datalake-alerts/alertmanager/alertmanager.yaml
@@ -32,7 +32,6 @@ spec:
   replicas: 3
   resources:
     limits:
-      cpu: 100m
       memory: 100Mi
     requests:
       cpu: 3m

--- a/k8s/apps/datalake-metrics/prometheus/prometheus.yaml
+++ b/k8s/apps/datalake-metrics/prometheus/prometheus.yaml
@@ -55,7 +55,6 @@ spec:
   replicas: 2
   resources:
     limits:
-      cpu: 1500m
       memory: 4Gi
     requests:
       cpu: 500m

--- a/k8s/apps/grafana/grafana/values.yaml
+++ b/k8s/apps/grafana/grafana/values.yaml
@@ -51,7 +51,6 @@ resources:
     cpu: 80m
     memory: 512Mi
   limits:
-    cpu: 800m
     memory: 4096Mi
 
 service:
@@ -69,7 +68,6 @@ sidecar:
       cpu: 6m
       memory: 192Mi
     limits:
-      cpu: 50m
       memory: 384Mi
   alerts:
     enabled: false

--- a/k8s/apps/grafana/postgres/values.yaml
+++ b/k8s/apps/grafana/postgres/values.yaml
@@ -7,7 +7,6 @@ cluster:
     size: 15Gi
   resources:
     limits:
-      cpu: 400m
       memory: 420Mi
     requests:
       cpu: 130m

--- a/k8s/apps/homer/app/values.yaml
+++ b/k8s/apps/homer/app/values.yaml
@@ -5,6 +5,9 @@
 
 resources:
   limits:
+    # cpu: null, not an omitted key. Helm deep-merges, so dropping the line
+    # leaves the chart's own 200m limit in place.
+    cpu: null
     memory: 256Mi
   requests:
     cpu: 10m

--- a/k8s/apps/homer/services/dashboard.yaml
+++ b/k8s/apps/homer/services/dashboard.yaml
@@ -11,6 +11,15 @@ metadata:
   namespace: homer
 spec:
   replicas: 2
+  # Spelled out only to drop the CPU limit from the operator's defaults, which
+  # are otherwise what these values are. The config-sync sidecar keeps its 50m:
+  # the CRD exposes resources for the Homer container alone.
+  resources:
+    limits:
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 32Mi
   ingressSelector:
     matchLabels:
       homer.rajsingh.info/enabled: "true"

--- a/k8s/apps/mealie/app/deployment.yaml
+++ b/k8s/apps/mealie/app/deployment.yaml
@@ -92,7 +92,6 @@ spec:
           name: http
         resources:
           limits:
-            cpu: 1
             memory: 512Mi
           requests:
             cpu: 100m

--- a/k8s/apps/mealie/db/values.yaml
+++ b/k8s/apps/mealie/db/values.yaml
@@ -7,7 +7,6 @@ cluster:
     size: 2Gi
   resources:
     limits:
-      cpu: 400m
       memory: 420Mi
     requests:
       cpu: 130m

--- a/k8s/apps/mended-drum/db/values.yaml
+++ b/k8s/apps/mended-drum/db/values.yaml
@@ -8,7 +8,6 @@ cluster:
     size: 1Gi
   resources:
     limits:
-      cpu: 400m
       memory: 420Mi
     requests:
       cpu: 100m

--- a/k8s/apps/paperless/manifests/app/statefulSet.yaml
+++ b/k8s/apps/paperless/manifests/app/statefulSet.yaml
@@ -53,9 +53,6 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 5
           resources:
-            limits:
-              cpu: 3
-            #  memory: 4Gi
             requests:
               cpu: 1
               memory: 2Gi

--- a/k8s/apps/paperless/manifests/broker/statefulSet.yaml
+++ b/k8s/apps/paperless/manifests/broker/statefulSet.yaml
@@ -31,7 +31,6 @@ spec:
               name: redis
           resources:
             limits:
-              cpu: 20m
               memory: 30Mi
             requests:
               cpu: 4m

--- a/k8s/apps/paperless/manifests/postgres/values.yaml
+++ b/k8s/apps/paperless/manifests/postgres/values.yaml
@@ -6,10 +6,7 @@ cluster:
   primaryUpdateMethod: switchover
   storage:
     size: 30Gi
-  # A cpu limit and no memory limit, matching the live spec.
   resources:
-    limits:
-      cpu: 200m
     requests:
       cpu: 100m
       memory: 400Mi

--- a/k8s/apps/plex/app/statefulset.yaml
+++ b/k8s/apps/plex/app/statefulset.yaml
@@ -82,7 +82,6 @@ spec:
             timeoutSeconds: 5
           resources:
             limits:
-              cpu: "4"
               gpu.intel.com/i915: "1"
               memory: 8Gi
             requests:

--- a/k8s/apps/pocket-id/postgres/values.yaml
+++ b/k8s/apps/pocket-id/postgres/values.yaml
@@ -11,7 +11,6 @@ cluster:
     size: 9Gi
   resources:
     limits:
-      cpu: 400m
       memory: 420Mi
     requests:
       cpu: 130m

--- a/k8s/apps/stirling-pdf/values.yaml
+++ b/k8s/apps/stirling-pdf/values.yaml
@@ -124,7 +124,6 @@ deployment:
           cpu: 10m
           memory: 32Mi
         limits:
-          cpu: 200m
           memory: 128Mi
 
 # The chart defaults to initialDelaySeconds 5 with failureThreshold 3 on a

--- a/k8s/apps/unifi/deployment.yaml
+++ b/k8s/apps/unifi/deployment.yaml
@@ -33,7 +33,6 @@ spec:
               protocol: TCP
           resources:
             limits:
-              cpu: 100m
               # Raised from 100Mi: from v3.2.0 unpoller refreshes in the
               # background every 60s and holds the result, rather than hitting
               # the controller per scrape, so it now keeps a copy of the whole

--- a/k8s/apps/ups/deployment.yaml
+++ b/k8s/apps/ups/deployment.yaml
@@ -33,7 +33,6 @@ spec:
               port: metrics
           resources:
             limits:
-              cpu: 200m
               memory: 128Mi
             requests:
               cpu: 10m

--- a/k8s/apps/valheim/server/statefulset.yaml
+++ b/k8s/apps/valheim/server/statefulset.yaml
@@ -55,7 +55,6 @@ spec:
           protocol: UDP
         resources:
           limits:
-            cpu: 2
             memory: 8Gi
           requests:
             cpu: 200m
@@ -80,7 +79,6 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 250m
             memory: 80Mi
           requests:
             cpu: 2m

--- a/k8s/apps/vod-arr/bazarr/deployment.yaml
+++ b/k8s/apps/vod-arr/bazarr/deployment.yaml
@@ -67,7 +67,6 @@ spec:
             timeoutSeconds: 10
           resources:
             limits:
-              cpu: 500m
               memory: 700Mi
             requests:
               cpu: 50m

--- a/k8s/apps/vod-arr/cleanuparr/deployment.yaml
+++ b/k8s/apps/vod-arr/cleanuparr/deployment.yaml
@@ -59,7 +59,6 @@ spec:
             timeoutSeconds: 10
           resources:
             limits:
-              cpu: 500m
               memory: 512Mi
             requests:
               cpu: 20m

--- a/k8s/apps/vod-arr/flaresolverr/deployment.yaml
+++ b/k8s/apps/vod-arr/flaresolverr/deployment.yaml
@@ -45,7 +45,6 @@ spec:
           # solver leaks browser processes until something reaps it.
           resources:
             limits:
-              cpu: "1"
               memory: 1Gi
             requests:
               cpu: 50m

--- a/k8s/apps/vod-arr/prowlarr/statefulset.yaml
+++ b/k8s/apps/vod-arr/prowlarr/statefulset.yaml
@@ -43,7 +43,6 @@ spec:
             timeoutSeconds: 10
           resources:
             limits:
-              cpu: 400m
               memory: 300Mi
             requests:
               cpu: 160m
@@ -88,7 +87,6 @@ spec:
             periodSeconds: 10
           resources:
             limits:
-              cpu: 50m
               memory: 100Mi
             requests:
               cpu: 1m
@@ -189,7 +187,6 @@ spec:
           name: render-config
           resources:
             limits:
-              cpu: 100m
               memory: 64Mi
             requests:
               cpu: 10m

--- a/k8s/apps/vod-arr/qbittorrent/deployment.yaml
+++ b/k8s/apps/vod-arr/qbittorrent/deployment.yaml
@@ -87,7 +87,6 @@ spec:
             timeoutSeconds: 10
           resources:
             limits:
-              cpu: "2"
               memory: 2Gi
             requests:
               cpu: 100m
@@ -119,7 +118,6 @@ spec:
               name: metrics
           resources:
             limits:
-              cpu: 50m
               memory: 128Mi
             requests:
               cpu: 1m
@@ -197,7 +195,6 @@ spec:
           name: seed-config
           resources:
             limits:
-              cpu: 50m
               memory: 32Mi
             requests:
               cpu: 10m

--- a/k8s/apps/vod-arr/radarr/statefulset.yaml
+++ b/k8s/apps/vod-arr/radarr/statefulset.yaml
@@ -43,7 +43,6 @@ spec:
             timeoutSeconds: 10
           resources:
             limits:
-              cpu: 400m
               memory: 600Mi
             requests:
               cpu: 180m
@@ -94,7 +93,6 @@ spec:
             periodSeconds: 10
           resources:
             limits:
-              cpu: 50m
               memory: 100Mi
             requests:
               cpu: 1m
@@ -186,7 +184,6 @@ spec:
           name: render-config
           resources:
             limits:
-              cpu: 100m
               memory: 64Mi
             requests:
               cpu: 10m

--- a/k8s/apps/vod-arr/recyclarr/cronjob.yaml
+++ b/k8s/apps/vod-arr/recyclarr/cronjob.yaml
@@ -55,7 +55,6 @@ spec:
               name: recyclarr
               resources:
                 limits:
-                  cpu: 500m
                   memory: 300Mi
                 requests:
                   cpu: 10m

--- a/k8s/apps/vod-arr/seerr/deployment.yaml
+++ b/k8s/apps/vod-arr/seerr/deployment.yaml
@@ -76,7 +76,6 @@ spec:
             timeoutSeconds: 10
           resources:
             limits:
-              cpu: "1"
               memory: 1Gi
             requests:
               cpu: 50m
@@ -125,7 +124,6 @@ spec:
           name: seed-settings
           resources:
             limits:
-              cpu: 50m
               memory: 32Mi
             requests:
               cpu: 10m

--- a/k8s/apps/vod-arr/sonarr/statefulset.yaml
+++ b/k8s/apps/vod-arr/sonarr/statefulset.yaml
@@ -43,7 +43,6 @@ spec:
             timeoutSeconds: 10
           resources:
             limits:
-              cpu: 750m
               memory: 700Mi
             requests:
               cpu: 200m
@@ -94,7 +93,6 @@ spec:
             periodSeconds: 10
           resources:
             limits:
-              cpu: 50m
               memory: 100Mi
             requests:
               cpu: 1m
@@ -186,7 +184,6 @@ spec:
           name: render-config
           resources:
             limits:
-              cpu: 100m
               memory: 64Mi
             requests:
               cpu: 10m

--- a/k8s/platform/cluster/descheduler/values.yaml
+++ b/k8s/platform/cluster/descheduler/values.yaml
@@ -8,6 +8,9 @@ resources:
     cpu: 10m
     memory: 64Mi
   limits:
+    # cpu: null, not an omitted key. Helm deep-merges, so dropping the line
+    # leaves the chart's own 500m limit in place.
+    cpu: null
     memory: 256Mi
 
 service:

--- a/k8s/platform/cluster/node-problem-detector/values.yaml
+++ b/k8s/platform/cluster/node-problem-detector/values.yaml
@@ -41,7 +41,6 @@ metrics:
 
 resources:
   limits:
-    cpu: 20m
     memory: 60Mi
   requests:
     cpu: 3m

--- a/k8s/platform/cluster/system-kured/values.yaml
+++ b/k8s/platform/cluster/system-kured/values.yaml
@@ -86,7 +86,6 @@ configuration:
 
 resources:
   limits:
-    cpu: 10m
     memory: 128Mi
   requests:
     cpu: 3m

--- a/k8s/platform/network/cilium/values.yaml
+++ b/k8s/platform/network/cilium/values.yaml
@@ -53,6 +53,12 @@ cluster:
   name: ankhmorpork
 cni:
   uninstall: false
+  resources:
+    limits:
+      # The install-cni-binaries initContainer, the one container in this chart
+      # that ships a limit. cpu: null, not an omitted key -- Helm deep-merges,
+      # so dropping the line leaves the chart's own 1 core in place.
+      cpu: null
 ipam:
   mode: cluster-pool
   operator:

--- a/k8s/platform/network/cloudflared/values.yaml
+++ b/k8s/platform/network/cloudflared/values.yaml
@@ -6,6 +6,13 @@ cloudflare:
 #  accountId: "<cloudflare-account-id>"
   tunnelName: "ankhmorpork-tunnel"
 
+# The controller's own resources, as opposed to the connector's below. cpu:
+# null, not an omitted key: Helm deep-merges, so dropping the line leaves the
+# chart's own 100m limit in place.
+resources:
+  limits:
+    cpu: null
+
 ingressClass:
   name: cloudflare
 

--- a/k8s/platform/network/traefik/values-common.yaml
+++ b/k8s/platform/network/traefik/values-common.yaml
@@ -31,7 +31,6 @@ resources:
     cpu: "100m"
     memory: "50Mi"
   limits:
-    cpu: "300m"
     memory: "150Mi"
 
 affinity:

--- a/k8s/platform/observability/blackbox-exporter/exporter/deployment.yaml
+++ b/k8s/platform/observability/blackbox-exporter/exporter/deployment.yaml
@@ -48,7 +48,6 @@ spec:
               name: http
           resources:
             limits:
-              cpu: 200m
               memory: 42Mi
             requests:
               cpu: 30m
@@ -73,7 +72,6 @@ spec:
           name: module-configmap-reloader
           resources:
             limits:
-              cpu: 200m
               memory: 42Mi
             requests:
               cpu: 30m
@@ -104,7 +102,6 @@ spec:
               name: https
           resources:
             limits:
-              cpu: 200m
               memory: 42Mi
             requests:
               cpu: 30m

--- a/k8s/platform/observability/kube-prometheus-stack/values.yaml
+++ b/k8s/platform/observability/kube-prometheus-stack/values.yaml
@@ -370,7 +370,6 @@ kube-state-metrics:
       cpu: 2m
       memory: 34Mi
     limits:
-      cpu: 200m
       memory: 180Mi
 
 prometheus-node-exporter:
@@ -398,5 +397,4 @@ prometheus-node-exporter:
       cpu: 2m
       memory: 20Mi
     limits:
-      cpu: 150m
       memory: 180Mi

--- a/k8s/platform/observability/uptimerobot/deployment.yaml
+++ b/k8s/platform/observability/uptimerobot/deployment.yaml
@@ -38,7 +38,6 @@ spec:
             timeoutSeconds: 10
           resources:
             limits:
-              cpu: 20m
               memory: 50Mi
             requests:
               cpu: 5m

--- a/k8s/platform/security/cert-manager/controllers/values.yaml
+++ b/k8s/platform/security/cert-manager/controllers/values.yaml
@@ -13,7 +13,6 @@ prometheus:
 
 resources:
   limits:
-    cpu: 50m
     memory: 150Mi
   requests:
     cpu: 3m
@@ -35,7 +34,6 @@ affinity:
 webhook:
   resources:
     limits:
-      cpu: 10m
       memory: 64Mi
     requests:
       cpu: 3m
@@ -56,7 +54,6 @@ webhook:
 cainjector:
   resources:
     limits:
-      cpu: 15m
       memory: 550Mi
     requests:
       cpu: 5m

--- a/k8s/platform/security/external-secrets/controllers/values.yaml
+++ b/k8s/platform/security/external-secrets/controllers/values.yaml
@@ -23,5 +23,4 @@ resources:
     cpu: 9m
     memory: 49Mi
   limits:
-    cpu: 20m
     memory: 80Mi

--- a/k8s/platform/security/kyverno/controllers/values.yaml
+++ b/k8s/platform/security/kyverno/controllers/values.yaml
@@ -14,6 +14,29 @@ features:
   backgroundScan:
     enabled: false
 
+# The CRD migration Job, which runs on every chart upgrade. cpu: null, not an
+# omitted key -- Helm deep-merges, so dropping the line leaves the chart's own
+# 100m in place. The controllers below clear the whole limits map instead; these
+# keep the chart's memory limit, which a Job -- the one thing here that runs
+# unattended -- is worth having.
+crds:
+  migration:
+    podResources:
+      limits:
+        cpu: null
+
+# The pre-delete hooks that tear the webhooks down on uninstall, and the
+# helm-test Pods. Neither runs in normal operation; they are here so that
+# "does anything still carry a CPU limit?" has one answer.
+webhooksCleanup:
+  resources:
+    limits:
+      cpu: null
+test:
+  resources:
+    limits:
+      cpu: null
+
 admissionController:
   # Admission is on the API write path, so keep one replica on each of the
   # cluster's three control-plane nodes.

--- a/k8s/platform/storage/smartctl-exporter/values.yaml
+++ b/k8s/platform/storage/smartctl-exporter/values.yaml
@@ -5,7 +5,6 @@ resources: &smartctlResources
     cpu: 5m
     memory: 24Mi
   limits:
-    cpu: 100m
     memory: 64Mi
 
 tolerations: &smartctlTolerations


### PR DESCRIPTION
Follow-up to #1451, which removed github-receiver's. This removes the rest.

## Why

A CPU limit is a CFS quota, so it chops bursts rather than capping average use. github-receiver was the worked example: `10m` meant 1ms of CPU per 100ms period, and 57% of its periods were throttled while it averaged 0.7m — a fourteenth of a limit it never came near.

The large limits were not protecting the nodes either. master01 already sits at **185% of allocatable in limits against 66% in requests**, so the aggregate was overcommitted long before any single container reached its ceiling. Requests are what reserve capacity and set the CFS share; the limit only made each container slower on the way there.

## What changed

- **53 `limits` blocks lose their `cpu` key.** Memory limits and every request are untouched.
- **Two blocks held nothing else and go entirely** — paperless's app and its postgres.
- **plex keeps `gpu.intel.com/i915`** in `limits`, where an extended resource has to live.

**Five charts needed more than a deletion.** Helm deep-merges, so an omitted key leaves the chart's own default standing rather than clearing it. These get an explicit `cpu: null`:

| Chart | Default that would have survived |
|---|---|
| cilium | `install-cni-binaries` initContainer, 1 core |
| descheduler | 500m |
| homer-operator | 200m |
| cloudflared (controller) | 100m |
| kyverno (CRD migration Job) | 100m |

kyverno's uninstall hooks and helm-test Pods get the same treatment, so "does anything still carry a CPU limit?" has one answer. The homer `Dashboard` CR grows a `resources` block for the same reason — the operator's defaults carried 100m, and the CR is the only way to reach it.

## Verification

Rendered, not read off the values files — the deep-merge trap makes the values file a bad witness:

```
# all 52 Flux Kustomization paths
flux-build --include-helm-hooks --api-versions monitoring.coreos.com/v1 <path>
# plus helm template for cloudflared and pocket-id, whose values come from a runtime Secret
```

**Zero containers carry a CPU limit afterwards**, and every memory limit and request renders exactly where it was. `make validate` (131 targets), `validate-flux`, `validate-configmaps`, `validate-alertmanager` and `docs-reference-check` all pass.

## Two things this does not reach

- **homer's `config-sync` sidecar keeps its 50m.** The Dashboard CRD exposes `resources` for the Homer container alone.
- **cloudflared's controller drops Guaranteed → Burstable** — the only QoS class change in the cluster, because its chart set requests equal to limits. Its memory request still equals its memory limit, so its OOM ranking barely moves, but it is now evicted ahead of a Guaranteed pod under node memory pressure. There are no other Guaranteed pods.

## Rollout

Every HelmRelease whose `values.yaml` changed needs the Kustomization reconciled *before* the release, or helm-controller upgrades against the old ConfigMap. The plain-manifest changes roll out with their Kustomization.

Expect a rolling restart of most of the cluster as the Pod specs change.

## Worth considering separately

Nothing stops a CPU limit coming back with the next chart bump or new app. A warn-only `ValidatingPolicy` alongside `require-resource-requests` would catch it at admission — happy to add it if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)