### PR TITLE
topolvm: keep the LogicalVolume CRD on uninstall

### DIFF
--- a/k8s/platform/storage/topolvm-system/topolvm/values.yaml
+++ b/k8s/platform/storage/topolvm-system/topolvm/values.yaml
@@ -1,5 +1,27 @@
 # Config reference: https://github.com/topolvm/topolvm/blob/main/charts/topolvm/values.yaml
 
+# The chart ships logicalvolumes.topolvm.io as a template, not from a chart-root
+# crds/ directory, so `helm uninstall` deletes it -- and deleting a CRD deletes
+# every custom resource of that kind.
+#
+# There are 34 LogicalVolumes here and they are not bookkeeping: each one is an
+# actual LVM logical volume backing an lvm-thin PV. Between them they hold every
+# Postgres cluster in the fleet and both Prometheus replicas. Each carries a
+# topolvm.io/logicalvolume finalizer that only the controller being uninstalled
+# can clear, so the CRD going away either wedges them all in Terminating or, if
+# the controller drains the queue first, removes the underlying volumes. Unlike
+# secrets, none of that can be re-synced from anywhere -- it is restore-from-
+# backup territory.
+#
+# `keep` makes Helm leave the CRD alone on uninstall. The chart documents this
+# exact annotation as the reason crd.annotations exists.
+#
+# This is a guard, not a preference. Its cost only shows up during an uninstall,
+# which is precisely when it is too late to add.
+crd:
+  annotations:
+    helm.sh/resource-policy: keep
+
 scheduler:
   enabled: false
 


### PR DESCRIPTION
Groundwork for moving topolvm-system into `platform-storage`. **Merge and confirm
this before the move**, not with it.

## The trap

`logicalvolumes.topolvm.io` is a chart *template*, not a chart-root `crds/`
entry, so it carries Helm ownership metadata and `helm uninstall` deletes it —
and deleting a CRD deletes every custom resource of that kind.

```
logicalvolumes.topolvm.io  release=topolvm  ns=topolvm-system  keep=<empty>
```

The 34 LogicalVolumes are not bookkeeping. Each is an actual LVM logical volume
backing an `lvm-thin` PV:

| What | Volumes |
|---|---|
| Postgres clusters | photos, paperless, grafana, atuin, mealie, pocket-id, ai-gateway, mended-drum, and all five vod-arr databases |
| Prometheus | both replicas, 100Gi each |
| plex | 96Gi transcode |

Every one carries a `topolvm.io/logicalvolume` finalizer that only the controller
being uninstalled can clear. So removing the CRD either wedges all 34 in
`Terminating`, or — if the controller drains its queue first — removes the
underlying volumes.

This is worse than the external-secrets case in #1461. There, the lost Secrets
could be re-synced from Doppler. Here nothing re-syncs; it is
restore-from-backup for every database in the fleet.

`crd.annotations` puts `helm.sh/resource-policy: keep` on the CRD through the
chart. The chart's own values documentation gives this annotation as the example
for why that knob exists. Verified by rendering at the pinned version: 1/1.

## Also found, and handled in the move PR rather than here

`k8s/flux/platform/topolvm.yaml` sets **`prune: false`**, the same as traefik in
#1463. There, the old HelmRelease survived the move, helm-controller reinstalled
it, and deleting it afterwards took shared cluster-scoped objects with it. For
topolvm the shared objects are `StorageClass/lvm-thin` and `CSIDriver/topolvm.io`,
so the ordering has to be: delete the old HelmRelease CR **before** the new one
installs. That belongs with the move, not with this guard.

## How to confirm before the move

The annotation is silent if it goes inert, so check the live object rather than
the diff:

```bash
kubectl get crd logicalvolumes.topolvm.io \
  -o jsonpath='{.metadata.annotations.helm\.sh/resource-policy}{"\n"}'   # keep

kubectl get logicalvolumes --no-headers | wc -l                          # 34
```

Nothing about cluster behaviour changes here — this only adds an annotation.

## Verification

`make validate` (131 targets) and `make validate-configmaps` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
