### PR TITLE
ci: run the Alertmanager config check only when that config changes

### DIFF
--- a/.github/workflows/alertmanager.yml
+++ b/.github/workflows/alertmanager.yml
@@ -1,0 +1,63 @@
+---
+name: alertmanager
+
+# Split out of validate.yml purely so it can carry a paths filter: the job needs
+# a Go toolchain, a source build of esoctl and a version-matched amtool, which is
+# several minutes of setup on every PR that touches anything in the repo. A
+# `paths:` filter applies to a whole workflow, never to one job, so the job has
+# to live in its own file to get one.
+on:
+  workflow_dispatch:
+  # Actions' parser rejects YAML anchors, so the two lists are duplicated by
+  # hand. hack/validate-alertmanager-config.sh reads alertmanager.yaml,
+  # configmap-template.yaml and externalsecret.yaml from that one directory and
+  # runs no kustomize, so nothing above it can change the rendered config.
+  push:
+    branches: [master]
+    paths:
+      - 'k8s/apps/datalake-alerts/alertmanager/**'
+      - 'hack/validate-alertmanager-config.sh'
+      - '.github/workflows/alertmanager.yml'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'k8s/apps/datalake-alerts/alertmanager/**'
+      - 'hack/validate-alertmanager-config.sh'
+      - '.github/workflows/alertmanager.yml'
+
+env:
+  golang-version: 1.27.1
+  yq-version: v4.53.6
+  esoctl-version: v2.10.0
+
+permissions:
+  contents: read
+
+jobs:
+  # The Alertmanager config reaches the cluster as a Go template inside a
+  # ConfigMap, so the manifest jobs in validate.yml only ever see an opaque
+  # string. This renders it with ESO's own engine and checks the result.
+  config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version: '${{ env.golang-version }}'
+      - run: go install github.com/mikefarah/yq/v4@${{ env.yq-version }}
+      # Built from source, not `go install`: esoctl deliberately has no go.mod of
+      # its own so it can move with ESO, and the parent module carries replace
+      # directives, which `go install pkg@version` refuses. There are no
+      # published esoctl binaries either.
+      - name: Build esoctl ${{ env.esoctl-version }}
+        run: |
+          git clone --quiet --depth 1 --branch "${{ env.esoctl-version }}" \
+            https://github.com/external-secrets/external-secrets "$RUNNER_TEMP/eso"
+          mkdir -p "$HOME/.local/bin"
+          cd "$RUNNER_TEMP/eso" && go build -o "$HOME/.local/bin/esoctl" ./cmd/esoctl
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      # amtool's config schema is version-specific, so take the version from the
+      # Alertmanager CR rather than a second pin that could drift from it.
+      - run: |
+          go install "github.com/prometheus/alertmanager/cmd/amtool@$(yq -r '.spec.version' k8s/apps/datalake-alerts/alertmanager/alertmanager.yaml)"
+      - run: ./hack/validate-alertmanager-config.sh

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,7 +14,6 @@ env:
   kustomize-version: v5.8.1
   yq-version: v4.53.6
   shellcheck-version: v0.11.0
-  esoctl-version: v2.10.0
 
 jobs:
   manifests:
@@ -55,34 +54,6 @@ jobs:
           # latest release, which would fail unrelated PRs on scripts nobody
           # touched. Renovate keeps this in step with koalaman/shellcheck.
           version: ${{ env.shellcheck-version }}
-
-  # The Alertmanager config reaches the cluster as a Go template inside a
-  # ConfigMap, so the manifests jobs above only ever see an opaque string. This
-  # renders it with ESO's own engine and checks the result.
-  alertmanager-config:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: actions/setup-go@v7
-        with:
-          go-version: '${{ env.golang-version }}'
-      - run: go install github.com/mikefarah/yq/v4@${{ env.yq-version }}
-      # Built from source, not `go install`: esoctl deliberately has no go.mod of
-      # its own so it can move with ESO, and the parent module carries replace
-      # directives, which `go install pkg@version` refuses. There are no
-      # published esoctl binaries either.
-      - name: Build esoctl ${{ env.esoctl-version }}
-        run: |
-          git clone --quiet --depth 1 --branch "${{ env.esoctl-version }}" \
-            https://github.com/external-secrets/external-secrets "$RUNNER_TEMP/eso"
-          mkdir -p "$HOME/.local/bin"
-          cd "$RUNNER_TEMP/eso" && go build -o "$HOME/.local/bin/esoctl" ./cmd/esoctl
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-      # amtool's config schema is version-specific, so take the version from the
-      # Alertmanager CR rather than a second pin that could drift from it.
-      - run: |
-          go install "github.com/prometheus/alertmanager/cmd/amtool@$(yq -r '.spec.version' k8s/apps/datalake-alerts/alertmanager/alertmanager.yaml)"
-      - run: ./hack/validate-alertmanager-config.sh
 
   # docs/reference/{apps,admission-policies,flux-kustomizations,helm-releases}.md
   # are generated from k8s/**. The docs workflow only runs when docs/** changes,


### PR DESCRIPTION
The `alertmanager-config` job in `validate.yml` ran on every pull request, paying for a Go toolchain, a source build of esoctl and a version-matched amtool regardless of what the pull request touched.

`paths:` filters a whole workflow and has no per-job equivalent, so the job moves into its own `alertmanager.yml` to get one. It now runs only for:

- `k8s/apps/datalake-alerts/alertmanager/**`
- `hack/validate-alertmanager-config.sh`
- `.github/workflows/alertmanager.yml`

### Notes

**Why a separate file, not an `if:`.** The alternative — a `dorny/paths-filter` gate job feeding `if: needs.changes.outputs.am == 'true'` — keeps one file but spins up a runner on every pull request just to compute the answer, and adds a third-party action. Nothing depends on the check name, so the split is cheaper.

**No required check is stranded.** `master` has neither branch protection nor a ruleset, so a workflow that does not run cannot leave a pull request waiting. Worth knowing if protection is ever added: a workflow skipped by `paths:` reports nothing at all, unlike a job skipped by `if:`, which reports "skipped" and counts as passing. `alertmanager / config` should not be listed as required.

**The filter is narrower than the app directory.** `hack/validate-alertmanager-config.sh` reads `alertmanager.yaml`, `configmap-template.yaml` and `externalsecret.yaml` from the `alertmanager/` subdirectory and shells out to no kustomize, so neither `github-receiver/` nor the parent `kustomization.yaml` can change what it validates.

**Renovate is unaffected.** Its customManagers glob `.github/workflows/*.yml`, so `golang-version`, `yq-version` and `esoctl-version` keep being bumped in the new file with no `renovate.json` change. `esoctl-version` leaves `validate.yml`, where nothing used it any more.

**The two `paths:` lists are duplicated by hand.** They were an anchor and alias first; Actions' workflow parser rejects YAML anchors. There is a comment saying so.

`make validate-alertmanager` and the reference to it in `docs/how-to/silence-alerts-for-maintenance.md` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)