### PR TITLE
external-secrets: keep CRDs on uninstall, read the token from its copy

### DIFF
--- a/k8s/platform/security/external-secrets/additional/clusterSecretStoreDoppler.yaml
+++ b/k8s/platform/security/external-secrets/additional/clusterSecretStoreDoppler.yaml
@@ -1,3 +1,13 @@
+# The root of the whole secret chain: every ExternalSecret in the cluster
+# resolves through this store, and it is the one credential that cannot itself
+# come from the chain.
+#
+# `doppler-token` is NOT in git -- it was hand-created in 2023 and is owned by
+# no release and no Kustomization, so nothing here would recreate it. It has
+# been copied into platform-security and digest-verified; this points at the
+# copy. The namespace is explicit and cluster-scoped, so it does not have to
+# match wherever the operator itself happens to run -- which is what lets this
+# move ahead of the operator's own migration and be verified on its own.
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
@@ -8,6 +18,6 @@ spec:
       auth:
         secretRef:
           dopplerToken:
-            namespace: external-secrets
+            namespace: platform-security
             name: doppler-token
             key: token

--- a/k8s/platform/security/external-secrets/controllers/values.yaml
+++ b/k8s/platform/security/external-secrets/controllers/values.yaml
@@ -1,5 +1,23 @@
 # Config reference: https://github.com/external-secrets/external-secrets/blob/main/deploy/charts/external-secrets/values.yaml
 
+# This chart ships its CRDs as ordinary templates -- there is no chart-root
+# crds/ directory -- so `helm uninstall` DELETES them, and deleting a CRD
+# deletes every custom resource of that kind. Every ExternalSecret here runs
+# creationPolicy: Owner, so the generated Secret carries an ownerReference back
+# to it: the CRD going away garbage-collects all 74 of them, which is every
+# Postgres credential in the cluster and cert-manager's DNS token with them.
+#
+# `keep` makes Helm leave the CRDs alone on uninstall. It has to reach them
+# through the chart -- annotating the live objects with `kubectl annotate` does
+# not survive the next apply.
+#
+# This is a guard, not a preference. Do not drop it because a release looks
+# stable; the cost only shows up during an uninstall, which is exactly when
+# nobody wants to discover it.
+crds:
+  annotations:
+    helm.sh/resource-policy: keep
+
 serviceMonitor:
   enabled: true
   honorLabels: true


### PR DESCRIPTION
Groundwork for moving external-secrets into `platform-security`. **Merge and
confirm this before the move**, not alongside it.

## The trap this closes

The external-secrets chart ships its CRDs as ordinary templates — there is no
chart-root `crds/` directory — so they carry Helm ownership metadata and
`helm uninstall` **deletes them**:

```
externalsecrets.external-secrets.io      release=external-secrets  keep=<empty>
clustersecretstores.external-secrets.io  release=external-secrets  keep=<empty>
secretstores.external-secrets.io         release=external-secrets  keep=<empty>
```

Deleting a CRD deletes every custom resource of that kind. All 74 ExternalSecrets
in this cluster run `creationPolicy: Owner`, and all 74 generated Secrets carry
an `ownerReference` back to their ExternalSecret — verified, not assumed. So the
uninstall-then-reinstall recipe that moved the six components in #1459 and
cert-manager in #1460 would here have garbage-collected **every ESO-managed
Secret in the cluster**: every Postgres credential, cert-manager's Cloudflare
token, cloudflared's tunnel credentials.

`crds.annotations` puts `helm.sh/resource-policy: keep` on all 25 CRDs through
the chart. Confirmed by rendering `helm template` at the pinned version: 25/25.
The chart's own knob is used rather than a `postRenderers` patch because the
chart has one, because values stay where Renovate's `helm-values` manager can
read them, and because a patch over 25 objects is more machinery for the same
result.

## The token move, landed separately on purpose

`doppler-auth-api` now reads `doppler-token` from `platform-security`.

That Secret is **not in git** — hand-created in 2023, owned by no Helm release
and no Kustomization, so nothing in this repo would recreate it. It has been
copied to `platform-security` and verified identical by SHA-256 of the token
material.

A ClusterSecretStore's `secretRef` carries an explicit namespace and the store is
cluster-scoped, so it does not have to match wherever the operator runs. That is
what lets this land ahead of the operator's own migration — if something is wrong
with the copy, it shows up here, on a one-line change, instead of inside a
namespace cutover where it would be one of several suspects.

## How to confirm before the move

Both changes are silent if they go inert — a values key at a path the chart no
longer reads produces no warning. So check the live objects, not the diff:

```bash
# all 25 CRDs must report "keep"
kubectl get crd -o json | jq -r '.items[]
  | select(.metadata.annotations["meta.helm.sh/release-name"]=="external-secrets")
  | "\(.metadata.annotations["helm.sh/resource-policy"] // "MISSING")  \(.metadata.name)"'

# the store must still be Ready, and all 74 ExternalSecrets still SecretSynced
kubectl get clustersecretstore doppler-auth-api
kubectl get externalsecrets -A --no-headers | awk '{print $4}' | sort | uniq -c
```

Existing Secrets persist even if the store fails — ESO does not delete on a sync
error — so a failure here degrades refresh, it does not break serving.

## Note

`make validate-platform-namespaces` still reports external-secrets as off-target;
that is this PR's whole point being deferred to the next one. The check is a
Makefile target and deliberately not in CI yet — it cannot pass until the last
component moves. Wiring it into `.github/workflows/validate.yml` is the final
step of the migration, otherwise the guard never guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
