### PR TITLE
cnpg-versity-gw: create the bucket with rclone

### DIFF
--- a/k8s/platform/storage/cnpg-versity-gw/job.yaml
+++ b/k8s/platform/storage/cnpg-versity-gw/job.yaml
@@ -4,25 +4,38 @@ metadata:
   name: cnpg-versity-gw-bootstrap-bucket
 spec:
   # barman-cloud will not create the bucket, and a missing one surfaces as a
-  # failed backup rather than anything naming the cause. Harmless if the copied
-  # data already contains it -- `mb --ignore-existing` is a no-op then.
+  # failed backup rather than anything naming the cause.
   template:
     spec:
       restartPolicy: OnFailure
       containers:
-        - name: mc
-          image: minio/mc:latest
+        - name: rclone
+          # Not minio/mc: MinIO withdrew their images from Docker Hub, so
+          # docker.io/minio/mc now 404s -- which reaches the kubelet as an
+          # authorization failure and reads like a credentials problem.
+          image: rclone/rclone:1.75.1
+          # rclone builds its whole config from RCLONE_CONFIG_<REMOTE>_* in the
+          # environment, so there is no config file, no shell wrapper, and no
+          # `|| true` swallowing real errors: this is the entrypoint with two
+          # arguments, and a non-zero exit is a genuine failure.
+          args: ["mkdir", "vgw:cnpg"]
           env:
-            - name: BUCKET_NAME
-              value: cnpg
-            - name: VGW_ENDPOINT
+            - name: RCLONE_CONFIG_VGW_TYPE
+              value: s3
+            - name: RCLONE_CONFIG_VGW_PROVIDER
+              value: Other
+            - name: RCLONE_CONFIG_VGW_ENDPOINT
               value: http://cnpg-versity-gw:7070
-            - name: ACCESS_KEY
+            # Not used for routing -- the endpoint above decides that -- but the
+            # SigV4 signature is computed over a region, so it cannot be empty.
+            - name: RCLONE_CONFIG_VGW_REGION
+              value: us-east-1
+            - name: RCLONE_CONFIG_VGW_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
                   name: cnpg-versity-gw-credentials
                   key: rootAccessKeyId
-            - name: SECRET_KEY
+            - name: RCLONE_CONFIG_VGW_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: cnpg-versity-gw-credentials
@@ -33,8 +46,3 @@ spec:
               memory: 32Mi
             limits:
               memory: 64Mi
-          command: ["/bin/sh", "-lc"]
-          args:
-            - |
-              mc alias set vgw "$VGW_ENDPOINT" "$ACCESS_KEY" "$SECRET_KEY" --api S3v4
-              mc mb --ignore-existing vgw/$BUCKET_NAME


### PR DESCRIPTION
The bootstrap Job from #1467 has been in `ImagePullBackOff` since it was applied.

## Cause

`docker.io/minio/mc` **no longer exists**. MinIO withdrew their images from
Docker Hub; the registry API answers `object not found`, which reaches the
kubelet as:

```
pull access denied, repository does not exist or may require authorization:
insufficient_scope: authorization failed
```

That message reads like a credentials problem, which is worth naming: there is
nothing to authorize against. I carried the image across from the old gateway
unchanged, and it had been dead before this was ever applied.

## Why rclone rather than mc elsewhere, or s5cmd

mc is still published on quay.io, and s5cmd exists on Docker Hub — but rclone is
maintained, multi-arch, and configures itself entirely from
`RCLONE_CONFIG_<REMOTE>_*` environment variables.

That last property is what makes this a smaller manifest rather than a
like-for-like swap. The old Job needed a shell wrapper to set up an alias and
then `mb --ignore-existing` to be idempotent. rclone needs neither:

```yaml
args: ["mkdir", "vgw:cnpg"]
```

No config file, no `/bin/sh -lc`, and no `|| true` to swallow the
already-exists case — so a non-zero exit is now a genuine failure instead of
something the manifest has to paper over.

Verified before writing it: `rclone/rclone:1.75.1` carries a `linux/amd64`
manifest, and all four nodes are amd64.

`REGION` is set because SigV4 signs over a region and it cannot be empty. It
plays no part in routing — the endpoint decides that.

## Rollout needs the Job deleted

A Job's `spec.template` is **immutable**, so this cannot be applied over the
existing object; Flux will fail the patch rather than replace it:

```bash
kubectl -n platform-storage delete job cnpg-versity-gw-bootstrap-bucket
flux -n flux-system reconcile kustomization cnpg-versity-gw
```

## Still to confirm after it runs

`rclone mkdir` against an existing bucket is expected to be a no-op, which is
what replaces `mb --ignore-existing`. That is the one claim here not verified up
front, so once the Job succeeds I will delete and re-run it against the
now-existing bucket and confirm it still exits zero. If it does not, the Job
needs an existence check and this note is the reason why.

## The old gateway's copy of this is left alone

`cnpg-system/versity/job.yaml` carries the same dead image, deliberately
untouched. That Job is `Complete`, so nothing re-pulls it, and editing it would
make Flux attempt an immutable-template patch on every reconcile of a component
being retired anyway. It goes when that component does.

## Impact

None beyond the Job. The gateway is `Running` and its PVC is `Bound` — only
bucket creation was blocked, and nothing points at this gateway yet.

## Verification

`make validate` (132 targets) and `make validate-configmaps` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
