### PR TITLE
cnpg-versity-gw: stand up a second backup gateway in platform-storage

### DIFF
--- a/docs/reference/flux-kustomizations.md
+++ b/docs/reference/flux-kustomizations.md
@@ -32,7 +32,7 @@ see [how Flux is layered](../explanation/flux-layering.md).
 | `cilium` | [`k8s/platform/network/cilium`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/network/cilium) | `15m0s` | **no** | no | — |
 | `cloudflared` | [`k8s/platform/network/cloudflared`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/network/cloudflared) | `15m0s` | yes | no | — |
 | `cnpg-system` | [`k8s/platform/storage/cnpg-system`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/storage/cnpg-system) | `15m0s` | yes | no | `kyverno` |
-| `cnpg-versity-gw` | [`k8s/platform/storage/cnpg-versity-gw`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/storage/cnpg-versity-gw) | `15m0s` | yes | **yes** (10m) | `kyverno` |
+| `cnpg-versity-gw` | [`k8s/platform/storage/cnpg-versity-gw`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/storage/cnpg-versity-gw) | `15m0s` | yes | **yes** (10m) | `csi-nfs` |
 | `csi-nfs` | [`k8s/platform/storage/csi-nfs`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/storage/csi-nfs) | `15m0s` | yes | no | `kyverno` |
 | `descheduler` | [`k8s/platform/cluster/descheduler`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/cluster/descheduler) | `15m0s` | yes | no | — |
 | `device-plugins` | [`k8s/platform/cluster/device-plugins`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/cluster/device-plugins) | `15m0s` | yes | no | — |

--- a/docs/reference/flux-kustomizations.md
+++ b/docs/reference/flux-kustomizations.md
@@ -9,8 +9,8 @@ see [how Flux is layered](../explanation/flux-layering.md).
 | | |
 | --- | --- |
 | **`prune: false`** | `prometheus-operator-crds`, `apps`, `platform`, `namespaces`, `cilium`, `flux-system`, `piraeus-datastore`, `topolvm`, `traefik` |
-| **`wait: true`** | `prometheus-operator-crds`, `kyverno` |
-| **Declare `dependsOn`** | `apps`, `platform`, `cnpg-system`, `csi-nfs`, `kyverno-policies`, `piraeus-datastore`, `homer-services` |
+| **`wait: true`** | `prometheus-operator-crds`, `cnpg-versity-gw`, `kyverno` |
+| **Declare `dependsOn`** | `apps`, `platform`, `cnpg-system`, `cnpg-versity-gw`, `csi-nfs`, `kyverno-policies`, `piraeus-datastore`, `homer-services` |
 | **Suspended in git** | none |
 
 ## Bootstrap — applied once by hand
@@ -32,6 +32,7 @@ see [how Flux is layered](../explanation/flux-layering.md).
 | `cilium` | [`k8s/platform/network/cilium`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/network/cilium) | `15m0s` | **no** | no | — |
 | `cloudflared` | [`k8s/platform/network/cloudflared`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/network/cloudflared) | `15m0s` | yes | no | — |
 | `cnpg-system` | [`k8s/platform/storage/cnpg-system`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/storage/cnpg-system) | `15m0s` | yes | no | `kyverno` |
+| `cnpg-versity-gw` | [`k8s/platform/storage/cnpg-versity-gw`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/storage/cnpg-versity-gw) | `15m0s` | yes | **yes** (10m) | `kyverno` |
 | `csi-nfs` | [`k8s/platform/storage/csi-nfs`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/storage/csi-nfs) | `15m0s` | yes | no | `kyverno` |
 | `descheduler` | [`k8s/platform/cluster/descheduler`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/cluster/descheduler) | `15m0s` | yes | no | — |
 | `device-plugins` | [`k8s/platform/cluster/device-plugins`](https://github.com/thaum-xyz/ankhmorpork/tree/master/k8s/platform/cluster/device-plugins) | `15m0s` | yes | no | — |

--- a/docs/reference/helm-releases.md
+++ b/docs/reference/helm-releases.md
@@ -12,7 +12,7 @@ and why the interval matters, see
 | | |
 | --- | --- |
 | **Intervals in use** | `5m` |
-| **Charts used more than once** | `cnpg-database` ×13, `versitygw` ×2, `traefik` ×2 |
+| **Charts used more than once** | `cnpg-database` ×13, `versitygw` ×3, `traefik` ×2 |
 
 | Release | Namespace | Chart | Source | Interval | Values from | Component |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -50,6 +50,7 @@ and why the interval matters, see
 | [`cert-manager`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/platform/security/cert-manager/controllers/release.yaml) | `platform-security` | `cert-manager` | `https://charts.jetstack.io` | `5m` | ConfigMap `values-cert-manager` | `cert-manager` |
 | [`external-secrets`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/platform/security/external-secrets/controllers/release.yaml) | `platform-security` | `external-secrets` | `https://charts.external-secrets.io` | `5m` | ConfigMap `values-external-secrets` | `external-secrets` |
 | [`kyverno`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/platform/security/kyverno/controllers/release.yaml) | `platform-security` | `kyverno` | `https://kyverno.github.io/kyverno/` | `5m` | ConfigMap `values-kyverno` | `kyverno` |
+| [`cnpg-versity-gw`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/platform/storage/cnpg-versity-gw/release.yaml) | `platform-storage` | `versitygw` | `oci://ghcr.io/versity/versitygw/charts` | `5m` | ConfigMap `values-cnpg-versity-gw` | `cnpg-versity-gw` |
 | [`csi-nfs`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/platform/storage/csi-nfs/release.yaml) | `platform-storage` | `csi-driver-nfs` | `https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts` | `5m` | ConfigMap `values-csi-nfs` | `csi-nfs` |
 | [`diskprep`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/platform/storage/topolvm-system/diskprep/release.yaml) | `platform-storage` | `lvm-diskprep` | `oci://ghcr.io/thaum-xyz/helm-charts` | `5m` | ConfigMap `values-diskprep` | `topolvm` |
 | [`k8up`](https://github.com/thaum-xyz/ankhmorpork/blob/master/k8s/platform/storage/k8up/release.yaml) | `platform-storage` | `k8up` | `https://k8up-io.github.io/k8up` | `5m` | ConfigMap `values-k8up` | `k8up` |

--- a/k8s/flux/platform/cnpg-versity-gw.yaml
+++ b/k8s/flux/platform/cnpg-versity-gw.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cnpg-versity-gw
+  namespace: flux-system
+  annotations:
+    kubernetes.io/description: >-
+      The S3 gateway the fleet's postgres backups are written to.
+
+      Its own Kustomization rather than a directory under cnpg-system, because
+      it outlives that namespace: this one stands up empty in platform-storage
+      while the old gateway keeps serving from cnpg-system, and the two exist
+      side by side until the data has been copied across on the NAS and the
+      clusters have been repointed.
+spec:
+  interval: 15m0s
+  path: ./k8s/platform/storage/cnpg-versity-gw
+  prune: true
+  wait: true
+  timeout: 10m
+  dependsOn:
+    - name: kyverno
+  sourceRef:
+    kind: GitRepository
+    name: ankhmorpork

--- a/k8s/flux/platform/cnpg-versity-gw.yaml
+++ b/k8s/flux/platform/cnpg-versity-gw.yaml
@@ -19,16 +19,12 @@ spec:
   wait: true
   timeout: 10m
   dependsOn:
-    # csi-nfs for both halves of this claim. It provisions unifi-nas, and it also
-    # ships mutate-nfs-pvc-alert-exclusion -- the policy that labels unifi-nas
-    # claims excluded_from_alerts, whose own comment names this chart as the
-    # reason it exists rather than manifest labels.
+    # The claim is unifi-nas, so it needs the provisioner. csi-nfs also ships
+    # mutate-nfs-pvc-alert-exclusion, which is failurePolicy: Fail on PVC CREATE
+    # for this storage class -- but csi-nfs already declares its own dependency
+    # on kyverno, so naming kyverno here too would restate a fact that has a home
+    # somewhere else.
     - name: csi-nfs
-    # And kyverno to enforce it. That policy is failurePolicy: Fail on PVC
-    # CREATE, so with the webhook unavailable the claim is rejected outright --
-    # not created unlabelled. Listed even though csi-nfs already depends on it,
-    # the way piraeus-datastore names topolvm and kyverno together.
-    - name: kyverno
   sourceRef:
     kind: GitRepository
     name: ankhmorpork

--- a/k8s/flux/platform/cnpg-versity-gw.yaml
+++ b/k8s/flux/platform/cnpg-versity-gw.yaml
@@ -19,6 +19,15 @@ spec:
   wait: true
   timeout: 10m
   dependsOn:
+    # csi-nfs for both halves of this claim. It provisions unifi-nas, and it also
+    # ships mutate-nfs-pvc-alert-exclusion -- the policy that labels unifi-nas
+    # claims excluded_from_alerts, whose own comment names this chart as the
+    # reason it exists rather than manifest labels.
+    - name: csi-nfs
+    # And kyverno to enforce it. That policy is failurePolicy: Fail on PVC
+    # CREATE, so with the webhook unavailable the claim is rejected outright --
+    # not created unlabelled. Listed even though csi-nfs already depends on it,
+    # the way piraeus-datastore names topolvm and kyverno together.
     - name: kyverno
   sourceRef:
     kind: GitRepository

--- a/k8s/platform/storage/cnpg-versity-gw/credentials-secret.yaml
+++ b/k8s/platform/storage/cnpg-versity-gw/credentials-secret.yaml
@@ -1,0 +1,26 @@
+# The same Doppler pair the old gateway used, and the same one eleven namespaces
+# already read as POSTGRES_S3_* for their postgres-backup secret. Keeping the
+# credentials identical means repointing a database at this gateway is an
+# endpoint change and nothing else.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cnpg-versity-gw-credentials
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-auth-api
+  target:
+    name: cnpg-versity-gw-credentials
+    template:
+      data:
+        rootAccessKeyId: "{{ .accessKey }}"
+        rootSecretAccessKey: "{{ .secretKey }}"
+  data:
+    - remoteRef:
+        key: POSTGRES_S3_ACCESS_KEY
+      secretKey: accessKey
+    - remoteRef:
+        key: POSTGRES_S3_SECRET_KEY
+      secretKey: secretKey

--- a/k8s/platform/storage/cnpg-versity-gw/job.yaml
+++ b/k8s/platform/storage/cnpg-versity-gw/job.yaml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cnpg-versity-gw-bootstrap-bucket
+spec:
+  # barman-cloud will not create the bucket, and a missing one surfaces as a
+  # failed backup rather than anything naming the cause. Harmless if the copied
+  # data already contains it -- `mb --ignore-existing` is a no-op then.
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: mc
+          image: minio/mc:latest
+          env:
+            - name: BUCKET_NAME
+              value: cnpg
+            - name: VGW_ENDPOINT
+              value: http://cnpg-versity-gw:7070
+            - name: ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cnpg-versity-gw-credentials
+                  key: rootAccessKeyId
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cnpg-versity-gw-credentials
+                  key: rootSecretAccessKey
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          command: ["/bin/sh", "-lc"]
+          args:
+            - |
+              mc alias set vgw "$VGW_ENDPOINT" "$ACCESS_KEY" "$SECRET_KEY" --api S3v4
+              mc mb --ignore-existing vgw/$BUCKET_NAME

--- a/k8s/platform/storage/cnpg-versity-gw/kustomization.yaml
+++ b/k8s/platform/storage/cnpg-versity-gw/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: platform-storage
+resources:
+  - repository.yaml
+  - release.yaml
+  - credentials-secret.yaml
+  - job.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+configMapGenerator:
+  - name: values-cnpg-versity-gw
+    files:
+      - values.yaml=values.yaml

--- a/k8s/platform/storage/cnpg-versity-gw/release.yaml
+++ b/k8s/platform/storage/cnpg-versity-gw/release.yaml
@@ -1,0 +1,24 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cnpg-versity-gw
+spec:
+  chart:
+    spec:
+      chart: versitygw
+      version: "0.3.5"
+      sourceRef:
+        kind: HelmRepository
+        name: versity
+      interval: 15m
+  interval: 5m
+  timeout: 10m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: values-cnpg-versity-gw

--- a/k8s/platform/storage/cnpg-versity-gw/repository.yaml
+++ b/k8s/platform/storage/cnpg-versity-gw/repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: versity
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/versity/versitygw/charts

--- a/k8s/platform/storage/cnpg-versity-gw/values.yaml
+++ b/k8s/platform/storage/cnpg-versity-gw/values.yaml
@@ -1,0 +1,43 @@
+# Config reference: https://github.com/versity/versitygw/blob/main/chart/values.yaml
+#
+# Backup target for the fleet's postgres clusters. Replaces the versitygw that
+# ran in cnpg-system; that one is deliberately left running and untouched while
+# its data is copied across on the NAS, so for a while there are two gateways and
+# only this one is empty.
+
+# Without this the release name would render as cnpg-versity-gw-versitygw: the
+# chart only collapses the repetition when the release name contains the chart
+# name, and "versity-gw" is not "versitygw". The Service name is the endpoint
+# eleven postgres clusters point at, so it is worth spelling out.
+fullnameOverride: cnpg-versity-gw
+
+# Pinned. The chart defaults to :latest.
+image:
+  tag: "v1.7.0"
+
+auth:
+  existingSecret: cnpg-versity-gw-credentials
+
+gateway:
+  backend:
+    type: posix
+    args: "/mnt/data"
+    # Object metadata as ordinary files rather than xattrs, which is what lets
+    # this sit on an NFSv3 share.
+    sidecarDir: "/mnt/metadata"
+
+# Eleven clusters at 3d-30d retention. nfs.csi.k8s.io does not enforce the
+# request, so this is a label rather than a reservation.
+persistence:
+  enabled: true
+  create: true
+  size: 100Gi
+  storageClassName: unifi-nas
+  accessMode: ReadWriteMany
+
+resources:
+  limits:
+    memory: 1Gi
+  requests:
+    cpu: 50m
+    memory: 128Mi


### PR DESCRIPTION
First step of the cnpg-system move, and deliberately an additive one: this
creates a **second** gateway and touches nothing that exists.

## Why not move the existing one

`versitygw-data` holds every postgres backup in the fleet. Migrating the PVC
would mean retaining the PV and rebinding it — workable, but it puts the only
copy of the backups in the middle of the change.

Since the data is on NFS and can be copied NAS-side, standing up an empty second
gateway is strictly safer: the old one keeps serving throughout, and if anything
here is wrong the blast radius is a Deployment that nobody points at yet.

## What this adds

| | |
|---|---|
| HelmRelease | `cnpg-versity-gw` in `platform-storage` |
| Service | `cnpg-versity-gw:7070` |
| PVC | `cnpg-versity-gw-data`, `unifi-nas`, 100Gi RWX |
| Credentials | `cnpg-versity-gw-credentials`, same Doppler pair as the old gateway |
| Bootstrap Job | creates the `cnpg` bucket; `mb --ignore-existing`, so harmless if the copy already brought one |

`fullnameOverride` is set deliberately. The chart only collapses the repeated
name when the release name contains the chart name, and `versity-gw` is not
`versitygw` — without the override the Service would be
`cnpg-versity-gw-versitygw`. That Service name is the endpoint eleven postgres
clusters will eventually point at, so it is worth spelling out.

Credentials are deliberately identical to the old gateway's, and are the same
pair the eleven namespaces already read as `POSTGRES_S3_*`. That makes repointing
a database an endpoint change and nothing else.

## The copy

Source, from the live PV:

```
192.168.40.10:/var/nfs/shared/k8snfscsi/cnpg-system/versitygw-data-pvc-35a24c77-27eb-4b9e-be5a-08ce36431c6f
```

The destination subdirectory is allocated by the provisioner when the new PVC
binds, so it is not knowable until this is applied. It will be
`platform-storage/cnpg-versity-gw-data-<new-pv-name>` under the same share, and
the exact path can be read afterwards from the new PV's
`csi.volumeAttributes.subDir`.

The `posix` backend reads the filesystem directly, so files copied underneath it
are visible without a restart — though restarting the Deployment after the copy
is the cheaper thing to reason about.

## What this does not do

No cluster is repointed and no backup changes destination. The five `vod-arr`
values files and the other object stores still name
`versitygw.cnpg-system.svc.cluster.local`, and the old gateway still answers
there. Repointing is a later, per-cluster change; the operator and barman move
after that.

Downtime is tolerable across those later steps because WAL archiving runs on the
postgres pods, not the operator — so the fleet keeps archiving through an
operator restart.

## Verification

`make validate` (132 targets), `make validate-flux` (53 paths),
`make validate-configmaps`, `make docs-lint` (0 errors) pass, and
`validate-platform-namespaces` reports the new component clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
